### PR TITLE
manual Linux testing harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@
 **/charts
 **/docker-compose*
 **/Dockerfile*
+!**/Dockerfile.template
 **/node_modules
 **/npm-debug.log
 **/obj

--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -39,6 +39,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.DockerEngine", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.Common", "src\AWS.Deploy.Common\AWS.Deploy.Common.csproj", "{3AAC19A6-02E8-45D0-BDD0-CAD0FBE15F64}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ManualLinuxTesting", "ManualLinuxTesting", "{D0172E70-D5BC-4EDE-84E4-9ADB67B5F8FB}"
+	ProjectSection(SolutionItems) = preProject
+		test\ManualLinuxTesting\Dockerfile = test\ManualLinuxTesting\Dockerfile
+		test\ManualLinuxTesting\Readme.md = test\ManualLinuxTesting\Readme.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -110,6 +116,7 @@ Global
 		{F06F9F2B-9018-4357-9ECB-EAF3D9EC335C} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{4C4F07CE-4C88-44C6-864F-C5E563712EE2} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{3AAC19A6-02E8-45D0-BDD0-CAD0FBE15F64} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
+		{D0172E70-D5BC-4EDE-84E4-9ADB67B5F8FB} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
 ## AWS .NET Deploy CLI Tool
 Initial prototyping for the AWS .NET CLI Tool
 
+## Local Testing
 
+You use `/test/ManualLinuxTesting/Dockerfile` to create a local sandbox for testing.  This image will build from source and install the aws cli deployment tool.
+
+1.  From the root directory, run 
+```
+docker build -f ./test/ManualLinuxTesting/Dockerfile/ . -t 'aws-deploy:local'
+```
+
+2. _Grab a caffeinated beverage_.  The first run can take several minutes.
+
+3.  Run the docker image in interactive mode: 
+```
+docker run -it --entrypoint bash aws-deploy:local
+ ```
+
+4. Enter your aws profile file using the aws cli and follow the prompts:
+
+```
+aws configure
+```
+
+For more assitance, follow the guide here: https://cdkworkshop.com/15-prerequisites/200-account.html
+
+You are now free to play with the cli.  There are several sample applications in `/testapps` that you can deploy:
+
+```shell
+root@562bccd30027:/testapps# cd WebAppNoDockerFile/
+root@562bccd30027:/testapps/WebAppNoDockerFile# dotnet aws deploy
+AWS .NET Suite for deploying .NET Core applications to AWS
+```
 
 ## Security
 

--- a/test/ManualLinuxTesting/Dockerfile
+++ b/test/ManualLinuxTesting/Dockerfile
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+####################################
+## Run at repository root with
+## docker build -f /test/ManualLinuxTesting/Dockerfile/ . -t 'aws-deploy:local'
+##
+## See the /README.md file for more details
+####################################
+
+ARG AWS_CLI_VERSION=0.0.1-local
+
+FROM ubuntu as base-updates
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
+RUN apt-get update
+
+FROM base-updates as base
+RUN apt-get install -y wget unzip
+
+# install dotnet sdk
+RUN wget https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN apt-get update; \
+  apt-get install -y apt-transport-https && \
+  apt-get update && \
+  apt-get install -y dotnet-sdk-5.0
+RUN dotnet --list-sdks
+
+#install aws cli
+RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+RUN aws --version
+
+# install node/npm
+RUN apt-get install -y nodejs
+RUN apt-get install -y npm
+
+#install cdk
+RUN npm install -g aws-cdk
+
+# manually add dotnet tools path to path variable
+# https://github.com/dotnet/dotnet-docker/issues/520
+ENV PATH="${PATH}:/root/.dotnet/tools"
+
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+ARG AWS_CLI_VERSION
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+WORKDIR /src
+COPY . .
+
+RUN echo $AWS_CLI_VERSION
+
+RUN dotnet restore "src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj"
+WORKDIR "/src/src/AWS.Deploy.CLI"
+RUN dotnet build "AWS.Deploy.CLI.csproj" -c Release -o /app/build -p:Version=$AWS_CLI_VERSION
+
+#FROM build as test
+#RUN dotnet test AWS.Deploy.sln
+
+FROM build AS publish
+ARG AWS_CLI_VERSION
+RUN dotnet pack "AWS.Deploy.CLI.csproj" -c Release -o /app/publish -p:PackageVersion=$AWS_CLI_VERSION -p:Version=$AWS_CLI_VERSION
+
+FROM base AS final
+ARG AWS_CLI_VERSION
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+#install aws deploy
+RUN dotnet tool install AWS.Deploy.CLI -g --add-source /app --version $AWS_CLI_VERSION
+
+# verify it worked
+RUN dotnet aws --version
+
+#copy in the testing apps
+COPY /testapps /testapps
+
+WORKDIR /testapps
+ENTRYPOINT ["echo", "\nMake sure to start in Interactive mode:  docker run -it --entrypoint bash <imagename>'\n\nThen try `dotnet aws --help`"]

--- a/test/ManualLinuxTesting/Readme.md
+++ b/test/ManualLinuxTesting/Readme.md
@@ -1,0 +1,1 @@
+See the **Local Testing** section in the README at the root directory for instructions on how to build and use this docker file.


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4675

*Description of changes:*
- Adds a Dockerfile that builds source and installs cli tool and required pre-reqs (no docker).  Image is intended for local testing.
- Updated **README.md** with instructions on how to setup and use.
