### PR TITLE
Use product version for AWS.Deploy.Recipes.CDK.Common

### DIFF
--- a/src/AWS.Deploy.Orchestrator/TemplateEngine.cs
+++ b/src/AWS.Deploy.Orchestrator/TemplateEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -57,7 +58,7 @@ namespace AWS.Deploy.Orchestrator
 
                 // CDK Template projects can parameterize the version number of the AWS.Deploy.Recipes.CDK.Common package. This avoid
                 // projects having to be modified every time the package version is bumped.
-                { "AWSDeployRecipesCDKCommonVersion", typeof(CloudFormationIdentifierConstants).Assembly.GetName().Version.ToString() }
+                { "AWSDeployRecipesCDKCommonVersion", FileVersionInfo.GetVersionInfo(typeof(CloudFormationIdentifierConstants).Assembly.Location).ProductVersion }
             };
 
             foreach(var option in recommendation.Recipe.OptionSettings)

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.0</Version>
+    <VersionPrefix>0.1.0</VersionPrefix>
     <Product>AWS Deployment Tooling for .NET CDK Utilities</Product>
     <Description>Utility code used in CDK recipes used by the AWS Deployment Tool. This package is not intended for direct usage.</Description>
     <PackageId>AWS.Deploy.Recipes.CDK.Common</PackageId>
@@ -65,11 +65,12 @@
  ]]></Code>
     </Task>
   </UsingTask>
-  
-  <Target Name="PublishBlazorApp" AfterTargets="Pack">
 
-    <SetupLocalCache NuGetPackage="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg"/>
-    
-  </Target>
-  
+<!-- TODO: we need to find a better fix for execute SetupLocalCache than skipping in Release configuration -->
+<Target Name="PublishBlazorApp" AfterTargets="Pack" Condition=" '$(Configuration)' != 'Release' ">
+
+  <SetupLocalCache NuGetPackage="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg"/>
+
+</Target>
+
 </Project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change also allows to skip SetupLocalCache task in Release configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
