### PR TITLE
Add footers to bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,7 @@ If applicable, add screen recording to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+---
+
+This is a :bug: bug report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+---
+
+This is a :rocket: feature request


### PR DESCRIPTION
*Description of changes:*

General question template has a nice footer.  Added it to the other templates.

![image](https://user-images.githubusercontent.com/1190907/110888455-147cc980-82a1-11eb-8fef-993994317734.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
