### PR TITLE
refactor: extract type hint handlers to their individual commands & DisplayValues method to ConsoleUtilities

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using Amazon.ElasticBeanstalk.Model;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class BeanstalkApplicationCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public BeanstalkApplicationCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            _toolInteractiveService.WriteLine(optionSetting.Description);
+
+            var applications = await _awsResourceQueryer.ListOfElasticBeanstalkApplications(_session);
+            var currentTypeHintResponse = recommendation.GetOptionSettingValue<BeanstalkApplicationTypeHintResponse>(optionSetting);
+
+            var userInputConfiguration = new UserInputConfiguration<ApplicationDescription>
+            {
+                DisplaySelector = app => app.ApplicationName,
+                DefaultSelector = app => app.ApplicationName.Equals(currentTypeHintResponse?.ApplicationName),
+                AskNewName = true,
+                DefaultNewName = currentTypeHintResponse.ApplicationName
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(applications, "Select Beanstalk application to deploy to:", userInputConfiguration);
+
+            return new BeanstalkApplicationTypeHintResponse
+            {
+                CreateNew = userResponse.CreateNew,
+                ApplicationName = userResponse.SelectedOption?.ApplicationName ?? userResponse.NewName
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class BeanstalkEnvironmentCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public BeanstalkEnvironmentCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+
+            _toolInteractiveService.WriteLine(optionSetting.Description);
+
+            var applicationOptionSetting = recommendation.GetOptionSetting(optionSetting.ParentSettingId);
+
+            var applicationName = recommendation.GetOptionSettingValue(applicationOptionSetting) as string;
+            var environments = await _awsResourceQueryer.ListOfElasticBeanstalkEnvironments(_session, applicationName);
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(
+                options: environments.Select(env => env.EnvironmentName),
+                title: "Select Beanstalk environment to deploy to:",
+                askNewName: true,
+                defaultNewName: currentValue.ToString());
+            return userResponse.SelectedOption ?? userResponse.NewName;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using Amazon.ElasticBeanstalk.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class DotnetBeanstalkPlatformArnCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public DotnetBeanstalkPlatformArnCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+
+            _toolInteractiveService.WriteLine(optionSetting.Description);
+
+            var platformArns = await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(_session);
+
+            var userInputConfiguration = new UserInputConfiguration<PlatformSummary>
+            {
+                DisplaySelector = platform => $"{platform.PlatformBranchName} v{platform.PlatformVersion}",
+                DefaultSelector = platform => platform.PlatformArn.Equals(currentValue),
+                CreateNew = false
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(platformArns, "Select the Platform to use:", userInputConfiguration);
+
+            return userResponse.SelectedOption?.PlatformArn;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class DotnetPublishArgsCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public DotnetPublishArgsCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var settingValue = _consoleUtilities
+                .AskUserForValue(
+                    optionSetting.Description,
+                    recommendation.GetOptionSettingValue(optionSetting).ToString(),
+                    allowEmpty: true,
+                    // validators:
+                    publishArgs =>
+                        (publishArgs.Contains("-o ") || publishArgs.Contains("--output "))
+                            ? "You must not include -o/--output as an additional argument as it is used internally."
+                            : "",
+                    publishArgs =>
+                        (publishArgs.Contains("-c ") || publishArgs.Contains("--configuration ")
+                            ? "You must not include -c/--configuration as an additional argument. You can set the build configuration in the advanced settings."
+                            : ""),
+                    publishArgs =>
+                        (publishArgs.Contains("--self-contained") || publishArgs.Contains("--no-self-contained")
+                            ? "You must not include --self-contained/--no-self-contained as an additional argument. You can set the self-contained property in the advanced settings."
+                            : ""))
+                .ToString()
+                .Replace("\"", "\"\"");
+            return Task.FromResult<object>(settingValue);
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class EC2KeyPairCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public EC2KeyPairCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+
+            _toolInteractiveService.WriteLine(optionSetting.Description);
+            var keyPairs = await _awsResourceQueryer.ListOfEC2KeyPairs(_session);
+
+            var userInputConfiguration = new UserInputConfiguration<KeyPairInfo>
+            {
+                DisplaySelector = kp => kp.KeyName,
+                DefaultSelector = kp => kp.KeyName.Equals(currentValue),
+                AskNewName = true,
+                EmptyOption = true,
+                CurrentValue = currentValue
+            };
+
+            var settingValue = "";
+
+            while (true)
+            {
+                var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(keyPairs, "Select Key Pair to use:", userInputConfiguration);
+
+                if (userResponse.IsEmpty)
+                {
+                    settingValue = "";
+                    break;
+                }
+                else
+                {
+                    settingValue = userResponse.SelectedOption?.KeyName ?? userResponse.NewName;
+                }
+
+                if (userResponse.CreateNew && !string.IsNullOrEmpty(userResponse.NewName))
+                {
+                    _toolInteractiveService.WriteLine(string.Empty);
+                    _toolInteractiveService.WriteLine("You have chosen to create a new Key Pair.");
+                    _toolInteractiveService.WriteLine("You are required to specify a directory to save the key pair private key.");
+
+                    var answer = _consoleUtilities.AskYesNoQuestion("Do you want to continue?", "false");
+                    if (answer == ConsoleUtilities.YesNo.No)
+                        continue;
+
+                    _toolInteractiveService.WriteLine(string.Empty);
+                    _toolInteractiveService.WriteLine($"A new Key Pair will be created with the name {settingValue}.");
+
+                    var keyPairDirectory = _consoleUtilities.AskForEC2KeyPairSaveDirectory(recommendation.ProjectPath);
+
+                    await _awsResourceQueryer.CreateEC2KeyPair(_session, settingValue.ToString(), keyPairDirectory);
+                }
+
+                break;
+            }
+
+            return settingValue;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using Amazon.IdentityManagement.Model;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class IAMRoleCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public IAMRoleCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            _toolInteractiveService.WriteLine(optionSetting.Description);
+            var typeHintData = optionSetting.GetTypeHintData<IAMRoleTypeHintData>();
+            var existingRoles = await _awsResourceQueryer.ListOfIAMRoles(_session, typeHintData?.ServicePrincipal);
+            var currentTypeHintResponse = recommendation.GetOptionSettingValue<IAMRoleTypeHintResponse>(optionSetting);
+
+            var userInputConfiguration = new UserInputConfiguration<Role>
+            {
+                DisplaySelector = role => role.RoleName,
+                DefaultSelector = role => currentTypeHintResponse.RoleArn?.Equals(role.Arn) ?? false,
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(existingRoles ,"Select an IAM role", userInputConfiguration);
+
+            return new IAMRoleTypeHintResponse
+            {
+                CreateNew = userResponse.CreateNew,
+                RoleArn = userResponse.SelectedOption?.Arn
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    /// <summary>
+    /// Interface for type hint commands such as <see cref="IAMRoleCommand"/>
+    /// </summary>
+    public interface ITypeHintCommand
+    {
+        Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting);
+    }
+
+    /// <summary>
+    /// Factory class responsible to build and get type hint command
+    /// </summary>
+    public class TypeHintCommandFactory
+    {
+        private readonly Dictionary<OptionSettingTypeHint, ITypeHintCommand> _commands;
+
+        public TypeHintCommandFactory(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _commands = new Dictionary<OptionSettingTypeHint, ITypeHintCommand>()
+            {
+                { OptionSettingTypeHint.BeanstalkApplication, new BeanstalkApplicationCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.BeanstalkEnvironment, new BeanstalkEnvironmentCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.DotnetBeanstalkPlatformArn, new DotnetBeanstalkPlatformArnCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.DotnetPublishArgs, new DotnetPublishArgsCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.EC2KeyPair, new EC2KeyPairCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.IAMRole, new IAMRoleCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.Vpc, new VpcCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+            };
+        }
+
+        public ITypeHintCommand GetCommand(OptionSettingTypeHint typeHint)
+        {
+            if (!_commands.ContainsKey(typeHint))
+            {
+                return null;
+            }
+
+            return _commands[typeHint];
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestrator;
+using AWS.Deploy.Orchestrator.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class VpcCommand : ITypeHintCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly OrchestratorSession _session;
+        private readonly ConsoleUtilities _consoleUtilities;
+
+        public VpcCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _awsResourceQueryer = awsResourceQueryer;
+            _session = session;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            _toolInteractiveService.WriteLine(optionSetting.Description);
+
+            var currentVpcTypeHintResponse = optionSetting.GetTypeHintData<VpcTypeHintResponse>();
+
+            var vpcs = await _awsResourceQueryer.GetListOfVpcs(_session);
+
+            var userInputConfig = new UserInputConfiguration<Vpc>
+            {
+                DisplaySelector = vpc =>
+                {
+                    var name = vpc.Tags?.FirstOrDefault(x => x.Key == "Name")?.Value ?? string.Empty;
+                    var namePart =
+                        string.IsNullOrEmpty(name)
+                            ? ""
+                            : $" ({name}) ";
+
+                    var isDefaultPart =
+                        vpc.IsDefault
+                            ? Constants.DEFAULT_LABEL
+                            : "";
+
+                    return $"{vpc.VpcId}{namePart}{isDefaultPart}";
+                },
+                DefaultSelector = vpc =>
+                    !string.IsNullOrEmpty(currentVpcTypeHintResponse?.VpcId)
+                        ? vpc.VpcId == currentVpcTypeHintResponse.VpcId
+                        : vpc.IsDefault
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(
+                vpcs,
+                "Select a VPC",
+                userInputConfig);
+
+            return new VpcTypeHintResponse
+            {
+                IsDefault = userResponse.SelectedOption?.IsDefault == true,
+                CreateNew = userResponse.CreateNew,
+                VpcId = userResponse.SelectedOption?.VpcId ?? ""
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -330,5 +330,24 @@ namespace AWS.Deploy.CLI
 
             return selectedValue.Value;
         }
+
+        public void DisplayValues(Dictionary<string, object> objectValues, string indent)
+        {
+            foreach (var (key, value) in objectValues)
+            {
+                if (value is Dictionary<string, object> childObjectValue)
+                {
+                    _interactiveService.WriteLine($"{indent}{key}");
+                    DisplayValues(childObjectValue, $"{indent}\t");
+                }
+                else if (value is string stringValue)
+                {
+                    if (!string.IsNullOrEmpty(stringValue))
+                    {
+                        _interactiveService.WriteLine($"{indent}{key}: {stringValue}");
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change breaks the `DeployCommand` type hint handling code to their separate files. The only interesting change is in `TypeHintCommandFactory` which holds the type hint and their respective commands and `GetCommand` returns `ITypeHintCommand` if exists.

Moves `DisplayValues` to `ConsoleUtilities`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
