### PR TITLE
use microsoft base image with valid cert: https://github.com/NuGet/An…

### DIFF
--- a/test/ManualLinuxTesting/Dockerfile
+++ b/test/ManualLinuxTesting/Dockerfile
@@ -68,7 +68,7 @@ ENV PATH="${PATH}:/root/.dotnet/tools"
 
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
 ARG AWS_CLI_VERSION
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
 


### PR DESCRIPTION
**Impacts Test Harnesses Only**
Per https://github.com/NuGet/Announcements/issues/49, update one of the base docker image to use a version that has the cert fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
