### PR TITLE
Polish the list and delete commands. 

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeleteApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteApplicationCommand.cs
@@ -17,7 +17,7 @@ namespace AWS.Deploy.CLI.Commands
     /// <summary>
     /// Represents a Delete command allows to delete a CloudFormation stack
     /// </summary>
-    public class DeleteStackCommand
+    public class DeleteApplicationCommand
     {
         private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(1);
 
@@ -27,7 +27,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly IAmazonCloudFormation _cloudFormationClient;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public DeleteStackCommand(IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
+        public DeleteApplicationCommand(IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
         {
             _awsClientFactory = awsClientFactory;
             _interactiveService = interactiveService;

--- a/src/AWS.Deploy.CLI/Commands/ListApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ListApplicationCommand.cs
@@ -10,7 +10,7 @@ using AWS.Deploy.Recipes;
 
 namespace AWS.Deploy.CLI.Commands
 {
-    public class ListStacksCommand
+    public class ListApplicationCommand
     {
         private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
         private readonly IToolInteractiveService _interactiveService;
@@ -18,7 +18,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ICdkProjectHandler _cdkProjectHandler;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
 
-        public ListStacksCommand(IToolInteractiveService interactiveService,
+        public ListApplicationCommand(IToolInteractiveService interactiveService,
             IOrchestratorInteractiveService orchestratorInteractiveService,
             ICdkProjectHandler cdkProjectHandler,
             IAWSResourceQueryer awsResourceQueryer,
@@ -41,6 +41,10 @@ namespace AWS.Deploy.CLI.Commands
                     _awsResourceQueryer,
                     new[] { RecipeLocator.FindRecipeDefinitionsPath() });
 
+            // Add Header
+            _interactiveService.WriteLine();
+            _interactiveService.WriteLine("Cloud Applications:");
+            _interactiveService.WriteLine("-------------------");
 
             var existingApplications = await orchestrator.GetExistingDeployedApplications();
             foreach (var app in existingApplications)

--- a/src/AWS.Deploy.CLI/Program.cs
+++ b/src/AWS.Deploy.CLI/Program.cs
@@ -111,7 +111,7 @@ namespace AWS.Deploy.CLI
             });
             rootCommand.Add(deployCommand);
 
-            var listCommand = new Command("list-stacks", "List CloudFormation stacks.")
+            var listCommand = new Command("list-applications", "List Cloud Applications.")
             {
                 _optionProfile,
                 _optionRegion,
@@ -149,7 +149,7 @@ namespace AWS.Deploy.CLI
                         awsCredentials,
                         awsRegion);
 
-                await new ListStacksCommand(toolInteractiveService,
+                await new ListApplicationCommand(toolInteractiveService,
                                                 new ConsoleOrchestratorLogger(toolInteractiveService),
                                                 new CdkProjectHandler(orchestratorInteractiveService, commandLineWrapper),
                                                 new AWSResourceQueryer(new DefaultAWSClientFactory()),
@@ -157,18 +157,15 @@ namespace AWS.Deploy.CLI
             });
             rootCommand.Add(listCommand);
 
-            var deleteCommand = new Command("delete-stack", "Deletes a CloudFormation stack.")
+            var deleteCommand = new Command("delete-application", "Deletes a Cloud Application.")
             {
                 _optionProfile,
                 _optionRegion,
                 _optionProjectPath,
-                new Option<string>("--stack-name", "The name or the unique stack ID that is associated with the stack.")
-                {
-                    IsRequired = true,
-                },
-                _optionDiagnosticLogging
+                _optionDiagnosticLogging,
+                new Argument("application-name")
             };
-            deleteCommand.Handler = CommandHandler.Create<string, string, string, string, bool>(async (profile, region, projectPath, stackName, diagnostics) =>
+            deleteCommand.Handler = CommandHandler.Create<string, string, string, string, bool>(async (profile, region, projectPath, applicationName, diagnostics) =>
             {
                 var toolInteractiveService = new ConsoleInteractiveServiceImpl(diagnostics);
                 var awsUtilities = new AWSUtilities(toolInteractiveService);
@@ -185,7 +182,7 @@ namespace AWS.Deploy.CLI
                     AWSRegion = awsRegion,
                 };
 
-                await new DeleteStackCommand(new DefaultAWSClientFactory(), toolInteractiveService, session).ExecuteAsync(stackName);
+                await new DeleteApplicationCommand(new DefaultAWSClientFactory(), toolInteractiveService, session).ExecuteAsync(applicationName);
 
                 return CommandReturnCodes.SUCCESS;
             });


### PR DESCRIPTION
*Description of changes:*
Polish up the list and delete commands. The commands were referring to stacks but when we deploy an application we ask for a "Cloud Application" name. Switch the verbiage of these commands to use the term application instead of stack. 

Tweaks:
* Rename stack to application
* Added a header to the list application output
* Delete command now uses an argument instead of option making it less to type to when deleting.

![CleanListAndDeleteCommands](https://user-images.githubusercontent.com/1653751/109404641-d4baf700-791c-11eb-98fc-09caf8913f46.gif)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
