### PR TITLE
Add ability to specify dotnet build configuration for beanstalk apps

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
@@ -25,6 +25,13 @@
             "description": "Specifies the AWS Region",
             "replaces": "AWSRegion",
             "datatype": "string"
+        },
+        "DotnetBuildConfiguration": {
+            "type": "parameter",
+            "description": "Specifies the dotnet build configuration",
+            "replaces": "DotnetBuildConfiguration-Placeholder",
+            "datatype": "string",
+            "defaultValue": "Release"
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Utilities/ZipPublisher.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Utilities/ZipPublisher.cs
@@ -26,7 +26,7 @@ namespace AspNetAppElasticBeanstalkLinux.Utilities
             var publishDirectoryInfo = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var publishCommands = new []
             {
-                $"dotnet publish {projectPath} -o {publishDirectoryInfo}"
+                $"dotnet publish {projectPath} -o {publishDirectoryInfo} -c DotnetBuildConfiguration-Placeholder"
             };
 
             _commandLineWrapper.Run(publishCommands);

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -111,6 +111,15 @@
             "Updatable": false,
             "MinimumPermissions": "...",
             "AssumeRolePolicy": "..."
+        },
+        {
+            "Id": "DotnetBuildConfiguration",
+            "Name": "Dotnet Build Configuration",
+            "Description": "The build configuration to use for the dotnet build",
+            "Type": "String",
+            "DefaultValue": "Release",
+            "AdvancedSetting": true,
+            "Updatable": true
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4742

*Description of changes:*
Add ability to specify dotnet build configuration for beanstalk apps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
