### PR TITLE
Add ability for recipes to define a deployment confirmation message.

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -190,9 +190,25 @@ namespace AWS.Deploy.CLI.Commands
                 Name = cloudApplicationName
             };
 
+            if(!ConfirmDeployment(selectedRecommendation))
+            {
+                return;
+            }
+
             await CreateDeploymentBundle(orchestrator, selectedRecommendation, cloudApplication);
 
             await orchestrator.DeployRecommendation(cloudApplication, selectedRecommendation);
+        }
+
+        private bool ConfirmDeployment(Recommendation recommendation)
+        {
+            var message = recommendation.Recipe.DeploymentConfirmation?.DefaultMessage;
+            if (string.IsNullOrEmpty(message))
+                return true;
+
+            var result = _consoleUtilities.AskYesNoQuestion(message);
+
+            return result == ConsoleUtilities.YesNo.Yes;
         }
 
         private async Task CreateDeploymentBundle(Orchestrator.Orchestrator orchestrator, Recommendation selectedRecommendation, CloudApplication cloudApplication)

--- a/src/AWS.Deploy.Common/Recipes/DeploymentConfirmationType.cs
+++ b/src/AWS.Deploy.Common/Recipes/DeploymentConfirmationType.cs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Common.Recipes
+{
+    public class DeploymentConfirmationType
+    {
+        public string DefaultMessage { get; set; }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -43,6 +43,11 @@ namespace AWS.Deploy.Common.Recipes
         public string TargetService { get; set; }
 
         /// <summary>
+        /// Confirmation messages to display to the user before performing deployment.
+        /// </summary>
+        public DeploymentConfirmationType DeploymentConfirmation { get; set; }
+
+        /// <summary>
         /// The type of deployment to perform. This controls what other tool to use to perform the deployment. For example a value of `CdkProject` means that CDK should
         /// be used to perform the deployment.
         /// </summary>

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
@@ -9,6 +9,9 @@
     "CdkProjectTemplateId": "netdeploy.BlazorWasm",
     "Description": "Deploy a Blazor WebAssembly application to an Amazon S3 bucket. The Amazon S3 bucket created during deployment will be configured for web hosting and its contents will be open to the public with read access.",
     "TargetService": "Amazon S3",
+    "DeploymentConfirmation": {
+        "DefaultMessage": "The Blazor WebAssembly application will be hosted in an Amazon S3 bucket with public read access. It is important that your application not contain any sensitive information like AWS credentials since the contents will be public. Do you wish to continue?"
+    },
 
     "RecipePriority": -1,
     "RecommendationRules": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -74,29 +74,45 @@
             "description": "The AWS service that the project will be deployed to",
             "minLength": 1
         },
+        "DeploymentConfirmation": {
+            "$ref": "#/definitions/DeploymentConfirmation"
+        },
         "RecipePriority": {
             "type": "integer",
             "title": "Recipe Priority",
             "description": "The type of test to perform."
         },
-        "RecommendationRules" : {
+        "RecommendationRules": {
             "$ref": "#/definitions/RecommendationRules"
         },
-        "OptionSettings" : {
+        "OptionSettings": {
             "$ref": "#/definitions/OptionSettings"
         }
     },
     "definitions": {
 
-        "RecommendationRules" : {
-            "type" : "array",
-            "description": "The rules that determine if the recipe is compatible with the project.",
-            "items": {"$ref": "#/definitions/RecommendationRule"}
-        },
-        "RecommendationRule" : {
-            "type" : "object",
+        "DeploymentConfirmation": {
+            "type": "object",
             "additionalProperties": false,
-            "required": ["Tests", "Effect"],
+            "description": "Settings for asking the user to confirm they want to continue with the deployment.",
+            "properties": {
+                "DefaultMessage": {
+                    "type": "string",
+                    "title": "Default Message",
+                    "description": "The message displayed to the user to confirm they want to continue with the deployment."
+                }
+            }
+        },
+
+        "RecommendationRules": {
+            "type": "array",
+            "description": "The rules that determine if the recipe is compatible with the project.",
+            "items": { "$ref": "#/definitions/RecommendationRule" }
+        },
+        "RecommendationRule": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "Tests", "Effect" ],
             "properties": {
                 "Comment": {
                     "type": "string",
@@ -121,43 +137,43 @@
             }
         },
 
-        "RuleTest" : {
-            "type" : "object",
+        "RuleTest": {
+            "type": "object",
             "additionalProperties": false,
-            "required": ["Type", "Condition"],
-            "properties" : {
+            "required": [ "Type", "Condition" ],
+            "properties": {
                 "Type": {
                     "type": "string",
                     "title": "Test Type",
                     "description": "The type of test to perform.",
-                    "enum" : [
+                    "enum": [
                         "MSProjectSdkAttribute",
                         "MSProperty",
                         "MSPropertyExists",
                         "FileExists"
                     ]
                 },
-                "Condition" : {
+                "Condition": {
                     "type": "object"
                 }
             },
             "allOf": [
                 {
-                    "if" : {
-                        "properties": {"Type" : {"const" : "MSProjectSdkAttribute"}}
+                    "if": {
+                        "properties": { "Type": { "const": "MSProjectSdkAttribute" } }
                     },
-                    "then" : {
+                    "then": {
                         "properties": {
                             "Condition": {
                                 "type": "object",
                                 "additionalProperties": false,
-                                "required": ["Value"],
-                                "properties" : {
+                                "required": [ "Value" ],
+                                "properties": {
                                     "Value": {
                                         "type": "string",
                                         "title": "SDK Value",
                                         "description": "The expected value of the sdk attribute",
-                                        "enum" : [
+                                        "enum": [
                                             "Microsoft.NET.Sdk",
                                             "Microsoft.NET.Sdk.Web"
                                         ]
@@ -169,16 +185,16 @@
                 },
 
                 {
-                    "if" : {
-                        "properties": {"Type" : {"const" : "MSProperty"}}
+                    "if": {
+                        "properties": { "Type": { "const": "MSProperty" } }
                     },
-                    "then" : {
+                    "then": {
                         "properties": {
                             "Condition": {
                                 "type": "object",
                                 "additionalProperties": false,
-                                "required": ["PropertyName", "AllowedValues"],
-                                "properties" : {
+                                "required": [ "PropertyName", "AllowedValues" ],
+                                "properties": {
                                     "PropertyName": {
                                         "type": "string",
                                         "title": "Property Name",
@@ -187,7 +203,7 @@
                                     },
                                     "AllowedValues": {
                                         "type": "array",
-                                        "items" :{
+                                        "items": {
                                             "type": "string"
                                         },
                                         "title": "Allowed Values",
@@ -200,16 +216,16 @@
                 },
 
                 {
-                    "if" : {
-                        "properties": {"Type" : {"const" : "MSPropertyExists"}}
+                    "if": {
+                        "properties": { "Type": { "const": "MSPropertyExists" } }
                     },
-                    "then" : {
+                    "then": {
                         "properties": {
                             "Condition": {
                                 "type": "object",
                                 "additionalProperties": false,
-                                "required": ["PropertyName"],
-                                "properties" : {
+                                "required": [ "PropertyName" ],
+                                "properties": {
                                     "PropertyName": {
                                         "type": "string",
                                         "title": "Property Name",
@@ -223,16 +239,16 @@
                 },
 
                 {
-                    "if" : {
-                        "properties": {"Type" : {"const" : "FileExists"}}
+                    "if": {
+                        "properties": { "Type": { "const": "FileExists" } }
                     },
-                    "then" : {
+                    "then": {
                         "properties": {
                             "Condition": {
                                 "type": "object",
                                 "additionalProperties": false,
-                                "required": ["FileName"],
-                                "properties" : {
+                                "required": [ "FileName" ],
+                                "properties": {
                                     "FileName": {
                                         "type": "string",
                                         "title": "File Exists",
@@ -247,8 +263,8 @@
             ]
         },
 
-        "RuleEffect" : {
-            "type" : "object",
+        "RuleEffect": {
+            "type": "object",
             "additionalProperties": false,
             "properties": {
                 "Include": {
@@ -264,14 +280,14 @@
             }
         },
 
-        "OptionSettings" : {
-            "type" : "array",
-            "items": {"$ref": "#/definitions/OptionSetting"}
+        "OptionSettings": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/OptionSetting" }
         },
-        "OptionSetting" : {
-            "type" : "object",
+        "OptionSetting": {
+            "type": "object",
             "additionalProperties": false,
-            "required": ["Id", "Name", "Description", "Type"],
+            "required": [ "Id", "Name", "Description", "Type" ],
             "properties": {
                 "Id": {
                     "type": "string",
@@ -302,7 +318,7 @@
                     "title": "Type",
                     "description": "The data type of the setting.",
                     "minLength": 1,
-                    "enum": ["String", "Int", "Bool", "Object"]
+                    "enum": [ "String", "Int", "Bool", "Object" ]
                 },
                 "TypeHint": {
                     "type": "string",
@@ -328,7 +344,7 @@
                     ]
                 },
                 "DefaultValue": {
-                    "type": ["string", "null", "boolean", "integer"],
+                    "type": [ "string", "null", "boolean", "integer" ],
                     "title": "The default value for the setting.",
                     "description": ""
                 },
@@ -337,7 +353,7 @@
                     "title": "Allowed Values",
                     "description": "The list of allowed values for the setting.",
                     "items": {
-                        "type" : "string"
+                        "type": "string"
                     }
                 },
                 "AdvancedSetting": {
@@ -357,9 +373,9 @@
                     "title": "",
                     "description": "",
                     "items": {
-                        "type" :"object",
+                        "type": "object",
                         "additionalProperties": false,
-                        "required": ["Id", "Value"],
+                        "required": [ "Id", "Value" ],
                         "properties": {
                             "Id": {
                                 "type": "string",
@@ -368,7 +384,7 @@
                                 "minLength": 1
                             },
                             "Value": {
-                                "type": ["boolean", "string"],
+                                "type": [ "boolean", "string" ],
                                 "title": "",
                                 "description": ""
                             }
@@ -376,7 +392,7 @@
                     }
                 },
                 "ChildOptionSettings": {
-                    "items": {"$ref": "#/definitions/OptionSetting"}
+                    "items": { "$ref": "#/definitions/OptionSetting" }
                 },
                 "TypeHintData": {
                     "type": "object",
@@ -384,7 +400,7 @@
                     "description": "Additional data required to process option setting.",
                     "properties": {
                         "ServicePrincipal": {
-                            "type": ["string", "null"]
+                            "type": [ "string", "null" ]
                         }
                     }
                 }

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -85,9 +85,10 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var recommendations = await engine.ComputeRecommendations(projectPath, new Dictionary<string, string>());
 
-            recommendations
-                .Any(r => r.Recipe.Id == Constants.BLAZOR_WASM)
-                .ShouldBeTrue("Failed to receive Recommendation: " + Constants.BLAZOR_WASM);
+            var blazorRecommendation = recommendations.FirstOrDefault(r => r.Recipe.Id == Constants.BLAZOR_WASM);
+
+            Assert.NotNull(blazorRecommendation);
+            Assert.NotNull(blazorRecommendation.Recipe.DeploymentConfirmation.DefaultMessage);
         }
 
 


### PR DESCRIPTION
*Description of changes:*
Add ability for recipes to define a deployment confirmation message. If a confirmation is not set then perform deployment as soon as the user is done settings confirmation. If one is set prompt the user for the explicitly say they want to do the deployment.

![BlazorConfirmation](https://user-images.githubusercontent.com/1653751/111235855-c290b800-85ae-11eb-9a2c-1d359846ccbf.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
