### PR TITLE
Make EnvironmentType is not updatable

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -117,7 +117,7 @@
                 "LoadBalanced": "Load Balanced"
             },
             "AdvancedSetting": false,
-            "Updatable": true
+            "Updatable": false
         },
         {
             "Id": "LoadBalancerType",


### PR DESCRIPTION
*Description of changes:*
Since EnvironmentType is not updatable in CloudFormation make the setting in the recipe not updatable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
