### PR TITLE
Show help instead of error if no args passed to dotnet aws

### DIFF
--- a/src/AWS.Deploy.CLI/Program.cs
+++ b/src/AWS.Deploy.CLI/Program.cs
@@ -218,6 +218,12 @@ namespace AWS.Deploy.CLI
             });
             rootCommand.Add(deleteCommand);
 
+            // if user didn't specify a command, default to help
+            if (args.Length == 0)
+            {
+                args = new string[] { "-h" };
+            }
+
             return await rootCommand.InvokeAsync(args);
         }
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4942

*Description of changes:*
If the deploy tool is run with no args (dotnet aws), we should not show an error. Instead we should show help.

**Before**
![image](https://user-images.githubusercontent.com/53088140/110668703-94b80780-8199-11eb-9621-214b980bee88.png)

**After**
![image](https://user-images.githubusercontent.com/53088140/110668599-794cfc80-8199-11eb-962e-919ad2111131.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
