### PR TITLE
feat: tag CloudFormation stacks deployed by CLI and only allow tagged resources to list and delete

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -114,7 +114,12 @@ namespace AWS.Deploy.CLI.Commands
                 configureSettings = _consoleUtilities.AskYesNoQuestion("Do you wish to change any of these settings?", ConsoleUtilities.YesNo.No);
             }
 
-            await orchestrator.DeployRecommendation(cloudApplicationName, selectedRecommendation);
+            var cloudApplication = new CloudApplication
+            {
+                Name = cloudApplicationName
+            };
+
+            await orchestrator.DeployRecommendation(cloudApplication, selectedRecommendation);
         }
 
         private async Task ConfigureDeployment(Recommendation recommendation)

--- a/src/AWS.Deploy.Common/CloudApplication.cs
+++ b/src/AWS.Deploy.Common/CloudApplication.cs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common
+{
+    /// <summary>
+    /// Contains CloudFormation specific configurations
+    /// </summary>
+    public class CloudApplication
+    {
+        /// <summary>
+        /// Name of the CloudApplication
+        /// used to create CloudFormation stack
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Name of CloudFormation stack
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Name"/> and <see cref="StackName"/> are two different properties and just happens to be same value at this moment.
+        /// </remarks>
+        public string StackName => Name;
+
+        /// <summary>
+        /// Tag key of the CloudFormation stack
+        /// used to uniquely identify a stack that is deployed by aws-dotnet-deploy
+        /// </summary>
+        public const string StackTagKey = "aws-dotnet-deploy";
+    }
+}

