### PR TITLE
Clean up how the description for a setting is displayed.

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -249,12 +249,13 @@ namespace AWS.Deploy.CLI.Commands
         {
             _toolInteractiveService.WriteLine(string.Empty);
             _toolInteractiveService.WriteLine($"{setting.Name}:");
+            _toolInteractiveService.WriteLine($"{setting.Description}");
+            _toolInteractiveService.WriteLine(string.Empty);
 
             var currentValue = recommendation.GetOptionSettingValue(setting);
             object settingValue = null;
             if (setting.AllowedValues?.Count > 0)
             {
-                _toolInteractiveService.WriteLine(setting.Description);
                 var userInputConfig = new UserInputConfiguration<string>
                 {
                     DisplaySelector = x => setting.ValueMapping[x],
@@ -281,10 +282,10 @@ namespace AWS.Deploy.CLI.Commands
                     {
                         case OptionSettingValueType.String:
                         case OptionSettingValueType.Int:
-                            settingValue = _consoleUtilities.AskUserForValue(setting.Description, currentValue?.ToString(), allowEmpty: true);
+                            settingValue = _consoleUtilities.AskUserForValue(string.Empty, currentValue?.ToString(), allowEmpty: true);
                             break;
                         case OptionSettingValueType.Bool:
-                            var answer = _consoleUtilities.AskYesNoQuestion(setting.Description, recommendation.GetOptionSettingValue(setting).ToString());
+                            var answer = _consoleUtilities.AskYesNoQuestion(string.Empty, recommendation.GetOptionSettingValue(setting).ToString());
                             settingValue = answer == ConsoleUtilities.YesNo.Yes ? "true" : "false";
                             break;
                         case OptionSettingValueType.Object:

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
@@ -28,8 +28,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            _toolInteractiveService.WriteLine(optionSetting.Description);
-
             var applications = await _awsResourceQueryer.ListOfElasticBeanstalkApplications(_session);
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<BeanstalkApplicationTypeHintResponse>(optionSetting);
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
@@ -28,9 +28,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
-
-            _toolInteractiveService.WriteLine(optionSetting.Description);
-
             var applicationOptionSetting = recommendation.GetOptionSetting(optionSetting.ParentSettingId);
 
             var applicationName = recommendation.GetOptionSettingValue(applicationOptionSetting) as string;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
@@ -28,9 +28,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
-
-            _toolInteractiveService.WriteLine(optionSetting.Description);
-
             var platformArns = await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(_session);
 
             var userInputConfiguration = new UserInputConfiguration<PlatformSummary>

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
@@ -28,8 +28,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
-
-            _toolInteractiveService.WriteLine(optionSetting.Description);
             var keyPairs = await _awsResourceQueryer.ListOfEC2KeyPairs(_session);
 
             var userInputConfiguration = new UserInputConfiguration<KeyPairInfo>

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
@@ -29,7 +29,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            _toolInteractiveService.WriteLine(optionSetting.Description);
             var typeHintData = optionSetting.GetTypeHintData<IAMRoleTypeHintData>();
             var existingRoles = await _awsResourceQueryer.ListOfIAMRoles(_session, typeHintData?.ServicePrincipal);
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<IAMRoleTypeHintResponse>(optionSetting);

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
@@ -29,8 +29,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            _toolInteractiveService.WriteLine(optionSetting.Description);
-
             var currentVpcTypeHintResponse = optionSetting.GetTypeHintData<VpcTypeHintResponse>();
 
             var vpcs = await _awsResourceQueryer.GetListOfVpcs(_session);

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -296,8 +296,12 @@ namespace AWS.Deploy.CLI
 
         public YesNo AskYesNoQuestion(string question, YesNo? defaultValue = default)
         {
-            var message = question;
-            message += ": y/n";
+            string message = string.Empty;
+            if(!string.IsNullOrEmpty(question))
+            {
+                message += question + ": ";
+            }
+            message += "y/n";
             if (defaultValue.HasValue)
             {
                 var defaultChar = defaultValue == YesNo.Yes ? 'y' : 'n';
@@ -314,11 +318,11 @@ namespace AWS.Deploy.CLI
                 {
                     selectedValue = defaultValue.Value;
                 }
-                else if (string.Equals(line, "y"))
+                else if (string.Equals(line, "y", StringComparison.OrdinalIgnoreCase))
                 {
                     selectedValue = YesNo.Yes;
                 }
-                else if (String.Equals(line, "n"))
+                else if (String.Equals(line, "n", StringComparison.OrdinalIgnoreCase))
                 {
                     selectedValue = YesNo.No;
                 }


### PR DESCRIPTION
*Description of changes:*
I found the description for a setting being configured looks weird especially if the description is long and has default values. For example in this before screen shot there is an extra colon and there is no spacing between the description and the valid options and default.

![image](https://user-images.githubusercontent.com/1653751/109405045-1483dd80-7921-11eb-9632-829a3f526184.png)

This is what it looks like after the rework.

![image](https://user-images.githubusercontent.com/1653751/109405057-3c734100-7921-11eb-9946-33b1fa963c7c.png)

I also made the yes/no asker being case insensitive and took out from the all the type hints the need to display the description because now that is just done as part of the config settings header.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
