### PR TITLE
fix: depends on should break for top level option settings when dependencies are not satisfied

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -145,7 +145,7 @@ namespace AWS.Deploy.CLI.Commands
                     recommendation
                         .Recipe
                         .OptionSettings
-                        .Where(x => !x.AdvancedSetting || showAdvancedSettings)
+                        .Where(x => (!x.AdvancedSetting || showAdvancedSettings) && recommendation.IsOptionSettingDisplayable(x))
                         .ToArray();
 
                 for (var i = 1; i <= optionSettings.Length; i++)
@@ -239,32 +239,6 @@ namespace AWS.Deploy.CLI.Commands
 
         private async Task ConfigureDeployment(Recommendation recommendation, OptionSettingItem setting)
         {
-            var isDisplayed = true;
-            PropertyDependency failedDependency = null;
-
-            foreach (var dependency in setting.DependsOn)
-            {
-                var dependsOnOptionSetting = recommendation.GetOptionSetting(setting.Id);
-                if (dependsOnOptionSetting != null && !recommendation.GetOptionSettingValue(dependsOnOptionSetting).Equals(dependency.Value))
-                {
-                    isDisplayed = false;
-                    failedDependency = dependency;
-                    setting.SetValueOverride(setting.DefaultValue);
-                    break;
-                }
-            }
-
-            if (!isDisplayed)
-            {
-                var dependentOption = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals(failedDependency.Id)).Name;
-                _toolInteractiveService.WriteLine(string.Empty);
-                _toolInteractiveService.WriteLine(
-                    $"{setting.Name} depends on '{dependentOption}' to have the value '{failedDependency.Value}'");
-                _toolInteractiveService.WriteLine($"Please configure '{dependentOption}' to have the value '{failedDependency.Value}' first, or select another setting.");
-                _toolInteractiveService.WriteLine(string.Empty);
-                return;
-            }
-
             _toolInteractiveService.WriteLine(string.Empty);
             _toolInteractiveService.WriteLine($"{setting.Name}:");
 
@@ -279,7 +253,7 @@ namespace AWS.Deploy.CLI.Commands
                 if (Equals(settingValue, currentValue))
                     return;
             }
-            if (setting.TypeHint == OptionSettingTypeHint.BeanstalkEnvironment)
+            else if (setting.TypeHint == OptionSettingTypeHint.BeanstalkEnvironment)
             {
                 _toolInteractiveService.WriteLine(setting.Description);
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -54,14 +54,18 @@ namespace AWS.Deploy.Common.Recipes
                 return null;
             }
 
-            var mappedValue = string.Copy(DefaultValue);
-            if (ValueMapping != null && ValueMapping.ContainsKey(DefaultValue))
+            if (DefaultValue is string defaultValueString)
             {
-                mappedValue = ValueMapping[DefaultValue];
+                var mappedValue = string.Copy(defaultValueString);
+                if (ValueMapping != null && ValueMapping.ContainsKey(defaultValueString))
+                {
+                    mappedValue = ValueMapping[defaultValueString];
+                }
+                mappedValue = ApplyReplacementTokens(replacementTokens, mappedValue);
+                return mappedValue;
             }
 
-            mappedValue = ApplyReplacementTokens(replacementTokens, mappedValue);
-            return mappedValue;
+            return DefaultValue;
         }
 
         public void SetValueOverride(object valueOverride)
@@ -72,12 +76,22 @@ namespace AWS.Deploy.Common.Recipes
             }
             else if (valueOverride is string valueOverrideString)
             {
-                if (ValueMapping != null && ValueMapping.ContainsKey(valueOverrideString))
+                if (bool.TryParse(valueOverrideString, out var valueOverrideBool))
                 {
-                    valueOverrideString = ValueMapping[valueOverrideString];
+                    _valueOverride = valueOverrideBool;
                 }
-
-                _valueOverride = valueOverrideString;
+                else if (int.TryParse(valueOverrideString, out var valueOverrideInt))
+                {
+                    _valueOverride = valueOverrideInt;
+                }
+                else
+                {
+                    if (ValueMapping != null && ValueMapping.ContainsKey(valueOverrideString))
+                    {
+                        valueOverrideString = ValueMapping[valueOverrideString];
+                    }
+                    _valueOverride = valueOverrideString;
+                }
             }
             else
             {

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -49,7 +49,7 @@ namespace AWS.Deploy.Common.Recipes
         /// <summary>
         /// The default value used for the recipe if the user doesn't override the value.
         /// </summary>
-        public string DefaultValue { get; set; }
+        public object DefaultValue { get; set; }
 
         /// <summary>
         /// UI can use this to reduce the amount of settings to show to the user when confirming the recommendation. This can make it so the user sees only the most important settings

--- a/src/AWS.Deploy.Common/Recipes/PropertyDependency.cs
+++ b/src/AWS.Deploy.Common/Recipes/PropertyDependency.cs
@@ -9,6 +9,6 @@ namespace AWS.Deploy.Common.Recipes
     public class PropertyDependency
     {
         public string Id { get; set; }
-        public string Value { get; set; }
+        public object Value { get; set; }
     }
 }

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -100,5 +100,30 @@ namespace AWS.Deploy.Common
         {
             return optionSetting.GetValue(_replacementTokens, ignoreDefaultValue);
         }