--- a/src/AWS.Deploy.Orchestrator/CdkAppSettingsSerializer.cs
+++ b/src/AWS.Deploy.Orchestrator/CdkAppSettingsSerializer.cs
@@ -11,14 +11,14 @@ namespace AWS.Deploy.Orchestrator
 {
     public class CdkAppSettingsSerializer
     {
-        public string Build(string stackName, Recommendation recommendation)
+        public string Build(CloudApplication cloudApplication, Recommendation recommendation)
         {
             // General Settings
             var settings = new Dictionary<string, object>
             {
                 { nameof(recommendation.ProjectPath), recommendation.ProjectPath },
-                { "StackName", stackName},
-                { "DockerfileDirectory",  new FileInfo(recommendation.ProjectPath).Directory.FullName}
+                { "StackName", cloudApplication.StackName },
+                { "DockerfileDirectory",  new FileInfo(recommendation.ProjectPath).Directory.FullName }
             };
 
             string solutionFilePath = GetProjectSolutionFile(recommendation.ProjectPath);

--- a/src/AWS.Deploy.Orchestrator/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestrator/CdkProjectHandler.cs
@@ -8,7 +8,7 @@ namespace AWS.Deploy.Orchestrator
 {
     public interface ICdkProjectHandler
     {
-        public Task CreateCdkDeployment(OrchestratorSession session, string cloudApplicationName, Recommendation recommendation);
+        public Task CreateCdkDeployment(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
     }
 
     public class CdkProjectHandler : ICdkProjectHandler
@@ -24,14 +24,14 @@ namespace AWS.Deploy.Orchestrator
             _appSettingsBuilder = new CdkAppSettingsSerializer();
         }
 
-        public async Task CreateCdkDeployment(OrchestratorSession session, string cloudApplicationName, Recommendation recommendation)
+        public async Task CreateCdkDeployment(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation)
         {
             // Create a new temporary CDK project for a new deployment
             _interactiveService.LogMessageLine($"Generating a {recommendation.Recipe.Name} CDK Project");
             var cdkProjectPath = await CreateCdkProjectForDeployment(recommendation, session);
 
             // Write required configuration in appsettings.json
-            var appSettingsBody = _appSettingsBuilder.Build(cloudApplicationName, recommendation);
+            var appSettingsBody = _appSettingsBuilder.Build(cloudApplication, recommendation);
             var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
             using (var appSettingsFile = new StreamWriter(appSettingsFilePath))
             {

--- a/src/AWS.Deploy.Orchestrator/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestrator/Orchestrator.cs
@@ -48,7 +48,7 @@ namespace AWS.Deploy.Orchestrator
             return engine.ComputeRecommendations(_session.ProjectPath);
         }
 
-        public async Task DeployRecommendation(string cloudApplicationName, Recommendation recommendation)
+        public async Task DeployRecommendation(CloudApplication cloudApplication, Recommendation recommendation)
         {
             _interactiveService.LogMessageLine($"Initiating deployment: {recommendation.Name}");
 
@@ -65,8 +65,8 @@ namespace AWS.Deploy.Orchestrator
             switch (recommendation.Recipe.DeploymentType)
             {
                 case RecipeDefinition.DeploymentTypes.CdkProject:
-                    await _cdkProjectHandler.CreateCdkDeployment(_session, cloudApplicationName, recommendation);
-                    PersistDeploymentSettings(cloudApplicationName, recommendation);
+                    await _cdkProjectHandler.CreateCdkDeployment(_session, cloudApplication, recommendation);
+                    PersistDeploymentSettings(cloudApplication, recommendation);
                     break;
                 default:
                     _interactiveService.LogErrorMessageLine($"Unknown deployment type {recommendation.Recipe.DeploymentType} specified in recipe.");
@@ -74,20 +74,20 @@ namespace AWS.Deploy.Orchestrator
             }
         }
 
-        private void PersistDeploymentSettings(string cloudApplicationName, Recommendation recommendation)
+        private void PersistDeploymentSettings(CloudApplication cloudApplication, Recommendation recommendation)
         {
             var settings = GetPreviousDeploymentSettings();
             settings.Profile = _session.AWSProfileName;
             settings.Region = _session.AWSRegion;
 
-            var deployment = settings.Deployments.FirstOrDefault(x => string.Equals(cloudApplicationName, x.StackName));
+            var deployment = settings.Deployments.FirstOrDefault(x => string.Equals(cloudApplication.StackName, x.StackName));
             if (deployment == null)
             {
                 deployment = new PreviousDeploymentSettings.DeploymentSettings();
                 settings.Deployments.Add(deployment);
             }
 
-            deployment.StackName = cloudApplicationName;
+            deployment.StackName = cloudApplication.StackName;
             deployment.RecipeId = recommendation.Recipe.Id;
 
             deployment.RecipeOverrideSettings.Clear();

--- a/src/AWS.Deploy.Orchestrator/TemplateEngine.cs
+++ b/src/AWS.Deploy.Orchestrator/TemplateEngine.cs
@@ -52,7 +52,8 @@ namespace AWS.Deploy.Orchestrator
 
             var templateParameters = new Dictionary<string, string> {
                 { "AWSAccountID" , session.AWSAccountId },
-                { "AWSRegion" , session.AWSRegion }
+                { "AWSRegion" , session.AWSRegion },
+                { "StackTagKey", CloudApplication.StackTagKey }
             };
 
             foreach(var option in recommendation.Recipe.OptionSettings)

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/.template.config/template.json
@@ -59,6 +59,12 @@
             "replaces": "DockerExecutionDirectory-Placeholder",
             "datatype": "string",
             "defaultValue": ""
+        },
+        "StackTagKey": {
+            "type": "parameter",
+            "description": "Specifies the CloudFormation tag key",
+            "replaces": "StackTagKey-Placeholder",
+            "datatype": "string"
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AppStack.cs
@@ -13,8 +13,16 @@ namespace AspNetAppEcsFargate
 {
     public class AppStack : Stack
     {
+        /// <summary>
+        /// Tag key of the CloudFormation stack
+        /// used to uniquely identify a stack that is deployed by aws-dotnet-deploy
+        /// </summary>
+        private const string STACK_TAG_KEY = "StackTagKey-Placeholder";
+
         internal AppStack(Construct scope, string id, Configuration configuration, IStackProps props = null) : base(scope, id, props)
         {
+            Tags.SetTag(STACK_TAG_KEY, "true");
+
 #if (UseExistingVPC)
             var vpc = Vpc.FromLookup(this, "Vpc", new VpcLookupOptions
             {

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
@@ -39,6 +39,12 @@
             "replaces": "DotNetPublishAdditionalArguments-Placeholder",
             "datatype": "string",
             "defaultValue": ""
+        },
+        "StackTagKey": {
+            "type": "parameter",
+            "description": "Specifies the CloudFormation tag key",
+            "replaces": "StackTagKey-Placeholder",
+            "datatype": "string"
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
@@ -10,8 +10,17 @@ namespace AspNetAppElasticBeanstalkLinux
     {
         private const string ENVIRONMENTTYPE_SINGLEINSTANCE = "SingleInstance";
         private const string ENVIRONMENTTYPE_LOADBALANCED = "LoadBalanced";
+
+        /// <summary>
+        /// Tag key of the CloudFormation stack
+        /// used to uniquely identify a stack that is deployed by aws-dotnet-deploy
+        /// </summary>
+        private const string STACK_TAG_KEY = "StackTagKey-Placeholder";
+
         internal AppStack(Construct scope, string id, Configuration configuration, IStackProps props = null) : base(scope, id, props)
         {
+            Tags.SetTag(STACK_TAG_KEY, "true");
+
             var asset = new Asset(this, "Asset", new AssetProps
             {
                 Path = configuration.AssetPath

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/.template.config/template.json
@@ -59,6 +59,12 @@
             "replaces": "DockerExecutionDirectory-Placeholder",
             "datatype": "string",
             "defaultValue": ""
+        },
+        "StackTagKey": {
+            "type": "parameter",
+            "description": "Specifies the CloudFormation tag key",
+            "replaces": "StackTagKey-Placeholder",
+            "datatype": "string"
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/AppStack.cs
@@ -12,8 +12,16 @@ namespace ConsoleAppEcsFargateService
 {
     public class AppStack : Stack
     {
+        /// <summary>
+        /// Tag key of the CloudFormation stack
+        /// used to uniquely identify a stack that is deployed by aws-dotnet-deploy
+        /// </summary>
+        private const string STACK_TAG_KEY = "StackTagKey-Placeholder";
+
         internal AppStack(Construct scope, string id, Configuration configuration, IStackProps props = null) : base(scope, id, props)
         {
+            Tags.SetTag(STACK_TAG_KEY, "true");
+
 #if (UseExistingVPC)
             var vpc = Vpc.FromLookup(this, "Vpc", new VpcLookupOptions
             {

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateTask/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateTask/.template.config/template.json
@@ -59,6 +59,12 @@
             "replaces": "DockerExecutionDirectory-Placeholder",
             "datatype": "string",
             "defaultValue": ""
+        },
+        "StackTagKey": {
+            "type": "parameter",
+            "description": "Specifies the CloudFormation tag key",
+            "replaces": "StackTagKey-Placeholder",
+            "datatype": "string"
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateTask/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateTask/AppStack.cs
@@ -13,8 +13,16 @@ namespace ConsoleAppEcsFargateTask
 {
     public class AppStack : Stack
     {
+        /// <summary>
+        /// Tag key of the CloudFormation stack
+        /// used to uniquely identify a stack that is deployed by aws-dotnet-deploy
+        /// </summary>
+        private const string STACK_TAG_KEY = "StackTagKey-Placeholder";
+
         internal AppStack(Construct scope, string id, Configuration configuration, IStackProps props = null) : base(scope, id, props)
         {
+            Tags.SetTag(STACK_TAG_KEY, "true");
+
 #if (UseExistingVPC)
             var vpc = Vpc.FromLookup(this, "Vpc", new VpcLookupOptions
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change allows to tag CloudFormation stacks that are deployed via CLI with "aws-dotnet-deploy" tag key. The same tag key is used to filter the CloudFormation stacks while using the list command.

Delete command also updated so that only the stacks that are deployed via the CLI can be deleted with delete command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
