### PR TITLE
Make Elastic Beanstalk recipe rely on service's default value for instance type

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
@@ -81,11 +81,6 @@ namespace AspNetAppElasticBeanstalkLinux
             var optionSettingProperties = new List<CfnEnvironment.OptionSettingProperty> {
                    new CfnEnvironment.OptionSettingProperty {
                         Namespace = "aws:autoscaling:launchconfiguration",
-                        OptionName = "InstanceType",
-                        Value= settings.InstanceType
-                   },
-                   new CfnEnvironment.OptionSettingProperty {
-                        Namespace = "aws:autoscaling:launchconfiguration",
                         OptionName =  "IamInstanceProfile",
                         Value = instanceProfile.AttrArn
                    },
@@ -95,6 +90,16 @@ namespace AspNetAppElasticBeanstalkLinux
                         Value = settings.EnvironmentType
                    }
                 };
+
+            if(!string.IsNullOrEmpty(settings.InstanceType))
+            {
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:autoscaling:launchconfiguration",
+                    OptionName = "InstanceType",
+                    Value = settings.InstanceType
+                });
+            }
 
             if (settings.EnvironmentType.Equals(ENVIRONMENTTYPE_LOADBALANCED))
             {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -98,7 +98,7 @@
             "Description": "The EC2 instance type used for the EC2 instances created for the environment.",
             "Type": "String",
             "TypeHint": "InstanceType",
-            "DefaultValue": "t2.micro",
+            "DefaultValue": "",
             "AdvancedSetting": true,
             "Updatable": true
         },


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-deploy/issues/122

*Description of changes:*
Switch CDK template for beanstalk deployment to rely on the service's default. The service uses different defaults depending on the region being deployed to. For example us-west-2 defaults to t2.miro and eu-north-1 defaults t3.micro.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
