### PR TITLE
Fix issue with not showing the correct region the tool is configured for.

### DIFF
--- a/src/AWS.Deploy.CLI/AWSUtilities.cs
+++ b/src/AWS.Deploy.CLI/AWSUtilities.cs
@@ -113,7 +113,7 @@ namespace AWS.Deploy.CLI
             var fallbackRegion = FallbackRegionFactory.GetRegionEndpoint()?.SystemName;
             if (!string.IsNullOrEmpty(fallbackRegion))
             {
-                _toolInteractiveService.WriteLine($"Configuring AWS region using AWS SDK region search to {region}.");
+                _toolInteractiveService.WriteLine($"Configuring AWS region using AWS SDK region search to {fallbackRegion}.");
                 return fallbackRegion;
             }
 


### PR DESCRIPTION
*Description of changes:*
Fix the issue of the "Configuring AWS region using AWS SDK region search to  ." displayed during startup not showing the correct region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
