### PR TITLE
Fix issue with using wrong environment variable name for AWS_ACCESS_KEY_ID

### DIFF
--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -57,7 +57,7 @@ namespace AWS.Deploy.CLI.Utilities
 
             // environment variables could already be set at the machine level,
             // use this syntax to make sure we don't create duplicate entries
-            processStartInfo.EnvironmentVariables["AWS_ACCESS_KEY"] = credentials.AccessKey;
+            processStartInfo.EnvironmentVariables["AWS_ACCESS_KEY_ID"] = credentials.AccessKey;
             processStartInfo.EnvironmentVariables["AWS_SECRET_ACCESS_KEY"] = credentials.SecretKey;
             processStartInfo.EnvironmentVariables["AWS_REGION"] = _awsRegion;
 


### PR DESCRIPTION
*Description of changes:*
Fixed issue with using wrong environment variable name for AWS_ACCESS_KEY_ID. This was causing deployments to fail if using anything besides the default profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
