### PR TITLE
fix: use UTF-8 for Console.OutputEncoding to be able to render emojis

### DIFF
--- a/src/AWS.Deploy.CLI/Program.cs
+++ b/src/AWS.Deploy.CLI/Program.cs
@@ -32,6 +32,8 @@ namespace AWS.Deploy.CLI
 
         private static async Task<int> Main(string[] args)
         {
+            Console.OutputEncoding = Encoding.UTF8;
+
             SetExecutionEnvironment();
 
             var preambleWriter = new ConsoleInteractiveServiceImpl(diagnosticLoggingEnabled: false);


### PR DESCRIPTION


*Issue #, if available:*


*Description of changes:*
This change allows to render emojis that are STDOUT from CDK.

![Screenshot 2021-03-09 155743](https://user-images.githubusercontent.com/8882380/110554734-3a16a100-80f0-11eb-9f18-fcb9ba1b4fe7.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