+
+        /// <summary>
+        /// Checks whether all the dependencies are satisfied or not, if there exists an unsatisfied dependency then returns false.
+        /// It allows caller to decide whether we want to display an <see cref="OptionSettingItem"/> to configure or not.
+        /// </summary>
+        /// <param name="optionSetting">Option setting to check whether it can be displayed for configuration or not.</param>
+        /// <returns>Returns true, if all the dependencies are satisfied, else false.</returns>
+        public bool IsOptionSettingDisplayable(OptionSettingItem optionSetting)
+        {
+            if (!optionSetting.DependsOn.Any())
+            {
+                return true;
+            }
+
+            foreach (var dependency in optionSetting.DependsOn)
+            {
+                var dependsOnOptionSetting = GetOptionSetting(dependency.Id);
+                if (dependsOnOptionSetting != null && !GetOptionSettingValue(dependsOnOptionSetting).Equals(dependency.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -93,7 +93,7 @@
             "Name": "Desired Task Count",
             "Description": "The desired number of ECS tasks to run for the service.",
             "Type": "Int",
-            "DefaultValue": "3",
+            "DefaultValue": 3,
             "AdvancedSetting": false,
             "Updatable": true
         },
@@ -114,7 +114,7 @@
                     "Name": "Create New Role",
                     "Description": "Do you want to create a new Role?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": false,
                     "Updatable": false
                 },
@@ -128,7 +128,7 @@
                     "DependsOn": [
                         {
                             "Id": "ApplicationIAMRole.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -148,7 +148,7 @@
                     "Name": "Use default VPC",
                     "Description": "Do you want to use the default VPC for the deployment?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": true,
                     "Updatable": false
                 },
@@ -157,13 +157,13 @@
                     "Name": "Create New VPC",
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
-                    "DefaultValue": "false",
+                    "DefaultValue": false,
                     "AdvancedSetting": true,
                     "Updatable": false,
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 },
@@ -178,11 +178,11 @@
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",
-                            "Value": "false"
+                            "Value": false
                         },
                         {
                             "Id": "Vpc.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -193,7 +193,7 @@
             "Name": "Add Docker Build Args",
             "Description": "Do you want to pass additional Docker build args?",
             "Type": "Bool",
-            "DefaultValue": "false",
+            "DefaultValue": false,
             "AdvancedSetting": true,
             "Updatable": true
         },
@@ -206,7 +206,7 @@
             "DependsOn": [
                 {
                     "Id": "AddDockerBuildArgs",
-                    "Value": "true"
+                    "Value": true
                 }
             ],
             "AdvancedSetting": true,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -65,7 +65,7 @@
                     "Name": "Create new Beanstalk application",
                     "Description": "Do you want to create new application?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": false,
                     "Updatable": false
                 },
@@ -160,7 +160,7 @@
                     "Name": "Create New Role",
                     "Description": "Do you want to create a new Role?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": false,
                     "Updatable": false
                 },
@@ -174,7 +174,7 @@
                     "DependsOn": [
                         {
                             "Id": "ApplicationIAMRole.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -214,7 +214,7 @@
             "Name": "Self Contained Build",
             "Description": "Publishing your app as self-contained produces an application that includes the .NET runtime and libraries. Users can run it on a machine that doesn't have the .NET runtime installed.",
             "Type": "Bool",
-            "DefaultValue": "false",
+            "DefaultValue": false,
             "AdvancedSetting": true,
             "Updatable": true
         },

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -102,7 +102,7 @@
             "Name": "Desired Task Count",
             "Description": "The desired number of ECS tasks to run for the service.",
             "Type": "Int",
-            "DefaultValue": "3",
+            "DefaultValue": 3,
             "AdvancedSetting": false,
             "Updatable": true
         },
