### PR TITLE
fix: exclude stacks with status ROLLBACK_COMPLETE from list of existing applications

### DIFF
--- a/src/AWS.Deploy.Orchestrator/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestrator/Data/AWSResourceQueryer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
+using Amazon.CloudFormation.Model;
 using Amazon.EC2;
 using Amazon.EC2.Model;
 using Amazon.ElasticBeanstalk;
@@ -30,6 +31,7 @@ namespace AWS.Deploy.Orchestrator.Data
         Task<List<AuthorizationData>> GetECRAuthorizationToken(OrchestratorSession session);
         Task<List<Repository>> GetECRRepositories(OrchestratorSession session, List<string> repositoryNames);
         Task<Repository> CreateECRRepository(OrchestratorSession session, string repositoryName);
+        Task<List<Stack>> GetCloudFormationStacks(OrchestratorSession session);
     }
 
     public class AWSResourceQueryer : IAWSResourceQueryer
@@ -215,6 +217,12 @@ namespace AWS.Deploy.Orchestrator.Data
             var response = await ecrClient.CreateRepositoryAsync(request);
 
             return response.Repository;
+        }
+
+        public async Task<List<Stack>> GetCloudFormationStacks(OrchestratorSession session)
+        {
+            using var cloudFormationClient = _awsClientFactory.GetAWSClient<Amazon.CloudFormation.IAmazonCloudFormation>(session.AWSCredentials, session.AWSRegion);
+            return await cloudFormationClient.Paginators.DescribeStacks(new DescribeStacksRequest()).Stacks.ToListAsync();
         }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Amazon.CloudFormation.Model;
 using Amazon.EC2.Model;
 using Amazon.ECR.Model;
 using Amazon.ElasticBeanstalk.Model;
@@ -17,6 +18,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
     {
         public Task<string> CreateEC2KeyPair(OrchestratorSession session, string keyName, string saveLocation) => throw new NotImplementedException();
         public Task<Repository> CreateECRRepository(OrchestratorSession session, string repositoryName) => throw new NotImplementedException();
+        public Task<List<Stack>> GetCloudFormationStacks(OrchestratorSession session) => throw new NotImplementedException();
 
         public Task<List<AuthorizationData>> GetECRAuthorizationToken(OrchestratorSession session)
         {


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
This change also moves the CloudFormation stack querying to IAWSResourceQueryer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
