### PR TITLE
feat: use CDK to add policies and permission to application IAM role

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AppStack.cs
@@ -49,28 +49,24 @@ namespace AspNetAppEcsFargate
                 ClusterName = settings.ClusterName
             });
 
-            IRole executionRole;
+            IRole taskRole;
             if (settings.ApplicationIAMRole.CreateNew)
             {
-                executionRole = new Role(this, "ExecutionRole", new RoleProps
+                taskRole = new Role(this, "TaskRole", new RoleProps
                 {
-                    AssumedBy = new ServicePrincipal("ecs-tasks.amazonaws.com"),
-                    ManagedPolicies = new[]
-                    {
-                        ManagedPolicy.FromAwsManagedPolicyName("service-role/AmazonECSTaskExecutionRolePolicy"),
-                    }
+                    AssumedBy = new ServicePrincipal("ecs-tasks.amazonaws.com")
                 });
             }
             else
             {
-                executionRole = Role.FromRoleArn(this, "ExecutionRole", settings.ApplicationIAMRole.RoleArn, new FromRoleArnOptions {
+                taskRole = Role.FromRoleArn(this, "TaskRole", settings.ApplicationIAMRole.RoleArn, new FromRoleArnOptions {
                     Mutable = false
                 });
             }
 
             var taskDefinition = new FargateTaskDefinition(this, "TaskDefinition", new FargateTaskDefinitionProps
             {
-                ExecutionRole = executionRole,
+                TaskRole = taskRole,
             });
 
             var dockerExecutionDirectory = @"DockerExecutionDirectory-Placeholder";
@@ -108,7 +104,8 @@ namespace AspNetAppEcsFargate
                 Cluster = cluster,
                 TaskDefinition = taskDefinition,
                 DesiredCount = settings.DesiredCount,
-                ServiceName = settings.ECSServiceName
+                ServiceName = settings.ECSServiceName,
+                AssignPublicIp = settings.Vpc.IsDefault
             });
         }
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
@@ -59,7 +59,6 @@ namespace AspNetAppElasticBeanstalkLinux
                     ManagedPolicies = new[]
                     {
                         ManagedPolicy.FromAwsManagedPolicyName("AWSElasticBeanstalkWebTier"),
-                        ManagedPolicy.FromAwsManagedPolicyName("AWSElasticBeanstalkMulticontainerDocker"),
                         ManagedPolicy.FromAwsManagedPolicyName("AWSElasticBeanstalkWorkerTier")
                     }
                 });

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/AppStack.cs
@@ -48,28 +48,24 @@ namespace ConsoleAppEcsFargateService
                 ClusterName = settings.ClusterName
             });
 
-            IRole executionRole;
+            IRole taskRole;
             if (settings.ApplicationIAMRole.CreateNew)
             {
-                executionRole = new Role(this, "ExecutionRole", new RoleProps
+                taskRole = new Role(this, "TaskRole", new RoleProps
                 {
-                    AssumedBy = new ServicePrincipal("ecs-tasks.amazonaws.com"),
-                    ManagedPolicies = new[]
-                    {
-                        ManagedPolicy.FromAwsManagedPolicyName("service-role/AmazonECSTaskExecutionRolePolicy"),
-                    }
+                    AssumedBy = new ServicePrincipal("ecs-tasks.amazonaws.com")
                 });
             }
             else
             {
-                executionRole = Role.FromRoleArn(this, "ExecutionRole", settings.ApplicationIAMRole.RoleArn, new FromRoleArnOptions {
+                taskRole = Role.FromRoleArn(this, "TaskRole", settings.ApplicationIAMRole.RoleArn, new FromRoleArnOptions {
                     Mutable = false
                 });
             }
 
             var taskDefinition = new FargateTaskDefinition(this, "TaskDefinition", new FargateTaskDefinitionProps
             {
-                ExecutionRole = executionRole,
+                TaskRole = taskRole,
             });
 
             var logging = new AwsLogDriver(new AwsLogDriverProps
@@ -106,6 +102,7 @@ namespace ConsoleAppEcsFargateService
             {
                 Cluster = cluster,
                 TaskDefinition = taskDefinition,
+                AssignPublicIp = settings.Vpc.IsDefault
             });
         }
 


### PR DESCRIPTION
No video because changes doesn't affect the UX.

*Issue #, if available:*

*Description of changes:*
This change removes usage of managed polices and now CDK app leverage CDK constructs to attach IAM policies and permissions.

It also fixes usage of Default VPC for fargate related deployment. Application uses public subnet for default VPC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