@@ -123,7 +123,7 @@
                     "Name": "Create New Role",
                     "Description": "Do you want to create a new Role?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": false,
                     "Updatable": false
                 },
@@ -137,7 +137,7 @@
                     "DependsOn": [
                         {
                             "Id": "ApplicationIAMRole.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -157,7 +157,7 @@
                     "Name": "Use default VPC",
                     "Description": "Do you want to use the default VPC for the deployment?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": true,
                     "Updatable": false
                 },
@@ -166,13 +166,13 @@
                     "Name": "Create New VPC",
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
-                    "DefaultValue": "false",
+                    "DefaultValue": false,
                     "AdvancedSetting": true,
                     "Updatable": false,
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 },
@@ -187,11 +187,11 @@
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",
-                            "Value": "false"
+                            "Value": false
                         },
                         {
                             "Id": "Vpc.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -202,7 +202,7 @@
             "Name": "Add Docker Build Args",
             "Description": "Do you want to pass additional Docker build args?",
             "Type": "Bool",
-            "DefaultValue": "false",
+            "DefaultValue": false,
             "AdvancedSetting": true,
             "Updatable": true
         },
@@ -215,7 +215,7 @@
             "DependsOn": [
                 {
                     "Id": "AddDockerBuildArgs",
-                    "Value": "true"
+                    "Value": true
                 }
             ],
             "AdvancedSetting": true,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateTask.recipe
@@ -101,7 +101,7 @@
                     "Name": "Create New Role",
                     "Description": "Do you want to create a new Role?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": false,
                     "Updatable": false
                 },
@@ -115,7 +115,7 @@
                     "DependsOn": [
                         {
                             "Id": "ApplicationIAMRole.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -145,7 +145,7 @@
                     "Name": "Use default VPC",
                     "Description": "Do you want to use the default VPC?",
                     "Type": "Bool",
-                    "DefaultValue": "true",
+                    "DefaultValue": true,
                     "AdvancedSetting": true,
                     "Updatable": false
                 },
@@ -154,13 +154,13 @@
                     "Name": "Create New VPC",
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
-                    "DefaultValue": "false",
+                    "DefaultValue": false,
                     "AdvancedSetting": true,
                     "Updatable": false,
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 },
@@ -175,11 +175,11 @@
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",
-                            "Value": "false"
+                            "Value": false
                         },
                         {
                             "Id": "Vpc.CreateNew",
-                            "Value": "false"
+                            "Value": false
                         }
                     ]
                 }
@@ -190,7 +190,7 @@
             "Name": "Add Docker Build Args",
             "Description": "Do you want to pass additional Docker build args?",
             "Type": "Bool",
-            "DefaultValue": "false",
+            "DefaultValue": false,
             "AdvancedSetting": true,
             "Updatable": true
         },
@@ -203,7 +203,7 @@
             "DependsOn": [
                 {
                     "Id": "AddDockerBuildArgs",
-                    "Value": "true"
+                    "Value": true
                 }
             ],
             "AdvancedSetting": true,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -316,7 +316,7 @@
                     ]
                 },
                 "DefaultValue": {
-                    "type": ["string", "null"],
+                    "type": ["string", "null", "boolean", "integer"],
                     "title": "The default value for the setting.",
                     "description": ""
                 },
@@ -356,7 +356,7 @@
                                 "minLength": 1
                             },
                             "Value": {
-                                "type": "string",
+                                "type": ["boolean", "string"],
                                 "title": "",
                                 "description": ""
                             }


### PR DESCRIPTION
Beanstalk case

https://user-images.githubusercontent.com/8882380/108568155-68a61680-72be-11eb-9729-82dbec1e0d34.mp4

This is a hypothetical case. For display purpose only.

https://user-images.githubusercontent.com/8882380/108568175-722f7e80-72be-11eb-8c34-ced571f42bea.mp4

*Issue #, if available:*


*Description of changes:*

This change allows to hide option settings from the list of option settings to configure if any of the dependences isn't satisfied. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice



.
