### PR TITLE
Add ability to assign EC2 security groups for container based deployments

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Configurations/Configuration.cs
@@ -35,6 +35,11 @@ namespace AspNetAppEcsFargate.Configurations
         /// </summary>
         public VpcConfiguration Vpc { get; set; }
 
+        /// <summary>
+        /// Comma-delimited list of security groups assigned to the ECS service.
+        /// </summary>
+        public string AdditionalECSServiceSecurityGroups { get; set; }
+
         /// <inheritdoc cref="FargateTaskDefinitionProps.Cpu"/>
         public double? TaskCpu { get; set; }
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Configurations/Configuration.cs
@@ -11,6 +11,11 @@ namespace ConsoleAppEcsFargateService.Configurations
         public string DockerfileName { get; set; } = "Dockerfile";
 
         /// <summary>
+        /// The desired number of ECS tasks to run for the service.
+        /// </summary>
+        public double DesiredCount { get; set; }
+
+        /// <summary>
         /// The Identity and Access Management Role that provides AWS credentials to the application to access AWS services.
         /// </summary>
         public IAMRoleConfiguration ApplicationIAMRole { get; set; }
@@ -24,6 +29,11 @@ namespace ConsoleAppEcsFargateService.Configurations
         /// Virtual Private Cloud to launch container instance into a virtual network.
         /// </summary>
         public VpcConfiguration Vpc { get; set; }
+
+        /// <summary>
+        /// Comma-delimited list of security groups assigned to the ECS service.
+        /// </summary>
+        public string ECSServiceSecurityGroups { get; set; }
 
         /// <inheritdoc cref="FargateTaskDefinitionProps.Cpu"/>
         public double? TaskCpu { get; set; }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -190,6 +190,15 @@
             ]
         },
         {
+            "Id": "AdditionalECSServiceSecurityGroups",
+            "Name": "ECS Service Security Groups",
+            "Description": "Comma delimited list of EC2 security groups to assign to the ECS service. This is commonly used to provide access to RDS databases running in their own security groups.",
+            "Type": "String",
+            "DefaultValue": "",
+            "AdvancedSetting": true,
+            "Updatable": true
+        },
+        {
             "Id": "AddDockerBuildArgs",
             "Name": "Add Docker Build Args",
             "Description": "Do you want to pass additional Docker build args?",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -103,7 +103,7 @@
             "Name": "Desired Task Count",
             "Description": "The desired number of ECS tasks to run for the service.",
             "Type": "Int",
-            "DefaultValue": 3,
+            "DefaultValue": 1,
             "AdvancedSetting": false,
             "Updatable": true
         },
@@ -197,6 +197,15 @@
                     ]
                 }
             ]
+        },
+        {
+            "Id": "ECSServiceSecurityGroups",
+            "Name": "ECS Service Security Groups",
+            "Description": "Comma delimited list of EC2 security groups to assign to the ECS service. This is commonly used to provide access to RDS databases running in their own security groups.",
+            "Type": "String",
+            "DefaultValue": "",
+            "AdvancedSetting": true,
+            "Updatable": true
         },
         {
             "Id": "AddDockerBuildArgs",


### PR DESCRIPTION
*Description of changes:*
For the ASP.NET Core and Console Service recipe add the ability to assign EC2 security groups. This can be used to allow access to an RDS database.

Schedule Task is not done yet because so far I haven't seen how using the  `ScheduledFargateTask` construct to specify security groups.

The Elastic Beanstalk recipe is going to require significant more work to add this since we are not currently configure VPCs which will significantly complicate the recipe.

Other issues fixed in the process:
DesiredCount setting for Console Service is not actually being propagated to the CDK project. Also changed the default to 1.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
