### PR TITLE
Fix issue building blazor wasm application

### DIFF
--- a/src/AWS.Deploy.Orchestrator/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestrator/DeploymentBundleHandler.cs
@@ -107,9 +107,15 @@ namespace AWS.Deploy.Orchestrator
                 $"dotnet publish \"{recommendation.ProjectPath}\"" +
                 $" -o \"{publishDirectoryInfo}\"" +
                 $" -c {recommendation.DeploymentBundle.DotnetPublishBuildConfiguration}" +
-                $" --self-contained {recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild}" +
                 $" {runtimeArg}" +
                 $" {additionalArguments}";
+
+            // Blazor applications do not build with the default of setting self-contained to false.
+            // So only add the --self-contained true if the user explicitly sets it to true.
+            if(recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild)
+            {
+                publishCommand += " --self-contained true";
+            }
 
             var result = await _commandLineWrapper.TryRunWithResult(publishCommand, redirectIO: false);
             if (result.ExitCode != 0)

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -108,7 +108,6 @@ namespace AWS.Deploy.CLI.UnitTests
                 $"dotnet publish \"{projectDefinition.ProjectPath}\"" +
                 $" -o \"{_directoryManager.CreatedDirectories.First()}\"" +
                 " -c Release" +
-                " --self-contained False" +
                 " " +
                 " --nologo";
 
@@ -133,9 +132,9 @@ namespace AWS.Deploy.CLI.UnitTests
                 $"dotnet publish \"{projectDefinition.ProjectPath}\"" +
                 $" -o \"{_directoryManager.CreatedDirectories.First()}\"" +
                 " -c Release" +
-                " --self-contained True" +
                 " --runtime linux-x64" +
-                " --nologo";
+                " --nologo" +
+                " --self-contained true";
 
             Assert.Equal(expectedCommand, _commandLineWrapper.CommandsToExecute.First().Command);
         }


### PR DESCRIPTION
*Description of changes:*
Blazor applications fail to build if `--self-contained false` is passed into the publish command. This is our default setting and is normally the default of `dotnet publish`. Blazor wasm has its own publish logic and doesn't like the --self-contained switch. The fix removes setting `--self-contained` if it is not explicitly set by the user.

I think a long term fix would be to define a blazor specific deployment bundle instead of reusing the same zip deployment bundle as server applications.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
