### PR TITLE
Add list-stacks option to display all active Cloud Formation stacks

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -16,10 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.7" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.5.0.9" />
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.0.9" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.9" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.1.47" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.5.2.6" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.2.5" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.47" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.2.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20427.1" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.CLI/Commands/DeleteStackCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteStackCommand.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using AWS.Deploy.Orchestrator;
+using AWS.DeploymentCommon;
+
+namespace AWS.Deploy.CLI.Commands
+{
+    public class DeleteStackCommand
+    {
+        private const string _inProgressSuffix = "IN_PROGRESS";
+        private static readonly TimeSpan _pollingPeriod = TimeSpan.FromSeconds(3);
+
+        private readonly IAWSClientFactory _awsClientFactory;
+        private readonly IToolInteractiveService _interactiveService;
+        private readonly OrchestratorSession _session;
+        private readonly IAmazonCloudFormation _cloudFormationClient;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public DeleteStackCommand(IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
+        {
+            _awsClientFactory = awsClientFactory;
+            _interactiveService = interactiveService;
+            _session = session;
+            _cloudFormationClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>(_session.AWSCredentials, _session.AWSRegion);
+            _consoleUtilities = new ConsoleUtilities(interactiveService);
+        }
+
+        public async Task ExecuteAsync(string stackName)
+        {
+            try
+            {
+                await _cloudFormationClient.DeleteStackAsync(new DeleteStackRequest { StackName = stackName });
+
+                await WaitStackToCompleteAsync(stackName, DateTime.Now);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Error removing previous failed stack creation {stackName}: {e.Message}");
+            }
+
+            using var cloudFormationClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>(_session.AWSCredentials, _session.AWSRegion);
+            var deleteStackRequest = new DeleteStackRequest()
+            {
+                StackName = stackName
+            };
+
+            await cloudFormationClient.DeleteStackAsync(deleteStackRequest);
+            await WaitStackToCompleteAsync(stackName, DateTime.Now);
+        }
+
+        private async Task WaitStackToCompleteAsync(string stackName, DateTime minTimeStampForEvents)
+        {
+            const int timestampWidth = 20;
+            const int logicalResourceWidth = 40;
+            const int resourceStatus = 40;
+            string mostRecentEventId = "";
+
+            // Write header for the status table.
+
+            var header = new[]
+            {
+                ("Timestamp", timestampWidth),
+                ("Logical Resource Id", logicalResourceWidth),
+                ("Status", resourceStatus),
+            };
+            _consoleUtilities.DisplayRow(header);
+
+            Stack stack;
+            do
+            {
+                Thread.Sleep(_pollingPeriod);
+                stack = await GetExistingStackAsync(stackName);
+
+                var events = await GetLatestEventsAsync(stackName, minTimeStampForEvents, mostRecentEventId);
+                if (events.Count > 0)
+                    mostRecentEventId = events[0].EventId;
+
+                for (int i = events.Count - 1; i >= 0; i--)
+                {
+                    var row = new[]
+                    {
+                        (events[i].Timestamp.ToString(CultureInfo.InvariantCulture), timestampWidth),
+                        (events[i].LogicalResourceId, logicalResourceWidth),
+                        (events[i].ResourceStatus.ToString(), resourceStatus),
+                        (events[i].ResourceStatusReason, resourceStatus)
+                    };
+                    _consoleUtilities.DisplayRow(row);
+                }
+            } while (stack.StackStatus.ToString().EndsWith(_inProgressSuffix));
+        }
+
+        private async Task<Stack> GetExistingStackAsync(string stackName)
+        {
+            try
+            {
+                var response = await _cloudFormationClient.DescribeStacksAsync(new DescribeStacksRequest
+                {
+                    StackName = stackName
+                });
+                if (response.Stacks.Count != 1)
+                    return null;
+
+                return response.Stacks[0];
+            }
+            catch (AmazonCloudFormationException)
+            {
+                return null;
+            }
+        }
+
+        private async Task<List<StackEvent>> GetLatestEventsAsync(string stackName, DateTime minTimeStampForEvents, string mostRecentEventId)
+        {
+            var noNewEvents = false;
+            var events = new List<StackEvent>();
+            DescribeStackEventsResponse response = null;
+            do
+            {
+                var request = new DescribeStackEventsRequest()
+                {
+                    StackName = stackName
+                };
+                if (response != null)
+                    request.NextToken = response.NextToken;
+
+                try
+                {
+                    response = await _cloudFormationClient.DescribeStackEventsAsync(request);
+                }
+                catch (Exception e)
+                {
+                    throw new Exception($"Error getting events for stack: {e.Message}");
+                }
+
+                foreach (var stackEvent in response.StackEvents)
+                {
+                    if (string.Equals(stackEvent.EventId, mostRecentEventId) || stackEvent.Timestamp < minTimeStampForEvents)
+                    {
+                        noNewEvents = true;
+                        break;
+                    }
+
+                    events.Add(stackEvent);
+                }
+            } while (!noNewEvents && !string.IsNullOrEmpty(response.NextToken));
+
+            return events;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/ListStacksCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ListStacksCommand.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using AWS.Deploy.Orchestrator;
+using AWS.DeploymentCommon;
+
+namespace AWS.Deploy.CLI.Commands
+{
+    public class ListStacksCommand
+    {
+        private readonly IAWSClientFactory _awsClientFactory;
+        private readonly IToolInteractiveService _interactiveService;
+        private readonly OrchestratorSession _session;
+
+        public ListStacksCommand(IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
+        {
+            _awsClientFactory = awsClientFactory;
+            _interactiveService = interactiveService;
+            _session = session;
+        }
+
+        public async Task ExecuteAsync()
+        {
+            using var cloudFormationClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>(_session.AWSCredentials, _session.AWSRegion);
+            var listStacksRequest = new ListStacksRequest
+            {
+                // Show only active Cloud Formation stacks, i.e. CREATE_FAILED & DELETE_COMPLETE statuses aren't included
+                StackStatusFilter = new List<string>
+                {
+                    "CREATE_IN_PROGRESS",
+                    "CREATE_COMPLETE",
+                    "ROLLBACK_IN_PROGRESS",
+                    "ROLLBACK_FAILED",
+                    "ROLLBACK_COMPLETE",
+                    "DELETE_IN_PROGRESS",
+                    "DELETE_FAILED",
+                    "UPDATE_IN_PROGRESS",
+                    "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+                    "UPDATE_COMPLETE",
+                    "UPDATE_ROLLBACK_IN_PROGRESS",
+                    "UPDATE_ROLLBACK_FAILED",
+                    "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+                    "UPDATE_ROLLBACK_COMPLETE",
+                    "REVIEW_IN_PROGRESS"
+                }
+            };
+
+            var listStacksPaginator = cloudFormationClient.Paginators.ListStacks(listStacksRequest);
+            await foreach (var response in listStacksPaginator.Responses)
+            {
+                foreach (var stackSummary in response.StackSummaries)
+                {
+                    _interactiveService.WriteLine(stackSummary.StackName);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
- This change allows user to display all active Cloud Formation stacks (including paginated responses). `ListStacksCommand` implements `ICommand` which will be implemented by all future commands for a consistent interface.

- Bumped package references to latest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
