### PR TITLE
fix: use current application name for default beanstalk app name

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -396,7 +396,8 @@ namespace AWS.Deploy.CLI.Commands
                     {
                         DisplaySelector = app => app.ApplicationName,
                         DefaultSelector = app => app.ApplicationName.Equals(currentTypeHintResponse?.ApplicationName),
-                        AskNewName = true
+                        AskNewName = true,
+                        DefaultNewName = currentTypeHintResponse.ApplicationName
                     };
 
                     var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(applications, "Select Beanstalk application to deploy to:", userInputConfiguration);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
