### PR TITLE
Fix user enter application name is not used as the default for replacement tokens

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -107,6 +107,9 @@ namespace AWS.Deploy.CLI.Commands
                 selectedRecommendation = _consoleUtilities.AskUserToChoose(recommendations, "Available options to deploy project", recommendations[0]);
             }
 
+            // Apply the user enter project name to the recommendation so that any default settings based on project name are applied.
+            selectedRecommendation.OverrideProjectName(cloudApplicationName);
+
             if (selectedRecommendation.Recipe.DeploymentType == DeploymentTypes.CdkProject &&
                 !(await _session.SystemCapabilities).NodeJsMinVersionInstalled)
             {

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -45,6 +45,15 @@ namespace AWS.Deploy.Common
             }
         }
 
+        /// <summary>
+        /// Overrides the project name used as a replacement token in default setting values.
+        /// </summary>
+        /// <param name="name"></param>
+        public void OverrideProjectName(string name)
+        {
+            _replacementTokens[REPLACE_TOKEN_PROJECT_NAME] = name;
+        }
+
         public void ApplyPreviousSettings(IDictionary<string, object> previousSettings)
         {
             if (previousSettings == null)

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -155,6 +155,23 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.False(iamRoleTypeHintResponse.CreateNew);
         }
 
+        [Fact]
+        public void ApplyProjectNameToSettings()
+        {
+            var projectPath = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
+
+            var engine = new RecommendationEngine.RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() });
+
+            var recommendations = engine.ComputeRecommendations(projectPath, new Dictionary<string, string>());
+
+            var beanstalkRecommendation = recommendations.FirstOrDefault(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+            var beanstalEnvNameSetting = beanstalkRecommendation.Recipe.OptionSettings.FirstOrDefault(x => string.Equals("EnvironmentName", x.Id));
+            Assert.Equal("WebAppNoDockerFile-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
+
+            beanstalkRecommendation.OverrideProjectName("CustomName");
+            Assert.Equal("CustomName-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
+        }
+
         [Theory]
         [MemberData(nameof(ShouldIncludeTestCases))]
         public void ShouldIncludeTests(RuleEffect effect, bool testPass, bool expectedResult)


### PR DESCRIPTION
*Description of changes:*
When a user enters a name for their cloud application that name should be used as the base string for settings that project name as a replacement token. Beanstalk applications and environments are examples of this. Otherwise a user who wants to create a second stack has to give both a new application name and configure all of the settings that used project name as a base token.

![FixProjectName](https://user-images.githubusercontent.com/1653751/108923699-28140900-75ee-11eb-9d9b-971599e25af1.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
