### PR TITLE
bugfix: prevent adding duplicate keys to EnvironmentVariables Dictionary

### DIFF
--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -52,18 +52,18 @@ namespace AWS.Deploy.CLI.Utilities
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                WorkingDirectory = workingDirectory,
-                EnvironmentVariables =
-                {
-                    { "AWS_ACCESS_KEY_ID", credentials.AccessKey },
-                    { "AWS_SECRET_ACCESS_KEY", credentials.SecretKey },
-                    { "AWS_REGION", _awsRegion }
-                }
+                WorkingDirectory = workingDirectory
             };
+
+            // environment variables could already be set at the machine level,
+            // use this syntax to make sure we don't create duplicate entries
+            processStartInfo.EnvironmentVariables["AWS_ACCESS_KEY"] = credentials.AccessKey;
+            processStartInfo.EnvironmentVariables["AWS_SECRET_ACCESS_KEY"] = credentials.SecretKey;
+            processStartInfo.EnvironmentVariables["AWS_REGION"] = _awsRegion;
 
             if (credentials.UseToken)
             {
-                processStartInfo.EnvironmentVariables.Add("AWS_SESSION_TOKEN", credentials.Token);
+                processStartInfo.EnvironmentVariables["AWS_SESSION_TOKEN"] = credentials.Token;
             }
 
             var process = Process.Start(processStartInfo);


### PR DESCRIPTION
### Bug:
If `AWS_REGION` env variable is set (System level only?) than tool will crash:

```
Unhandled exception.  This is a bug.  Please copy the stack trace below and file a bug at https://github.com/aws/aws-dotnet-deploy.
Value does not fall within the expected range.
   at System.Collections.Specialized.StringDictionaryWrapper.Add(String key, String value)
   at AWS.Deploy.CLI.Utilities.CommandLineWrapper.Run(String command, String workingDirectory, Boolean streamOutputToInteractiveService, Func`2 onComplete, CancellationToken cancelToken) in C:\codebuild\tmp\output\src865507767\src\src\AWS.Deploy.CLI\Utilities\CommandLineWrapper.cs:line 64
   at AWS.Deploy.CLI.SystemCapabilityEvaluator.HasDockerInstalledAndRunning() in C:\codebuild\tmp\output\src865507767\src\src\AWS.Deploy.CLI\SystemCapabilityEvaluator.cs:line 54
   at AWS.Deploy.CLI.SystemCapabilityEvaluator.Evaluate() in C:\codebuild\tmp\output\src865507767\src\src\AWS.Deploy.CLI\SystemCapabilityEvaluator.cs:line 31
   at AWS.Deploy.CLI.Commands.DeployCommand.ExecuteAsync(Boolean saveCdkProject) in C:\codebuild\tmp\output\src865507767\src\src\AWS.Deploy.CLI\Commands\DeployCommand.cs:line 108
   at AWS.Deploy.CLI.Program.<>c.<<Main>b__5_0>d.MoveNext() in C:\codebuild\tmp\output\src865507767\src\src\AWS.Deploy.CLI\Program.cs:line 94
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Solution:
Don't add duplicate keys to `EnvironmentVariables` dictionary.