### PR TITLE
fix: don't include null object values to allow only option setting overrides in aws-netsuite-deployment.json

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -32,10 +32,16 @@ namespace AWS.Deploy.Common.Recipes
 
             if (Type == OptionSettingValueType.Object)
             {
-                var objectValue = ChildOptionSettings
-                    .ToDictionary(childOptionSetting => childOptionSetting.Id, childOptionSetting => childOptionSetting.GetValue(replacementTokens, ignoreDefaultValue));
-
-                return objectValue;
+                var objectValue = new Dictionary<string, object>();
+                foreach (var childOptionSetting in ChildOptionSettings)
+                {
+                    var childValue = childOptionSetting.GetValue(replacementTokens, ignoreDefaultValue);
+                    if (childValue != null)
+                    {
+                        objectValue[childOptionSetting.Id] = childValue;
+                    }
+                }
+                return objectValue.Any() ? objectValue : null;
             }
 
             if (ignoreDefaultValue)
@@ -78,7 +84,10 @@ namespace AWS.Deploy.Common.Recipes
                 var deserialized = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(valueOverride));
                 foreach (var childOptionSetting in ChildOptionSettings)
                 {
-                    childOptionSetting.SetValueOverride(deserialized[childOptionSetting.Id]);
+                    if (deserialized.TryGetValue(childOptionSetting.Id, out var childValueOverride))
+                    {
+                        childOptionSetting.SetValueOverride(childValueOverride);
+                    }
                 }
             }
         }

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Recipes;
@@ -84,6 +85,34 @@ namespace AWS.Deploy.CLI.UnitTests
         }
 
         [Fact]
+        public void ObjectMappingWithDefaultValue()
+        {
+            var projectPath = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
+            var engine = new RecommendationEngine.RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() });
+            var recommendations = engine.ComputeRecommendations(projectPath);
+            var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+            var applicationIAMRoleOptionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ApplicationIAMRole"));
+
+            var iamRoleTypeHintResponse = beanstalkRecommendation.GetOptionSettingValue<IAMRoleTypeHintResponse>(applicationIAMRoleOptionSetting, false);
+
+            Assert.Null(iamRoleTypeHintResponse.RoleArn);
+            Assert.True(iamRoleTypeHintResponse.CreateNew);
+        }
+
+        [Fact]
+        public void ObjectMappingWithoutDefaultValue()
+        {
+            var projectPath = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
+            var engine = new RecommendationEngine.RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() });
+            var recommendations = engine.ComputeRecommendations(projectPath);
+            var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+            var applicationIAMRoleOptionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ApplicationIAMRole"));
+
+            Assert.Null(beanstalkRecommendation.GetOptionSettingValue(applicationIAMRoleOptionSetting, true));
+        }
+
+
+        [Fact]
         public void ValueMappingSetWithAllowedValues()
         {
             var projectPath = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
@@ -107,6 +136,23 @@ namespace AWS.Deploy.CLI.UnitTests
 
             environmentTypeOptionSetting.SetValueOverride("LoadBalanced");
             Assert.Equal("LoadBalanced", beanstalkRecommendation.GetOptionSettingValue(environmentTypeOptionSetting, false));
+        }
+
+        [Fact]
+        public void ObjectMappingSetWithValue()
+        {
+            var projectPath = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
+            var engine = new RecommendationEngine.RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() });
+            var recommendations = engine.ComputeRecommendations(projectPath);
+            var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+            var applicationIAMRoleOptionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ApplicationIAMRole"));
+
+            applicationIAMRoleOptionSetting.SetValueOverride(new IAMRoleTypeHintResponse {CreateNew = false, RoleArn = "role_arn"});
+
+            var iamRoleTypeHintResponse = beanstalkRecommendation.GetOptionSettingValue<IAMRoleTypeHintResponse>(applicationIAMRoleOptionSetting, false);
+
+            Assert.Equal("role_arn", iamRoleTypeHintResponse.RoleArn);
+            Assert.False(iamRoleTypeHintResponse.CreateNew);
         }
 
         [Theory]


### PR DESCRIPTION
…errides in aws-netsuite-deployment.json

*Issue #, if available:*

*Description of changes:*
We don't want to include default settings in `aws-netsuite-deployment.json`, but after the Object type option settings, even if all the child values are having default value, the Object type option item was included in the overrides stored in  `aws-netsuite-deployment.json`.

With this change, we no longer stored Object type option settings if they have default value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
