### PR TITLE
chore: Reduce use of OrchestratorSession

### DIFF
--- a/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
+++ b/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
@@ -10,7 +10,6 @@ using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using AWS.Deploy.CLI.Extensions;
 using AWS.Deploy.Common;
-using AWS.Deploy.Orchestration;
 
 namespace AWS.Deploy.CLI.CloudFormation
 {
@@ -33,11 +32,11 @@ namespace AWS.Deploy.CLI.CloudFormation
         private readonly HashSet<string> _processedEventIds = new HashSet<string>();
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public StackEventMonitor(string stackName, IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
+        public StackEventMonitor(string stackName, IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService)
         {
             _stackName = stackName;
 
-            _cloudFormationClient = awsClientFactory.GetAWSClient<IAmazonCloudFormation>(session.AWSCredentials, session.AWSRegion);
+            _cloudFormationClient = awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
             _consoleUtilities = new ConsoleUtilities(interactiveService);
         }
 

--- a/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
@@ -8,8 +8,6 @@ using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using AWS.Deploy.CLI.CloudFormation;
 using AWS.Deploy.Common;
-using AWS.Deploy.DockerEngine;
-using AWS.Deploy.Orchestration;
 using AWS.Deploy.Recipes.CDK.Common;
 
 namespace AWS.Deploy.CLI.Commands
@@ -23,16 +21,14 @@ namespace AWS.Deploy.CLI.Commands
 
         private readonly IAWSClientFactory _awsClientFactory;
         private readonly IToolInteractiveService _interactiveService;
-        private readonly OrchestratorSession _session;
         private readonly IAmazonCloudFormation _cloudFormationClient;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public DeleteDeploymentCommand(IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService, OrchestratorSession session)
+        public DeleteDeploymentCommand(IAWSClientFactory awsClientFactory, IToolInteractiveService interactiveService)
         {
             _awsClientFactory = awsClientFactory;
             _interactiveService = interactiveService;
-            _session = session;
-            _cloudFormationClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>(_session.AWSCredentials, _session.AWSRegion);
+            _cloudFormationClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
             _consoleUtilities = new ConsoleUtilities(interactiveService);
         }
 
@@ -56,7 +52,7 @@ namespace AWS.Deploy.CLI.Commands
             }
 
             _interactiveService.WriteLine($"{stackName}: deleting...");
-            var monitor = new StackEventMonitor(stackName, _awsClientFactory, _interactiveService, _session);
+            var monitor = new StackEventMonitor(stackName, _awsClientFactory, _interactiveService);
 
             try
             {

--- a/src/AWS.Deploy.CLI/Commands/ListDeploymentsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ListDeploymentsCommand.cs
@@ -2,53 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Threading.Tasks;
-using AWS.Deploy.Orchestration;
-using AWS.Deploy.Orchestration.Data;
-using AWS.Deploy.Recipes;
+using AWS.Deploy.Orchestration.Utilities;
 
 namespace AWS.Deploy.CLI.Commands
 {
     public class ListDeploymentsCommand
     {
-        private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
         private readonly IToolInteractiveService _interactiveService;
-        private readonly OrchestratorSession _session;
-        private readonly ICdkProjectHandler _cdkProjectHandler;
-        private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly IDeploymentBundleHandler _deploymentBundleHandler;
-
-        public ListDeploymentsCommand(IToolInteractiveService interactiveService,
-            IOrchestratorInteractiveService orchestratorInteractiveService,
-            ICdkProjectHandler cdkProjectHandler,
-            IDeploymentBundleHandler deploymentBundleHandler,
-            IAWSResourceQueryer awsResourceQueryer,
-            OrchestratorSession session)
+        private readonly IDeployedApplicationQueryer _deployedApplicationQueryer;
+        
+        public ListDeploymentsCommand(
+            IToolInteractiveService interactiveService,
+            IDeployedApplicationQueryer deployedApplicationQueryer)
         {
             _interactiveService = interactiveService;
-            _orchestratorInteractiveService = orchestratorInteractiveService;
-            _cdkProjectHandler = cdkProjectHandler;
-            _deploymentBundleHandler = deploymentBundleHandler;
-            _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
+            _deployedApplicationQueryer = deployedApplicationQueryer;
         }
 
         public async Task ExecuteAsync()
         {
-            var orchestrator =
-                new Orchestrator(
-                    _session,
-                    _orchestratorInteractiveService,
-                    _cdkProjectHandler,
-                    _awsResourceQueryer,
-                    _deploymentBundleHandler,
-                    new[] { RecipeLocator.FindRecipeDefinitionsPath() });
-
             // Add Header
             _interactiveService.WriteLine();
             _interactiveService.WriteLine("Cloud Applications:");
             _interactiveService.WriteLine("-------------------");
 
-            var existingApplications = await orchestrator.GetExistingDeployedApplications();
+            var existingApplications = await _deployedApplicationQueryer.GetExistingDeployedApplications();
             foreach (var app in existingApplications)
             {
                 _interactiveService.WriteLine(app.Name);

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
@@ -13,22 +13,18 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 {
     public class BeanstalkApplicationCommand : ITypeHintCommand
     {
-        private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public BeanstalkApplicationCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public BeanstalkApplicationCommand(IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
-            _toolInteractiveService = toolInteractiveService;
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            var applications = await _awsResourceQueryer.ListOfElasticBeanstalkApplications(_session);
+            var applications = await _awsResourceQueryer.ListOfElasticBeanstalkApplications();
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<BeanstalkApplicationTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<ApplicationDescription>

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
@@ -5,23 +5,18 @@ using System.Linq;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
-using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
 {
     public class BeanstalkEnvironmentCommand : ITypeHintCommand
     {
-        private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public BeanstalkEnvironmentCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public BeanstalkEnvironmentCommand(IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
-            _toolInteractiveService = toolInteractiveService;
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
@@ -31,7 +26,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var applicationOptionSetting = recommendation.GetOptionSetting(optionSetting.ParentSettingId);
 
             var applicationName = recommendation.GetOptionSettingValue(applicationOptionSetting) as string;
-            var environments = await _awsResourceQueryer.ListOfElasticBeanstalkEnvironments(_session, applicationName);
+            var environments = await _awsResourceQueryer.ListOfElasticBeanstalkEnvironments(applicationName);
 
             var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(
                 options: environments.Select(env => env.EnvironmentName),

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
@@ -12,23 +12,19 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 {
     public class DotnetBeanstalkPlatformArnCommand : ITypeHintCommand
     {
-        private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public DotnetBeanstalkPlatformArnCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public DotnetBeanstalkPlatformArnCommand(IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
-            _toolInteractiveService = toolInteractiveService;
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
-            var platformArns = await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(_session);
+            var platformArns = await _awsResourceQueryer.GetElasticBeanstalkPlatformArns();
 
             var userInputConfiguration = new UserInputConfiguration<PlatformSummary>
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Amazon.EC2.Model;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
-using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -14,21 +13,19 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
     {
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public EC2KeyPairCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public EC2KeyPairCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
             _toolInteractiveService = toolInteractiveService;
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
-            var keyPairs = await _awsResourceQueryer.ListOfEC2KeyPairs(_session);
+            var keyPairs = await _awsResourceQueryer.ListOfEC2KeyPairs();
 
             var userInputConfiguration = new UserInputConfiguration<KeyPairInfo>
             {
@@ -70,7 +67,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
                     var keyPairDirectory = _consoleUtilities.AskForEC2KeyPairSaveDirectory(recommendation.ProjectPath);
 
-                    await _awsResourceQueryer.CreateEC2KeyPair(_session, settingValue.ToString(), keyPairDirectory);
+                    await _awsResourceQueryer.CreateEC2KeyPair(settingValue, keyPairDirectory);
                 }
 
                 break;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ECSClusterCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ECSClusterCommand.cs
@@ -1,15 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Amazon.ECS.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
-using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -17,19 +13,17 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
     public class ECSClusterCommand : ITypeHintCommand
     {
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public ECSClusterCommand(IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public ECSClusterCommand(IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            var clusters = await _awsResourceQueryer.ListOfECSClusters(_session);
+            var clusters = await _awsResourceQueryer.ListOfECSClusters();
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<ECSClusterTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<Cluster>

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
@@ -14,23 +14,19 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 {
     public class IAMRoleCommand : ITypeHintCommand
     {
-        private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public IAMRoleCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public IAMRoleCommand(IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
-            _toolInteractiveService = toolInteractiveService;
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
             var typeHintData = optionSetting.GetTypeHintData<IAMRoleTypeHintData>();
-            var existingRoles = await _awsResourceQueryer.ListOfIAMRoles(_session, typeHintData?.ServicePrincipal);
+            var existingRoles = await _awsResourceQueryer.ListOfIAMRoles(typeHintData?.ServicePrincipal);
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<IAMRoleTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<Role>

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
-using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -18,29 +17,34 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting);
     }
 
+    public interface ITypeHintCommandFactory
+    {
+        ITypeHintCommand GetCommand(OptionSettingTypeHint typeHint);
+    }
+
     /// <summary>
     /// Factory class responsible to build and get type hint command
     /// </summary>
-    public class TypeHintCommandFactory
+    public class TypeHintCommandFactory : ITypeHintCommandFactory
     {
         private readonly Dictionary<OptionSettingTypeHint, ITypeHintCommand> _commands;
 
-        public TypeHintCommandFactory(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public TypeHintCommandFactory(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
-            _commands = new Dictionary<OptionSettingTypeHint, ITypeHintCommand>()
+            _commands = new Dictionary<OptionSettingTypeHint, ITypeHintCommand>
             {
-                { OptionSettingTypeHint.BeanstalkApplication, new BeanstalkApplicationCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
-                { OptionSettingTypeHint.BeanstalkEnvironment, new BeanstalkEnvironmentCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
-                { OptionSettingTypeHint.DotnetBeanstalkPlatformArn, new DotnetBeanstalkPlatformArnCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
-                { OptionSettingTypeHint.EC2KeyPair, new EC2KeyPairCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
-                { OptionSettingTypeHint.IAMRole, new IAMRoleCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
-                { OptionSettingTypeHint.Vpc, new VpcCommand(toolInteractiveService, awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.BeanstalkApplication, new BeanstalkApplicationCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.BeanstalkEnvironment, new BeanstalkEnvironmentCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.DotnetBeanstalkPlatformArn, new DotnetBeanstalkPlatformArnCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.EC2KeyPair, new EC2KeyPairCommand(toolInteractiveService, awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.IAMRole, new IAMRoleCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.Vpc, new VpcCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishAdditionalBuildArguments, new DotnetPublishArgsCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishSelfContainedBuild, new DotnetPublishSelfContainedBuildCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishBuildConfiguration, new DotnetPublishBuildConfigurationCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DockerExecutionDirectory, new DockerExecutionDirectoryCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DockerBuildArgs, new DockerBuildArgsCommand(consoleUtilities) },
-                { OptionSettingTypeHint.ECSCluster, new ECSClusterCommand(awsResourceQueryer, session, consoleUtilities) },
+                { OptionSettingTypeHint.ECSCluster, new ECSClusterCommand(awsResourceQueryer, consoleUtilities) },
             };
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
@@ -14,16 +14,12 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 {
     public class VpcCommand : ITypeHintCommand
     {
-        private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly OrchestratorSession _session;
         private readonly ConsoleUtilities _consoleUtilities;
 
-        public VpcCommand(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, OrchestratorSession session, ConsoleUtilities consoleUtilities)
+        public VpcCommand(IAWSResourceQueryer awsResourceQueryer, ConsoleUtilities consoleUtilities)
         {
-            _toolInteractiveService = toolInteractiveService;
             _awsResourceQueryer = awsResourceQueryer;
-            _session = session;
             _consoleUtilities = consoleUtilities;
         }
 
@@ -31,7 +27,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             var currentVpcTypeHintResponse = optionSetting.GetTypeHintData<VpcTypeHintResponse>();
 
-            var vpcs = await _awsResourceQueryer.GetListOfVpcs(_session);
+            var vpcs = await _awsResourceQueryer.GetListOfVpcs();
 
             var userInputConfig = new UserInputConfiguration<Vpc>
             {

--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;

--- a/src/AWS.Deploy.Common/DefaultAWSClientFactory.cs
+++ b/src/AWS.Deploy.Common/DefaultAWSClientFactory.cs
@@ -9,9 +9,18 @@ namespace AWS.Deploy.Common
 {
     public class DefaultAWSClientFactory : IAWSClientFactory
     {
-        public T GetAWSClient<T>(AWSCredentials credentials, string region) where T : IAmazonService
+        private readonly AWSCredentials _credentials;
+        private readonly string _region;
+
+        public DefaultAWSClientFactory(AWSCredentials credentials, string region)
         {
-            var awsOptions = new AWSOptions { Credentials = credentials, Region = RegionEndpoint.GetBySystemName(region) };
+            _credentials = credentials;
+            _region = region;
+        }
+
+        public T GetAWSClient<T>() where T : IAmazonService
+        {
+            var awsOptions = new AWSOptions { Credentials = _credentials, Region = RegionEndpoint.GetBySystemName(_region) };
 
             return awsOptions.CreateServiceClient<T>();
         }

--- a/src/AWS.Deploy.Common/IAWSClientFactory.cs
+++ b/src/AWS.Deploy.Common/IAWSClientFactory.cs
@@ -7,6 +7,6 @@ namespace AWS.Deploy.Common
 {
     public interface IAWSClientFactory
     {
-        T GetAWSClient<T>(AWSCredentials credentials, string region) where T : IAmazonService;
+        T GetAWSClient<T>() where T : IAmazonService;
     }
 }

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -22,19 +22,19 @@ namespace AWS.Deploy.Orchestration.Data
 {
     public interface IAWSResourceQueryer
     {
-        Task<List<Cluster>> ListOfECSClusters(OrchestratorSession session);
-        Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications(OrchestratorSession session);
-        Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(OrchestratorSession session, string applicationName);
-        Task<List<KeyPairInfo>> ListOfEC2KeyPairs(OrchestratorSession session);
-        Task<string> CreateEC2KeyPair(OrchestratorSession session, string keyName, string saveLocation);
-        Task<List<Role>> ListOfIAMRoles(OrchestratorSession session, string servicePrincipal);
-        Task<List<Vpc>> GetListOfVpcs(OrchestratorSession session);
-        Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(OrchestratorSession session);
-        Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(OrchestratorSession session);
-        Task<List<AuthorizationData>> GetECRAuthorizationToken(OrchestratorSession session);
-        Task<List<Repository>> GetECRRepositories(OrchestratorSession session, List<string> repositoryNames);
-        Task<Repository> CreateECRRepository(OrchestratorSession session, string repositoryName);
-        Task<List<Stack>> GetCloudFormationStacks(OrchestratorSession session);
+        Task<List<Cluster>> ListOfECSClusters();
+        Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications();
+        Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName);
+        Task<List<KeyPairInfo>> ListOfEC2KeyPairs();
+        Task<string> CreateEC2KeyPair(string keyName, string saveLocation);
+        Task<List<Role>> ListOfIAMRoles(string servicePrincipal);
+        Task<List<Vpc>> GetListOfVpcs();
+        Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns();
+        Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn();
+        Task<List<AuthorizationData>> GetECRAuthorizationToken();
+        Task<List<Repository>> GetECRRepositories(List<string> repositoryNames);
+        Task<Repository> CreateECRRepository(string repositoryName);
+        Task<List<Stack>> GetCloudFormationStacks();
     }
 
     public class AWSResourceQueryer : IAWSResourceQueryer
@@ -46,9 +46,9 @@ namespace AWS.Deploy.Orchestration.Data
             _awsClientFactory = awsClientFactory;
         }
 
-        public async Task<List<Cluster>> ListOfECSClusters(OrchestratorSession session)
+        public async Task<List<Cluster>> ListOfECSClusters()
         {
-            var ecsClient = _awsClientFactory.GetAWSClient<IAmazonECS>(session.AWSCredentials, session.AWSRegion);
+            var ecsClient = _awsClientFactory.GetAWSClient<IAmazonECS>();
 
             var clusterArns = await ecsClient.Paginators
                 .ListClusters(new ListClustersRequest())
@@ -63,16 +63,16 @@ namespace AWS.Deploy.Orchestration.Data
             return clusters.Clusters;
         }
 
-        public async Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications(OrchestratorSession session)
+        public async Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications()
         {
-            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>(session.AWSCredentials, session.AWSRegion);
+            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
             var applications = await beanstalkClient.DescribeApplicationsAsync();
             return applications.Applications;
         }
 
-        public async Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(OrchestratorSession session, string applicationName)
+        public async Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName)
         {
-            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>(session.AWSCredentials, session.AWSRegion);
+            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
             var environments = new List<EnvironmentDescription>();
             var request = new DescribeEnvironmentsRequest
             {
@@ -91,19 +91,19 @@ namespace AWS.Deploy.Orchestration.Data
             return environments;
         }
 
-        public async Task<List<KeyPairInfo>> ListOfEC2KeyPairs(OrchestratorSession session)
+        public async Task<List<KeyPairInfo>> ListOfEC2KeyPairs()
         {
-            var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>(session.AWSCredentials, session.AWSRegion);
+            var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>();
             var response = await ec2Client.DescribeKeyPairsAsync();
 
             return response.KeyPairs;
         }
 
-        public async Task<string> CreateEC2KeyPair(OrchestratorSession session, string keyName, string saveLocation)
+        public async Task<string> CreateEC2KeyPair(string keyName, string saveLocation)
         {
-            var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>(session.AWSCredentials, session.AWSRegion);
+            var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>();
 
-            var request = new CreateKeyPairRequest() { KeyName = keyName };
+            var request = new CreateKeyPairRequest { KeyName = keyName };
 
             var response = await ec2Client.CreateKeyPairAsync(request);
 
@@ -112,9 +112,9 @@ namespace AWS.Deploy.Orchestration.Data
             return response.KeyPair.KeyName;
         }
 
-        public async Task<List<Role>> ListOfIAMRoles(OrchestratorSession session, string servicePrincipal)
+        public async Task<List<Role>> ListOfIAMRoles(string servicePrincipal)
         {
-            var identityManagementServiceClient = _awsClientFactory.GetAWSClient<IAmazonIdentityManagementService>(session.AWSCredentials, session.AWSRegion);
+            var identityManagementServiceClient = _awsClientFactory.GetAWSClient<IAmazonIdentityManagementService>();
 
             var listRolesRequest = new ListRolesRequest();
             var roles = new List<Role>();
@@ -134,9 +134,9 @@ namespace AWS.Deploy.Orchestration.Data
             return !string.IsNullOrEmpty(role.AssumeRolePolicyDocument) && role.AssumeRolePolicyDocument.Contains(servicePrincipal);
         }
 
-        public async Task<List<Vpc>> GetListOfVpcs(OrchestratorSession session)
+        public async Task<List<Vpc>> GetListOfVpcs()
         {
-            var vpcClient = _awsClientFactory.GetAWSClient<IAmazonEC2>(session.AWSCredentials, session.AWSRegion);
+            var vpcClient = _awsClientFactory.GetAWSClient<IAmazonEC2>();
 
             return await vpcClient.Paginators
                 .DescribeVpcs(new DescribeVpcsRequest())
@@ -146,9 +146,9 @@ namespace AWS.Deploy.Orchestration.Data
                 .ToListAsync();
         }
 
-        public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(OrchestratorSession session)
+        public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns()
         {
-            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>(session.AWSCredentials, session.AWSRegion);
+            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
 
             var request = new ListPlatformVersionsRequest
             {
@@ -182,9 +182,9 @@ namespace AWS.Deploy.Orchestration.Data
             return platformVersions;
         }
 
-        public async Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(OrchestratorSession session)
+        public async Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn()
         {
-            var platforms = await GetElasticBeanstalkPlatformArns(session);
+            var platforms = await GetElasticBeanstalkPlatformArns();
 
             if (!platforms.Any())
             {
@@ -194,18 +194,18 @@ namespace AWS.Deploy.Orchestration.Data
             return platforms.First();
         }
 
-        public async Task<List<AuthorizationData>> GetECRAuthorizationToken(OrchestratorSession session)
+        public async Task<List<AuthorizationData>> GetECRAuthorizationToken()
         {
-            var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>(session.AWSCredentials, session.AWSRegion);
+            var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>();
 
             var response = await ecrClient.GetAuthorizationTokenAsync(new GetAuthorizationTokenRequest());
 
             return response.AuthorizationData;
         }
 
-        public async Task<List<Repository>> GetECRRepositories(OrchestratorSession session, List<string> repositoryNames)
+        public async Task<List<Repository>> GetECRRepositories(List<string> repositoryNames)
         {
-            var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>(session.AWSCredentials, session.AWSRegion);
+            var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>();
 
             var request = new DescribeRepositoriesRequest
             {
@@ -225,9 +225,9 @@ namespace AWS.Deploy.Orchestration.Data
             }
         }
 
-        public async Task<Repository> CreateECRRepository(OrchestratorSession session, string repositoryName)
+        public async Task<Repository> CreateECRRepository(string repositoryName)
         {
-            var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>(session.AWSCredentials, session.AWSRegion);
+            var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>();
 
             var request = new CreateRepositoryRequest
             {
@@ -239,9 +239,9 @@ namespace AWS.Deploy.Orchestration.Data
             return response.Repository;
         }
 
-        public async Task<List<Stack>> GetCloudFormationStacks(OrchestratorSession session)
+        public async Task<List<Stack>> GetCloudFormationStacks()
         {
-            using var cloudFormationClient = _awsClientFactory.GetAWSClient<Amazon.CloudFormation.IAmazonCloudFormation>(session.AWSCredentials, session.AWSRegion);
+            using var cloudFormationClient = _awsClientFactory.GetAWSClient<Amazon.CloudFormation.IAmazonCloudFormation>();
             return await cloudFormationClient.Paginators.DescribeStacks(new DescribeStacksRequest()).Stacks.ToListAsync();
         }
     }

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -27,19 +27,16 @@ namespace AWS.Deploy.Orchestration
         private readonly ICommandLineWrapper _commandLineWrapper;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
         private readonly IOrchestratorInteractiveService _interactiveService;
-        private readonly OrchestratorSession _session;
         private readonly IDirectoryManager _directoryManager;
         private readonly IZipFileManager _zipFileManager;
 
         public DeploymentBundleHandler(
-            OrchestratorSession session,
             ICommandLineWrapper commandLineWrapper,
             IAWSResourceQueryer awsResourceQueryer,
             IOrchestratorInteractiveService interactiveService,
             IDirectoryManager directoryManager,
             IZipFileManager zipFileManager)
         {
-            _session = session;
             _commandLineWrapper = commandLineWrapper;
             _awsResourceQueryer = awsResourceQueryer;
             _interactiveService = interactiveService;
@@ -235,7 +232,7 @@ namespace AWS.Deploy.Orchestration
 
         private async Task InitiateDockerLogin()
         {
-            var authorizationTokens = await _awsResourceQueryer.GetECRAuthorizationToken(_session);
+            var authorizationTokens = await _awsResourceQueryer.GetECRAuthorizationToken();
 
             if (authorizationTokens.Count == 0)
                 throw new DockerLoginFailedException();
@@ -253,7 +250,7 @@ namespace AWS.Deploy.Orchestration
 
         private async Task<Repository> SetupECRRepository(string ecrRepositoryName)
         {
-            var existingRepositories = await _awsResourceQueryer.GetECRRepositories(_session, new List<string> { ecrRepositoryName });
+            var existingRepositories = await _awsResourceQueryer.GetECRRepositories(new List<string> { ecrRepositoryName });
 
             if (existingRepositories.Count == 1)
             {
@@ -261,7 +258,7 @@ namespace AWS.Deploy.Orchestration
             }
             else
             {
-                return await _awsResourceQueryer.CreateECRRepository(_session, ecrRepositoryName);
+                return await _awsResourceQueryer.CreateECRRepository(ecrRepositoryName);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -4,17 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
-using Amazon.CloudFormation;
-using Amazon.CloudFormation.Model;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
-using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.Recipes;
-using AWS.Deploy.Recipes.CDK.Common;
 using Newtonsoft.Json;
 
 namespace AWS.Deploy.Orchestration
@@ -30,7 +25,6 @@ namespace AWS.Deploy.Orchestration
         private readonly IList<string> _recipeDefinitionPaths;
 
         private readonly OrchestratorSession _session;
-        private readonly IAWSClientFactory _awsClientFactory;
 
         public Orchestrator(
             OrchestratorSession session,
@@ -46,10 +40,9 @@ namespace AWS.Deploy.Orchestration
             _deploymentBundleHandler = deploymentBundleHandler;
             _recipeDefinitionPaths = recipeDefinitionPaths;
             _awsResourceQueryer = awsResourceQueryer;
-            _awsClientFactory = new DefaultAWSClientFactory();
         }
 
-        public async Task<IList<Recommendation>> GenerateDeploymentRecommendations()
+        public async Task<List<Recommendation>> GenerateDeploymentRecommendations()
         {
             var engine = new RecommendationEngine.RecommendationEngine(_recipeDefinitionPaths, _session);
             var additionalReplacements = await GetReplacements();
@@ -60,7 +53,7 @@ namespace AWS.Deploy.Orchestration
         {
             var replacements = new Dictionary<string, string>();
 
-            var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(_session);
+            var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn();
             replacements[REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN] = latestPlatform.PlatformArn;
 
             return replacements;
@@ -86,89 +79,6 @@ namespace AWS.Deploy.Orchestration
                     _interactiveService.LogErrorMessageLine($"Unknown deployment type {recommendation.Recipe.DeploymentType} specified in recipe.");
                     break;
             }
-        }
-
-        /// <summary>
-        /// Get the list of existing deployed applications by describe the CloudFormation stacks and filtering the stacks to the
-        /// ones that have the AWS .NET deployment tool tag and description.
-        /// </summary>
-        public Task<IList<CloudApplication>> GetExistingDeployedApplications()
-        {
-            return GetExistingDeployedApplications(null);
-        }
-
-        /// <summary>
-        /// Get the list of existing deployed applications by describe the CloudFormation stacks and filtering the stacks to the
-        /// ones that have the AWS .NET deployment tool tag and description.
-        ///
-        /// If compatibleRecommendations has any values that only existing applications that were deployed with any of the recipes
-        /// identified by the recommendations will be returned.
-        /// </summary>
-        /// <returns></returns>
-        public async Task<IList<CloudApplication>> GetExistingDeployedApplications(IList<Recommendation> compatibleRecommendations)
-        {
-            var stacks = await _awsResourceQueryer.GetCloudFormationStacks(_session);
-            var apps = new List<CloudApplication>();
-
-            foreach (var stack in stacks)
-            {
-                // Check to see if stack has AWS .NET deployment tool tag and the stack is not deleted or in the process of being deleted.
-                var deployTag = stack.Tags.FirstOrDefault(tags => string.Equals(tags.Key, CloudFormationIdentifierConstants.STACK_TAG));
-
-                // Skip stacks that don't have AWS .NET deployment tool tag
-                if (deployTag == null ||
-
-                    // Skip stacks does not have AWS .NET deployment tool description prefix. (This is filter out stacks that have the tag propagated to it like the Beanstalk stack)
-                    (stack.Description == null || !stack.Description.StartsWith(CloudFormationIdentifierConstants.STACK_DESCRIPTION_PREFIX)) ||
-
-                    // Skip tags that are deleted or in the process of being deleted
-                    stack.StackStatus.ToString().StartsWith("DELETE"))
-                {
-                    continue;
-                }
-
-                // ROLLBACK_COMPLETE occurs when a stack creation fails and successfully rollbacks with cleaning partially created resources.
-                // In this state, only a delete operation can be performed. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html)
-                // We don't want to include ROLLBACK_COMPLETE because it never succeeded to deploy.
-                // However, a customer can give name of new application same as ROLLBACK_COMPLETE stack, which will trigger the re-deployment flow on the ROLLBACK_COMPLETE stack.
-                if (stack.StackStatus == StackStatus.ROLLBACK_COMPLETE)
-                {
-                    continue;
-                }
-
-                // If a list of compatible recommendations was given then skip existing applications that were used with a
-                // recipe that is not compatible.
-                var recipeId = deployTag.Value;
-                if (compatibleRecommendations?.Count > 0 && !compatibleRecommendations.Any(rec => string.Equals(rec.Recipe.Id, recipeId)))
-                {
-                    continue;
-                }
-
-                apps.Add(new CloudApplication
-                {
-                    Name = stack.StackName,
-                    RecipeId = recipeId
-                });
-            }
-
-            return apps;
-        }
-
-        /// <summary>
-        /// For a given Cloud Application loads the metadata for it. This includes the settings used to deploy and the recipe information.
-        /// </summary>
-        /// <param name="cloudApplication"></param>
-        /// <returns></returns>
-        public async Task<CloudApplicationMetadata> LoadCloudApplicationMetadata(string cloudApplication)
-        {
-            using var client = _awsClientFactory.GetAWSClient<Amazon.CloudFormation.IAmazonCloudFormation>(_session.AWSCredentials, _session.AWSRegion);
-
-            var response = await client.GetTemplateAsync(new GetTemplateRequest
-            {
-                StackName = cloudApplication
-            });
-
-            return TemplateMetadataReader.ReadSettings(response.TemplateBody);
         }
 
         public DeploymentBundleDefinition GetDeploymentBundleDefinition(Recommendation recommendation)

--- a/src/AWS.Deploy.Orchestration/RecommendationEngine/RecommendationEngine.cs
+++ b/src/AWS.Deploy.Orchestration/RecommendationEngine/RecommendationEngine.cs
@@ -43,7 +43,7 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
             }
         }
 
-        public async Task<IList<Recommendation>> ComputeRecommendations(string projectPath, Dictionary<string, string> additionalReplacements)
+        public async Task<List<Recommendation>> ComputeRecommendations(string projectPath, Dictionary<string, string> additionalReplacements)
         {
             var projectDefinition = new ProjectDefinition(projectPath);
             var recommendations = new List<Recommendation>();

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.Data;
+using AWS.Deploy.Recipes.CDK.Common;
+
+namespace AWS.Deploy.Orchestration.Utilities
+{
+    public interface IDeployedApplicationQueryer
+    {
+        /// <summary>
+        /// Get the list of existing deployed applications by describe the CloudFormation stacks and filtering the stacks to the
+        /// ones that have the AWS .NET deployment tool tag and description.
+        ///
+        /// If <paramref name="compatibleRecommendations"/> has any values that only existing applications that were deployed with any of the recipes
+        /// identified by the recommendations will be returned.
+        /// </summary>
+        Task<List<CloudApplication>> GetExistingDeployedApplications(List<Recommendation> compatibleRecommendations = null);
+    }
+
+    public class DeployedApplicationQueryer : IDeployedApplicationQueryer
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public DeployedApplicationQueryer(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<List<CloudApplication>> GetExistingDeployedApplications(List<Recommendation> compatibleRecommendations = null)
+        {
+            compatibleRecommendations ??= new List<Recommendation>();
+
+            var stacks = await _awsResourceQueryer.GetCloudFormationStacks();
+            var apps = new List<CloudApplication>();
+
+            foreach (var stack in stacks)
+            {
+                // Check to see if stack has AWS .NET deployment tool tag and the stack is not deleted or in the process of being deleted.
+                var deployTag = stack.Tags.FirstOrDefault(tags => string.Equals(tags.Key, CloudFormationIdentifierConstants.STACK_TAG));
+
+                // Skip stacks that don't have AWS .NET deployment tool tag
+                if (deployTag == null ||
+
+                    // Skip stacks does not have AWS .NET deployment tool description prefix. (This is filter out stacks that have the tag propagated to it like the Beanstalk stack)
+                    (stack.Description == null || !stack.Description.StartsWith(CloudFormationIdentifierConstants.STACK_DESCRIPTION_PREFIX)) ||
+
+                    // Skip tags that are deleted or in the process of being deleted
+                    stack.StackStatus.ToString().StartsWith("DELETE"))
+                {
+                    continue;
+                }
+
+                // ROLLBACK_COMPLETE occurs when a stack creation fails and successfully rollbacks with cleaning partially created resources.
+                // In this state, only a delete operation can be performed. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html)
+                // We don't want to include ROLLBACK_COMPLETE because it never succeeded to deploy.
+                // However, a customer can give name of new application same as ROLLBACK_COMPLETE stack, which will trigger the re-deployment flow on the ROLLBACK_COMPLETE stack.
+                if (stack.StackStatus == StackStatus.ROLLBACK_COMPLETE)
+                {
+                    continue;
+                }
+
+                // If a list of compatible recommendations was given then skip existing applications that were used with a
+                // recipe that is not compatible.
+                var recipeId = deployTag.Value;
+                if (!compatibleRecommendations.Any(rec => string.Equals(rec.Recipe.Id, recipeId)))
+                {
+                    continue;
+                }
+
+                apps.Add(new CloudApplication
+                {
+                    Name = stack.StackName,
+                    RecipeId = recipeId
+                });
+            }
+
+            return apps;
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -23,17 +23,18 @@ namespace AWS.Deploy.CLI.UnitTests
         private readonly TestToolCommandLineWrapper _commandLineWrapper;
         private readonly OrchestratorSession _session;
         private readonly TestDirectoryManager _directoryManager;
-        private readonly TestZipFileManager _zipFileManager;
 
         public DeploymentBundleHandlerTests()
         {
             _session = new OrchestratorSession();
             var awsResourceQueryer = new TestToolAWSResourceQueryer();
             var interactiveService = new TestToolOrchestratorInteractiveService();
+            var zipFileManager = new TestZipFileManager();
+
             _commandLineWrapper = new TestToolCommandLineWrapper();
             _directoryManager = new TestDirectoryManager();
-            _zipFileManager = new TestZipFileManager();
-            _deploymentBundleHandler = new DeploymentBundleHandler(_session, _commandLineWrapper, awsResourceQueryer, interactiveService, _directoryManager, _zipFileManager);
+            
+            _deploymentBundleHandler = new DeploymentBundleHandler(_commandLineWrapper, awsResourceQueryer, interactiveService, _directoryManager, zipFileManager);
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TemplateMetadataReaderTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TemplateMetadataReaderTests.cs
@@ -1,28 +1,39 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
 using Xunit;
-
-using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Utilities;
+using Moq;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
     public class TemplateMetadataReaderTests
     {
         [Fact]
-        public void ReadYamlMetadata()
+        public async Task ReadYamlMetadata()
         {
+            // ARRANGE
             var templateBody = File.ReadAllText("./TestFiles/ReadYamlTemplateMetadata.yml");
-            var metadata = TemplateMetadataReader.ReadSettings(templateBody);
 
+            var mockClient = new Mock<IAmazonCloudFormation>();
+            mockClient
+                .Setup(x => x.GetTemplateAsync(It.IsAny<GetTemplateRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetTemplateResponse
+                {
+                    TemplateBody = templateBody
+                }));
+
+            var templateMetadataReader = new TemplateMetadataReader(new TestAWSClientFactory(mockClient.Object));
+
+            // ACT
+            var metadata = await templateMetadataReader.LoadCloudApplicationMetadata("");
+
+            // ASSERT
             Assert.Equal("aws-elasticbeanstalk-role", metadata.Settings["ApplicationIAMRole"].ToString());
         }
     }

--- a/test/AWS.Deploy.CLI.UnitTests/TestAWSClientFactory.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TestAWSClientFactory.cs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using Amazon.Runtime;
+using AWS.Deploy.Common;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    /// <summary>
+    /// Helpful fake of <see cref="IAWSClientFactory"/>.  Pass in one or more
+    /// Mock <see cref="IAmazonService"/>s and this will handle the plumbing.
+    /// </summary>
+    public class TestAWSClientFactory : IAWSClientFactory
+    {
+        private readonly IAmazonService[] _clients;
+
+        public TestAWSClientFactory(params IAmazonService[] clientMocks)
+        {
+            _clients = clientMocks ?? new IAmazonService[0];
+        }
+
+        public T GetAWSClient<T>() where T : IAmazonService
+        {
+            var match = _clients.OfType<T>().FirstOrDefault();
+
+            if (null == match)
+                throw new Exception(
+                    $"Test setup exception.  Somebody wanted a [{typeof(T)}] but I don't have it." +
+                    $"I have the following clients: {string.Join(",", _clients.Select(x => x.GetType().Name))}");
+
+            return match;
+        } 
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -16,11 +16,11 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
 {
     public class TestToolAWSResourceQueryer : IAWSResourceQueryer
     {
-        public Task<string> CreateEC2KeyPair(OrchestratorSession session, string keyName, string saveLocation) => throw new NotImplementedException();
-        public Task<Repository> CreateECRRepository(OrchestratorSession session, string repositoryName) => throw new NotImplementedException();
-        public Task<List<Stack>> GetCloudFormationStacks(OrchestratorSession session) => throw new NotImplementedException();
+        public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
+        public Task<Repository> CreateECRRepository(string repositoryName) => throw new NotImplementedException();
+        public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
 
-        public Task<List<AuthorizationData>> GetECRAuthorizationToken(OrchestratorSession session)
+        public Task<List<AuthorizationData>> GetECRAuthorizationToken()
         {
             var authorizationData = new AuthorizationData
             {
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             return Task.FromResult<List<AuthorizationData>>(new List<AuthorizationData>(){ authorizationData });
         }
 
-        public Task<List<Repository>> GetECRRepositories(OrchestratorSession session, List<string> repositoryNames)
+        public Task<List<Repository>> GetECRRepositories(List<string> repositoryNames)
         {
             if (repositoryNames.Count == 0)
                 return Task.FromResult<List<Repository>>(new List<Repository>() { });
@@ -44,13 +44,13 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             return Task.FromResult<List<Repository>>(new List<Repository>() { repository });
         }
 
-        public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(OrchestratorSession session) => throw new NotImplementedException();
-        public Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(OrchestratorSession session) => throw new NotImplementedException();
-        public Task<List<Vpc>> GetListOfVpcs(OrchestratorSession session) => throw new NotImplementedException();
-        public Task<List<KeyPairInfo>> ListOfEC2KeyPairs(OrchestratorSession session) => throw new NotImplementedException();
-        public Task<List<Amazon.ECS.Model.Cluster>> ListOfECSClusters(OrchestratorSession session) => throw new NotImplementedException();
-        public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications(OrchestratorSession session) => throw new NotImplementedException();
-        public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(OrchestratorSession session, string applicationName) => throw new NotImplementedException();
-        public Task<List<Role>> ListOfIAMRoles(OrchestratorSession session, string servicePrincipal) => throw new NotImplementedException();
+        public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns() => throw new NotImplementedException();
+        public Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn() => throw new NotImplementedException();
+        public Task<List<Vpc>> GetListOfVpcs() => throw new NotImplementedException();
+        public Task<List<KeyPairInfo>> ListOfEC2KeyPairs() => throw new NotImplementedException();
+        public Task<List<Amazon.ECS.Model.Cluster>> ListOfECSClusters() => throw new NotImplementedException();
+        public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications() => throw new NotImplementedException();
+        public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName) => throw new NotImplementedException();
+        public Task<List<Role>> ListOfIAMRoles(string servicePrincipal) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
**Non Functional Change**

This refactor helps reduce overuse/misuse of `OrchestratorSession` as a CredetialStore that needed to be passed around in areas not really using "Orchestration"


Also refactors out reading cloud application metadata so less commands rely on Orchestrator.

Meat of change:

![image](https://user-images.githubusercontent.com/1190907/112234602-1b3d0200-8bfa-11eb-9ee7-1e2a108e641a.png)

Which allowed:

![image](https://user-images.githubusercontent.com/1190907/112234684-43c4fc00-8bfa-11eb-9ec2-3f7037769f92.png)

And also: 

![image](https://user-images.githubusercontent.com/1190907/112234758-7111aa00-8bfa-11eb-8bc9-7693927a413e.png)

Which cleans up List and Delete commands.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

