### PR TITLE
Bug: Option settings with Allowed Values and Mapping Values do not display Default values

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -248,7 +248,15 @@ namespace AWS.Deploy.CLI.Commands
             if (setting.AllowedValues?.Count > 0)
             {
                 _toolInteractiveService.WriteLine(setting.Description);
-                settingValue = _consoleUtilities.AskUserToChoose(setting.AllowedValues, null, currentValue?.ToString());
+                var userInputConfig = new UserInputConfiguration<string>
+                {
+                    DisplaySelector = x => setting.ValueMapping[x],
+                    DefaultSelector = x => x.Equals(currentValue),
+                    CreateNew = false
+                };
+
+                var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(setting.AllowedValues, string.Empty, userInputConfig);
+                settingValue = userResponse.SelectedOption;
 
                 // If they didn't change the value then don't store so we can rely on using the default in the recipe.
                 if (Equals(settingValue, currentValue))

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -51,6 +51,13 @@ namespace AWS.Deploy.Common
     public class FailedToGenerateAnyRecommendations : Exception {}
 
     /// <summary>
+    /// Throw if a value is set that is not part of the allowed values
+    /// of an option setting item
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class InvalidOverrideValueException : Exception { }
+
+    /// <summary>
     /// Throw if there is a parse error reading the existing Cloud Application's metadata
     /// </summary>
     [AWSDeploymentExpectedException]

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -56,13 +56,7 @@ namespace AWS.Deploy.Common.Recipes
 
             if (DefaultValue is string defaultValueString)
             {
-                var mappedValue = string.Copy(defaultValueString);
-                if (ValueMapping != null && ValueMapping.ContainsKey(defaultValueString))
-                {
-                    mappedValue = ValueMapping[defaultValueString];
-                }
-                mappedValue = ApplyReplacementTokens(replacementTokens, mappedValue);
-                return mappedValue;
+                return ApplyReplacementTokens(replacementTokens, defaultValueString);
             }
 
             return DefaultValue;
@@ -86,10 +80,8 @@ namespace AWS.Deploy.Common.Recipes
                 }
                 else
                 {
-                    if (ValueMapping != null && ValueMapping.ContainsKey(valueOverrideString))
-                    {
-                        valueOverrideString = ValueMapping[valueOverrideString];
-                    }
+                    if (AllowedValues != null && !AllowedValues.Contains(valueOverrideString))
+                        throw new InvalidOverrideValueException();
                     _valueOverride = valueOverrideString;
                 }
             }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -68,8 +68,8 @@ namespace AWS.Deploy.Common.Recipes
         public IList<string> AllowedValues { get; set; } = new List<string>();
 
         /// <summary>
-        /// The value mapping for allowed values. The key of the dictionary is the display value shown to users and
-        /// the value is what is sent to services.
+        /// The value mapping for allowed values. The key of the dictionary is what is sent to services
+        /// and the value is the display value shown to users.
         /// </summary>
         public IDictionary<string, string> ValueMapping { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -107,14 +107,14 @@
             "Name": "Environment Type",
             "Description": "The type of environment to create for example a single instance for development or load balanced for production",
             "Type": "String",
-            "DefaultValue": "Single Instance",
+            "DefaultValue": "SingleInstance",
             "AllowedValues": [
-                "Single Instance",
-                "Load Balanced"
+                "SingleInstance",
+                "LoadBalanced"
             ],
             "ValueMapping": {
-                "Single Instance": "SingleInstance",
-                "Load Balanced": "LoadBalanced"
+                "SingleInstance": "Single Instance",
+                "LoadBalanced": "Load Balanced"
             },
             "AdvancedSetting": false,
             "Updatable": true
@@ -124,16 +124,16 @@
             "Name": "Load Balancer Type",
             "Description": "The type of load balancer for your environment.",
             "Type": "String",
-            "DefaultValue": "Application",
+            "DefaultValue": "application",
             "AllowedValues": [
-                "Application",
-                "Classic",
-                "Network"
+                "application",
+                "classic",
+                "network"
             ],
             "ValueMapping": {
-                "Application": "application",
-                "Classic": "classic",
-                "Network": "network"
+                "application": "Application",
+                "classic": "Classic",
+                "network": "Network"
             },
             "DependsOn": [
                 {

--- a/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Recipes;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class SetOptionSettingTests
+    {
+        private readonly OptionSettingItem _optionSetting;
+
+        public SetOptionSettingTests()
+        {
+            var projectPath = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
+            var engine = new RecommendationEngine.RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() });
+            var recommendations = engine.ComputeRecommendations(projectPath, new Dictionary<string, string>());
+            var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            _optionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(x => x.Id.Equals("EnvironmentType"));
+        }
+
+        /// <summary>
+        /// This test is to make sure no exception is throw when we set a valid value.
+        /// The values in AllowedValues are the only values allowed to be set.
+        /// </summary>
+        [Fact]
+        public void SetOptionSettingTests_AllowedValues()
+        {
+            _optionSetting.SetValueOverride(_optionSetting.AllowedValues.First());
+        }
+
+        /// <summary>
+        /// This test asserts that an exception will be thrown if we set an invalid value.
+        /// _optionSetting.ValueMapping.Values contain display values and are not
+        /// considered valid values to be set for an option setting. Only values
+        /// in AllowedValues can be set. Any other value will throw an exception.
+        /// </summary>
+        [Fact]
+        public void SetOptionSettingTests_MappedValues()
+        {
+            Assert.Throws<InvalidOverrideValueException>(() => _optionSetting.SetValueOverride(_optionSetting.ValueMapping.Values.First()));
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4880

*Description of changes:*
Bug: Option settings with Allowed Values and Mapping Values do not display Default values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
