### PR TITLE
fix: don't throw an exception when a target stack does not exist on deletion

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
@@ -46,7 +46,6 @@ namespace AWS.Deploy.CLI.Commands
             var canDelete = await CanDeleteAsync(stackName);
             if (!canDelete)
             {
-                _interactiveService.WriteErrorLine("Only Stacks that were deployed with this tool can be deleted.");
                 return;
             }
 
@@ -89,10 +88,17 @@ namespace AWS.Deploy.CLI.Commands
             var stack = await GetStackAsync(stackName);
             if (stack == null)
             {
-                throw new FailedToDeleteException($"Stack with name {stackName} does not exist.");
+                _interactiveService.WriteErrorLine($"Stack with name {stackName} does not exist.");
+                return false;
             }
 
-            return stack.Tags.Any(tag => tag.Key.Equals(CloudFormationIdentifierConstants.STACK_TAG));
+            var canDelete = stack.Tags.Any(tag => tag.Key.Equals(CloudFormationIdentifierConstants.STACK_TAG));
+            if (!canDelete)
+            {
+                _interactiveService.WriteErrorLine("Only Stacks that were deployed with this tool can be deleted.");
+            }
+
+            return canDelete;
         }
 
         private async Task WaitForStackDelete(string stackName)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
![Screenshot 2021-03-09 162934](https://user-images.githubusercontent.com/8882380/110557145-d9d62e00-80f4-11eb-9309-2ae19f66f094.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

