### PR TITLE
Bug: Key Pairs option setting does not include and Empty option

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -303,14 +303,24 @@ namespace AWS.Deploy.CLI.Commands
                 {
                     DisplaySelector = kp => kp.KeyName,
                     DefaultSelector = kp => kp.KeyName.Equals(currentValue),
-                    AskNewName = true
+                    AskNewName = true,
+                    EmptyOption = true,
+                    CurrentValue = currentValue
                 };
 
                 while (true)
                 {
                     var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(keyPairs, "Select Key Pair to use:", userInputConfiguration);
 
-                    settingValue = userResponse.SelectedOption?.KeyName ?? userResponse.NewName;
+                    if (userResponse.IsEmpty)
+                    {
+                        settingValue = "";
+                        break;
+                    }
+                    else
+                    {
+                        settingValue = userResponse.SelectedOption?.KeyName ?? userResponse.NewName;
+                    }
 
                     if (userResponse.CreateNew && !string.IsNullOrEmpty(userResponse.NewName))
                     {

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -138,13 +138,22 @@ namespace AWS.Deploy.CLI
             var defaultOption = options.FirstOrDefault(userInputConfiguration.DefaultSelector);
             var defaultValue = "";
             if (defaultOption != null)
+            {
                 defaultValue = userInputConfiguration.DisplaySelector(defaultOption);
+            }
             else
-                defaultValue = userInputConfiguration.CreateNew ? Constants.CREATE_NEW_LABEL : userInputConfiguration.DisplaySelector(options.FirstOrDefault());
+            {
+                if (userInputConfiguration.CurrentValue != null && string.IsNullOrEmpty(userInputConfiguration.CurrentValue.ToString()))
+                    defaultValue = Constants.EMPTY_LABEL;
+                else
+                    defaultValue = userInputConfiguration.CreateNew ? Constants.CREATE_NEW_LABEL : userInputConfiguration.DisplaySelector(options.FirstOrDefault());
+            }
 
             if (optionStrings.Any())
             {
                 var displayOptionStrings = new List<string>(optionStrings);
+                if (userInputConfiguration.EmptyOption)
+                    displayOptionStrings.Insert(0, Constants.EMPTY_LABEL);
                 if (userInputConfiguration.CreateNew)
                     displayOptionStrings.Add(Constants.CREATE_NEW_LABEL);
 

--- a/src/AWS.Deploy.CLI/UserInputConfiguration.cs
+++ b/src/AWS.Deploy.CLI/UserInputConfiguration.cs
@@ -25,6 +25,11 @@ namespace AWS.Deploy.CLI
         public Func<T, bool> DefaultSelector;
 
         /// <summary>
+        /// The current value for the option setting.
+        /// </summary>
+        public object CurrentValue;
+
+        /// <summary>
         /// If true, ask for the new name
         /// <para />
         /// Default is <c>false</c>
@@ -50,5 +55,11 @@ namespace AWS.Deploy.CLI
         /// then a "Create New" option will be added to the list of valid options.
         /// </summary>
         public bool CreateNew { get; set; } = true;
+
+        /// <summary>
+        /// If <see cref="EmptyOption" /> is set to true,
+        /// then an "Empty" option will be added to the list of valid options.
+        /// </summary>
+        public bool EmptyOption { get; set; }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4881

*Description of changes:*
There is a bug where the "Empty" option does not show for Key Pairs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
