### PR TITLE
Add recommendation engine test to checks if a NuGet package is added to the project.

### DIFF
--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -91,6 +91,12 @@ namespace AWS.Deploy.Common
             return propertyValue;
         }
 
+        public string GetPackageReferenceVersion(string packageName)
+        {
+            var packageReference = _xmlProjectFile.SelectSingleNode($"//ItemGroup/PackageReference[@Include='{packageName}']") as XmlElement;
+            return packageReference?.GetAttribute("Version");
+        }
+
         private bool CheckIfDockerFileExists(string projectPath)
         {
             var dir = Directory.GetFiles(new FileInfo(projectPath).DirectoryName, "Dockerfile");

--- a/src/AWS.Deploy.Common/Recipes/RuleCondition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RuleCondition.cs
@@ -29,5 +29,10 @@ namespace AWS.Deploy.Common.Recipes
         /// The name of file to search for. Used by the FileExists test.
         /// </summary>
         public string FileName { get; set; }
+
+        /// <summary>
+        /// The name of a NuGet package for tests. Used to see if projects are taking dependencies on specific packages.
+        /// </summary>
+        public string NuGetPackageName { get; set; }
     }
 }

--- a/src/AWS.Deploy.Orchestrator/RecommendationEngine/NuGetPackageReferenceTest.cs
+++ b/src/AWS.Deploy.Orchestrator/RecommendationEngine/NuGetPackageReferenceTest.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.Orchestrator.RecommendationEngine
+{
+    public class NuGetPackageReferenceTest : BaseRecommendationTest
+    {
+        public override string Name => "NuGetPackageReference";
+
+        public override Task<bool> Execute(RecommendationTestInput input)
+        {
+            var result = !string.IsNullOrEmpty(input.ProjectDefinition.GetPackageReferenceVersion(input.Test.Condition.NuGetPackageName));
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -14,6 +14,7 @@ using AWS.Deploy.Orchestrator.RecommendationEngine;
 using Should;
 using Xunit;
 using System.Threading.Tasks;
+using AWS.Deploy.Common;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -266,6 +267,40 @@ namespace AWS.Deploy.CLI.UnitTests
 
             // Look to see if the known system test FileExists has been found by LoadAvailableTests.
             Assert.Contains(new FileExistsTest().Name, tests);
+        }
+
+        [Fact]
+        public async Task PackageReferenceTest()
+        {
+            var projectPath = SystemIOUtilities.ResolvePath("MessageProcessingApp");
+            var projectDefinition = new ProjectDefinition(projectPath);
+            var test = new NuGetPackageReferenceTest();
+
+            Assert.True(await test.Execute(new RecommendationTestInput
+            {
+                Test = new RuleTest
+                {
+                    Type = test.Name,
+                    Condition = new RuleCondition
+                    {
+                        NuGetPackageName = "AWSSDK.SQS"
+                    }                    
+                },
+                ProjectDefinition = projectDefinition
+            }));
+
+            Assert.False(await test.Execute(new RecommendationTestInput
+            {
+                Test = new RuleTest
+                {
+                    Type = test.Name,
+                    Condition = new RuleCondition
+                    {
+                        NuGetPackageName = "AWSSDK.S3"
+                    }
+                },
+                ProjectDefinition = projectDefinition
+            }));
         }
     }
 }

--- a/testapps/MessageProcessingApp/MessageProcessingApp.csproj
+++ b/testapps/MessageProcessingApp/MessageProcessingApp.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.21" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
*Description of changes:*
Add the ability to have the recommendation engine check to see if a NuGet package is added to the project. This can be used to create recommendations for Grpc by looking for this `Grpc.AspNetCore` package or Blazor WebAssembly by looking for `Microsoft.AspNetCore.Components.WebAssembly`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
