### PR TITLE
Add Delete Stack command

### DIFF
--- a/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
+++ b/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.Orchestrator;
+using AWS.DeploymentCommon;
+
+namespace AWS.Deploy.CLI.CloudFormation
+{
+    /// <summary>
+    /// Monitors a CloudFormation Stack event activities independently
+    /// It uses stdout and displays the current status of the CloudFormation stack by polling periodically
+    /// </summary>
+    internal class StackEventMonitor
+    {
+        private const int TIMESTAMP_WIDTH = 18;
+        private const int RESOURCE_STATUS_WIDTH = 20;
+        private const int RESOURCE_TYPE_WIDTH = 40;
+        private const int LOGICAL_RESOURCE_WIDTH = 40;
+        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(1);
+
+        private readonly string _stackName;
+        private bool _isActive;
+        private DateTime _startTime;
+        private readonly IAmazonCloudFormation _cloudFormationClient;
+        private readonly HashSet<string> _processedEventIds = new HashSet<string>();
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public StackEventMonitor(string stackName, IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
+        {
+            _stackName = stackName;
+
+            _cloudFormationClient = awsClientFactory.GetAWSClient<IAmazonCloudFormation>(session.AWSCredentials, session.AWSRegion);
+            _consoleUtilities = new ConsoleUtilities(interactiveService);
+        }
+
+        /// <summary>
+        /// Starts monitoring the CloudFormation Stack events since now
+        /// </summary>
+        public async Task StartAsync()
+        {
+            // CloudFormation API returns timestamps for events based on the system time
+            _startTime = DateTime.Now;
+
+            _isActive = true;
+
+            await PollEventsAsync();
+        }
+
+        /// <summary>
+        /// Stops monitoring the CloudFormation Stack events
+        /// </summary>
+        public void Stop()
+        {
+            _isActive = false;
+        }
+
+        private async Task PollEventsAsync()
+        {
+            while (_isActive)
+            {
+                await ReadNewEventsAsync();
+                await Task.Delay(s_pollingPeriod);
+            }
+        }
+
+        private async Task ReadNewEventsAsync()
+        {
+            var stackEvents = new List<StackEvent>();
+
+            var describeStackEventsRequest = new DescribeStackEventsRequest { StackName = _stackName };
+            var listStacksPaginator = _cloudFormationClient.Paginators.DescribeStackEvents(describeStackEventsRequest);
+
+            try
+            {
+                var breakPaginator = false;
+                await foreach (var response in listStacksPaginator.Responses)
+                {
+                    foreach (var stackEvent in response?.StackEvents ?? new List<StackEvent>())
+                    {
+                        // Event from before we are interested in
+                        if (stackEvent.Timestamp < _startTime)
+                        {
+                            breakPaginator = true;
+                            break;
+                        }
+
+                        // Already processed event
+                        if (_processedEventIds.Contains(stackEvent.EventId))
+                        {
+                            breakPaginator = true;
+                            break;
+                        }
+
+                        // New event, save it
+                        _processedEventIds.Add(stackEvent.EventId);
+                        stackEvents.Add(stackEvent);
+                    }
+
+                    if (breakPaginator)
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ValidationError") && exception.Message.Equals($"Stack [{_stackName}] does not exist"))
+            {
+                // Stack is deleted, there could be some missed events between the last poll timestamp and DELETE_COMPLETE
+            }
+            catch (AmazonCloudFormationException)
+            {
+                // Other AmazonCloudFormationException
+            }
+
+            foreach (var stackEvent in stackEvents.OrderBy(e => e.Timestamp))
+            {
+                var row = new[]
+                {
+                    (stackEvent.Timestamp.ToString(CultureInfo.InvariantCulture), TIMESTAMP_WIDTH),
+                    (stackEvent.ResourceStatus.ToString(), RESOURCE_STATUS_WIDTH),
+                    (stackEvent.ResourceType.Truncate(RESOURCE_TYPE_WIDTH, true), RESOURCE_TYPE_WIDTH),
+                    (stackEvent.LogicalResourceId, LOGICAL_RESOURCE_WIDTH),
+                };
+                _consoleUtilities.DisplayRow(row);
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/CloudFormation/StackStatusExtension.cs
+++ b/src/AWS.Deploy.CLI/CloudFormation/StackStatusExtension.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudFormation;
+
+namespace AWS.Deploy.CLI.CloudFormation
+{
+    internal static class StackStatusExtension
+    {
+        public static bool IsDeleted(this StackStatus stackStatus)
+        {
+            return stackStatus.Value.Equals("DELETE_COMPLETE");
+        }
+
+        public static bool IsFailed(this StackStatus stackStatus)
+        {
+            return stackStatus.Value.EndsWith("FAILED");
+        }
+
+        public static bool IsInProgress(this StackStatus stackStatus)
+        {
+            return stackStatus.Value.EndsWith("_IN_PROGRESS");
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AWS.DeploymentCommon;
 
 namespace AWS.Deploy.CLI
@@ -99,6 +100,21 @@ namespace AWS.Deploy.CLI
 
                 _interactiveService.WriteLine($"Invalid option. The selected option should be between 1 and {options.Count}.");
             }
+        }
+
+        public void DisplayRow((string, int)[] row)
+        {
+            var blocks = new List<string>();
+            for (var col = 0; col < row.Length; col++)
+            {
+                var (_, width) = row[col];
+                blocks.Add($"{{{col},{-width}}}");
+            }
+
+            var values = row.Select(col => col.Item1).ToArray();
+            var format = string.Join(" | ", blocks);
+
+            _interactiveService.WriteLine(string.Format(format, values));
         }
 
         public string AskUserToChooseOrCreateNew(IList<string> options, string title, string defaultValue)

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -8,4 +8,16 @@ namespace AWS.Deploy.CLI
 {
     [AWSDeploymentExpectedException]
     public class NoAWSCredentialsFoundException : Exception { }
+
+    /// <summary>
+    /// Throw if Delete Command is unable to delete
+    /// the specified stack
+    /// </summary>
+    [AWSDeploymentExpectedExceptionAttribute ]
+    public class FailedToDeleteException : Exception
+    {
+        public FailedToDeleteException(string message) : base(message)
+        {
+        }
+    }
 }

--- a/src/AWS.Deploy.CLI/Extensions/StringTruncate.cs
+++ b/src/AWS.Deploy.CLI/Extensions/StringTruncate.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace AWS.Deploy.CLI.Extensions
+{
+    public static class StringTruncate
+    {
+        /// <summary>
+        /// Truncates a string to the specified length.
+        /// </summary>
+        /// <param name="value">The string to be truncated.</param>
+        /// <param name="maxLength">The maximum length.</param>
+        /// <param name="ellipsis">true to add ellipsis to the truncated text; otherwise, false.</param>
+        /// <returns>Truncated string.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when maxLength less than truncated string length with ellipsis</exception>
+        public static string Truncate(this string value, int maxLength, bool ellipsis = false)
+        {
+            if (ellipsis && maxLength <= 3)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxLength),$"{nameof(maxLength)} must be greater than three when replacing with an ellipsis.");
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            if (ellipsis && value.Length > maxLength)
+            {
+                return value.Substring(0, maxLength - 3) + "...";
+            }
+
+            return value.Substring(0, Math.Min(value.Length, maxLength));
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -95,5 +95,15 @@ namespace AWS.Deploy.CLI.UnitTests
 
             interactiveServices.OutputContains("Invalid option.");
         }
+
+        [Fact]
+        public void DisplayRow()
+        {
+            var interactiveServices = new TestToolInteractiveServiceImpl();
+            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            consoleUtilities.DisplayRow(new[] { ("Hello", 10), ("World", 20) });
+
+            Assert.Equal("Hello      | World               ", interactiveServices.OutputMessages[0]);
+        }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/StringTruncateTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/StringTruncateTests.cs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using AWS.Deploy.CLI.Extensions;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class StringTruncateTests
+    {
+        [Fact]
+        public void Truncate_MaxLengthLessThanThree_Ellipsis_Throws()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                "Hi".Truncate(2, true);
+            });
+            Assert.Equal("maxLength must be greater than three when replacing with an ellipsis. (Parameter 'maxLength')", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Hello World", "He...")]
+        public void Truncate_Ellipsis(string input, string expectedOutput)
+        {
+            var output = input.Truncate(5, true);
+            Assert.Equal(expectedOutput, output);
+        }
+
+        [Theory]
+        [InlineData("Hello World", "Hello")]
+        [InlineData("Hello", "Hello")]
+        [InlineData("", "")]
+        public void Truncate(string input, string expectedOutput)
+        {
+            var output = input.Truncate(5);
+            Assert.Equal(expectedOutput, output);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/TestToolInteractiveServiceImpl.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TestToolInteractiveServiceImpl.cs
@@ -14,6 +14,9 @@ namespace AWS.Deploy.CLI.UnitTests
 
         private IList<string> InputCommands { get; set; }
 
+        public TestToolInteractiveServiceImpl(): this(new List<string>())
+        {
+        }
 
         public TestToolInteractiveServiceImpl(IList<string> inputCommands)
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This change adds ability to delete a CloudFormation stack using its name.
- DeleteCommand first confirms for the deletion of the stack, on confirmation it triggers the deletion and monitors the stack events and output them as they happen in their timestamp order. It is possible that some of the events don't appear in the output because of the fact, once the stack is deleted, CloudFormation doesn't return events and it is possible to miss some events between the last poll action and the deletion completion.
- If the CloudFormation stack doesn't exist, it is a noop.

![Screenshot 2020-12-23 093149](https://user-images.githubusercontent.com/8882380/103022961-db368800-4501-11eb-971b-6716a84bb04b.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
