### PR TITLE
Make VPC settings non-advanced. 

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -141,7 +141,7 @@
             "Description": "A VPC enables you to launch the application into a virtual network that you've defined",
             "Type": "Object",
             "TypeHint": "Vpc",
-            "AdvancedSetting": true,
+            "AdvancedSetting": false,
             "Updatable": false,
             "ChildOptionSettings": [
                 {
@@ -150,7 +150,7 @@
                     "Description": "Do you want to use the default VPC for the deployment?",
                     "Type": "Bool",
                     "DefaultValue": true,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false
                 },
                 {
@@ -159,7 +159,7 @@
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
                     "DefaultValue": false,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [
                         {
@@ -174,7 +174,7 @@
                     "Description": "The Id of the existing VPC to use.",
                     "Type": "String",
                     "DefaultValue": null,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [
                         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -150,7 +150,7 @@
             "Description": "A VPC enables you to launch the application into a virtual network that you've defined",
             "Type": "Object",
             "TypeHint": "Vpc",
-            "AdvancedSetting": true,
+            "AdvancedSetting": false,
             "Updatable": false,
             "ChildOptionSettings": [
                 {
@@ -159,7 +159,7 @@
                     "Description": "Do you want to use the default VPC for the deployment?",
                     "Type": "Bool",
                     "DefaultValue": true,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false
                 },
                 {
@@ -168,7 +168,7 @@
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
                     "DefaultValue": false,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [
                         {
@@ -183,7 +183,7 @@
                     "Description": "The Id of the existing VPC to use.",
                     "Type": "String",
                     "DefaultValue": null,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [
                         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateTask.recipe
@@ -138,7 +138,7 @@
             "Description": "A VPC enables you to launch the application into a virtual network that you've defined",
             "Type": "Object",
             "TypeHint": "Vpc",
-            "AdvancedSetting": true,
+            "AdvancedSetting": false,
             "Updatable": false,
             "ChildOptionSettings": [
                 {
@@ -147,7 +147,7 @@
                     "Description": "Do you want to use the default VPC?",
                     "Type": "Bool",
                     "DefaultValue": true,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false
                 },
                 {
@@ -156,7 +156,7 @@
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
                     "DefaultValue": false,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [
                         {
@@ -171,7 +171,7 @@
                     "Description": "The Id of the existing VPC to use.",
                     "Type": "String",
                     "DefaultValue": null,
-                    "AdvancedSetting": true,
+                    "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [
                         {


### PR DESCRIPTION
*Description of changes:*
Make VPC settings non-advanced. That way users will always see that by default we are deploying to the default VPC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
