### PR TITLE
enable clearing the value of an OptionSettingsItem

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -61,7 +61,11 @@ namespace AWS.Deploy.CLI.Commands
                     Environment.Exit(-1);
                 }
 
-                cloudApplicationName = _consoleUtilities.AskUserForValue("Enter name for Cloud Application", GetDefaultApplicationName(project.ProjectPath));
+                cloudApplicationName =
+                    _consoleUtilities.AskUserForValue(
+                        "Enter name for Cloud Application",
+                        GetDefaultApplicationName(new ProjectDefinition(_session.ProjectPath).ProjectPath),
+                        allowEmpty: false);
             }
             else
             {
@@ -257,6 +261,7 @@ namespace AWS.Deploy.CLI.Commands
                         .AskUserForValue(
                                 setting.Description,
                                 recommendation.GetOptionSettingValue(setting.Id).ToString(),
+                                 allowEmpty: true,
                                 // validators:
                                 publishArgs =>
                                         (publishArgs.Contains("-o ") || publishArgs.Contains("--output "))
@@ -312,12 +317,10 @@ namespace AWS.Deploy.CLI.Commands
             }
             else
             {
-                _toolInteractiveService.WriteLine(setting.Description);
-                _toolInteractiveService.WriteLine($"(default: {recommendation.GetOptionSettingValue(setting.Id)}):");
-                settingValue = _toolInteractiveService.ReadLine();
+                settingValue = _consoleUtilities.AskUserForValue(setting.Description, currentValue.ToString(), allowEmpty: true);
             }
 
-            if (!Equals(settingValue, currentValue) && settingValue != null && (settingValue as string) != string.Empty)
+            if (!Equals(settingValue, currentValue) && settingValue != null)
             {
                 recommendation.SetOverrideOptionSettingValue(setting.Id, settingValue);
             }

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -150,19 +150,32 @@ namespace AWS.Deploy.CLI
             }
 
 
-            return AskUserForValue("Enter name:", !options.Contains(defaultValue) ? defaultValue : null);
+            return AskUserForValue("Enter name:", !options.Contains(defaultValue) ? defaultValue : null, allowEmpty: false);
         }
 
-        public string AskUserForValue(string message, string defaultValue, params Func<string, string>[] validators)
+        public string AskUserForValue(string message, string defaultValue, bool allowEmpty, params Func<string, string>[] validators)
         {
-            message += $" (default: {defaultValue})";
+            const string CLEAR = "<clear>";
 
             _interactiveService.WriteLine(message);
+
+            var prompt = $"Enter value (default: {defaultValue}.";
+            if (allowEmpty)
+                prompt += $"  Type {CLEAR} to clear.";
+            prompt += "): ";
+            _interactiveService.WriteLine(prompt);
 
             string userValue = null;
             while (true)
             {
-                var line = _interactiveService.ReadLine()?.Trim();
+                var line = _interactiveService.ReadLine()?.Trim() ?? "";
+
+                if (allowEmpty && 
+                    (string.Equals(CLEAR, line.Trim(), StringComparison.OrdinalIgnoreCase) ||
+                     string.Equals($"'{CLEAR}'", line.Trim(), StringComparison.OrdinalIgnoreCase)))
+                {
+                    return string.Empty;
+                }
 
                 if (string.IsNullOrEmpty(line) && !string.IsNullOrEmpty(defaultValue))
                 {

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
+using Should;
 using Xunit;
 
 namespace AWS.Deploy.CLI.UnitTests
@@ -52,6 +53,36 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.Equal("Option1", selectedValue);
 
             Assert.Equal("1: Option1", interactiveServices.OutputMessages[0]);
+        }
+
+        [Fact]
+        public void AskUserForValueCanBeSetToEmptyString()
+        {
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "<clear>" });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+
+            var selectedValue =
+                consoleUtilities.AskUserForValue(
+                    "message",
+                    "defaultValue",
+                    allowEmpty: true);
+
+            selectedValue.ShouldEqual(string.Empty);
+        }
+
+        [Fact]
+        public void AskUserForValueCanBeSetToEmptyStringNoDefault()
+        {
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "<clear>" });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+
+            var selectedValue =
+                consoleUtilities.AskUserForValue(
+                    "message",
+                    "",
+                    allowEmpty: true);
+
+            selectedValue.ShouldEqual(string.Empty);
         }
 
         [Fact]


### PR DESCRIPTION
*Issue #, if available:*

Adds the ability for a user to set an `OptionSettingsItem` to an empty value when:
- There is a default value
- After a value has already been set on a previous deployment.


*Description of changes:*
**BEFORE:**
![clearOptionBug_before](https://user-images.githubusercontent.com/1190907/106344882-4a21a200-6261-11eb-86d5-f823582f4275.gif)

**AFTER:**
![clearOptionBug_after2](https://user-images.githubusercontent.com/1190907/106345253-b56c7380-6263-11eb-8715-f71a32742191.gif)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

