### PR TITLE
chore: dedicated project parsing class

### DIFF
--- a/src/AWS.Deploy.CLI/Program.cs
+++ b/src/AWS.Deploy.CLI/Program.cs
@@ -91,6 +91,10 @@ namespace AWS.Deploy.CLI
                     var systemCapabilityEvaluator = new SystemCapabilityEvaluator(commandLineWrapper, cdkManager);
                     var systemCapabilities = systemCapabilityEvaluator.Evaluate();
 
+                    var projectParser = new ProjectDefinitionParser(fileManager, directoryManager);
+                    var projectParserUtility = new ProjectParserUtility(toolInteractiveService, projectParser, directoryManager);
+                    var projectDefinition = await projectParserUtility.Parse(projectPath);
+
                     var stsClient = new AmazonSecurityTokenServiceClient(awsCredentials);
                     var callerIdentity = await stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
 
@@ -100,8 +104,7 @@ namespace AWS.Deploy.CLI
                         AWSCredentials = awsCredentials,
                         AWSRegion = awsRegion,
                         AWSAccountId = callerIdentity.Account,
-                        ProjectPath = projectPath,
-                        ProjectDirectory = projectPath,
+                        ProjectDefinition = projectDefinition,
                         SystemCapabilities = systemCapabilities,
                         CdkManager = cdkManager
                     };
@@ -115,6 +118,7 @@ namespace AWS.Deploy.CLI
                         orchestratorInteractiveService,
                         new CdkProjectHandler(orchestratorInteractiveService, commandLineWrapper),
                         new DeploymentBundleHandler(commandLineWrapper, awsResourceQueryer, orchestratorInteractiveService, directoryManager, zipFileManager),
+                        new DockerEngine.DockerEngine(projectDefinition),
                         awsResourceQueryer,
                         new TemplateMetadataReader(awsClientFactory),
                         new DeployedApplicationQueryer(awsResourceQueryer),

--- a/src/AWS.Deploy.CLI/Utilities/ProjectParserUtility.cs
+++ b/src/AWS.Deploy.CLI/Utilities/ProjectParserUtility.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.CLI.Utilities
+{
+    /// <summary>
+    /// Sits on top of <see cref="IProjectDefinitionParser"/> and adds UI specific logic
+    /// for error handling.
+    /// </summary>
+    public class ProjectParserUtility
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IProjectDefinitionParser _projectDefinitionParser;
+        private readonly IDirectoryManager _directoryManager;
+
+        public ProjectParserUtility(
+            IToolInteractiveService toolInteractiveService,
+            IProjectDefinitionParser projectDefinitionParser,
+            IDirectoryManager directoryManager)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _projectDefinitionParser = projectDefinitionParser;
+            _directoryManager = directoryManager;
+        }
+
+        public async Task<ProjectDefinition> Parse(string projectPath)
+        {
+            try
+            {
+                return await _projectDefinitionParser.Parse(projectPath);
+            }
+            catch (ProjectFileNotFoundException ex)
+            {
+                var files = _directoryManager.GetFiles(projectPath, "*.sln");
+
+                if (files.Any())
+                    _toolInteractiveService.WriteErrorLine(
+                        "This directory contains a solution file, but the tool requires a project file. " +
+                        "Please run the tool from the directory that contains a .csproj/.fsproj or provide a path to the .csproj/.fsproj via --project-path flag.");
+                else
+                    _toolInteractiveService.WriteErrorLine($"A project was not found at the path {projectPath}");
+
+                throw new FailedToFindDeployableTargetException(ex);
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/IO/DirectoryManager.cs
+++ b/src/AWS.Deploy.Common/IO/DirectoryManager.cs
@@ -9,18 +9,15 @@ namespace AWS.Deploy.Common.IO
     {
         DirectoryInfo CreateDirectory(string path);
         bool Exists(string path);
+        string[] GetFiles(string projectPath, string searchPattern = null);
     }
 
     public class DirectoryManager : IDirectoryManager
     {
-        public DirectoryInfo CreateDirectory(string path)
-        {
-            return Directory.CreateDirectory(path);
-        }
+        public DirectoryInfo CreateDirectory(string path) => Directory.CreateDirectory(path);
+        
+        public bool Exists(string path) => Directory.Exists(path);
 
-        public bool Exists(string path)
-        {
-            return Directory.Exists(path);
-        }
+        public string[] GetFiles(string path, string searchPattern = null) => Directory.GetFiles(path, searchPattern ?? "*");
     }
 }

--- a/src/AWS.Deploy.Common/IO/FileManager.cs
+++ b/src/AWS.Deploy.Common/IO/FileManager.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,6 +11,7 @@ namespace AWS.Deploy.Common.IO
     {
         bool Exists(string path);
         Task<string> ReadAllTextAsync(string path);
+        Task<string[]> ReadAllLinesAsync(string path);
         Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken = default);
     }
 
@@ -20,19 +20,13 @@ namespace AWS.Deploy.Common.IO
     /// </summary>
     public class FileManager : IFileManager
     {
-        public bool Exists(string path)
-        {
-            return File.Exists(path);
-        }
+        public bool Exists(string path) => File.Exists(path);
 
-        public Task<string> ReadAllTextAsync(string path)
-        {
-            return File.ReadAllTextAsync(path);
-        }
+        public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
 
-        public Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken)
-        {
-            return File.WriteAllTextAsync(filePath, contents, cancellationToken);
-        }
+        public Task<string[]> ReadAllLinesAsync(string path) => File.ReadAllLinesAsync(path);
+
+        public Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken) =>
+            File.WriteAllTextAsync(filePath, contents, cancellationToken);
     }
 }

--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -9,95 +9,55 @@ using System.Xml;
 namespace AWS.Deploy.Common
 {
     /// <summary>
-    /// Stores metadata about a parsed project
+    /// Models metadata about a parsed .csproj or .fsproj project.
+    /// Use <see cref="IProjectDefinitionParser.Parse"/> to build
     /// </summary>
     public class ProjectDefinition
     {
-        private readonly XmlDocument _xmlProjectFile;
-        public string ProjectPath { get; private set; }
+        /// <summary>
+        /// Xml file contents of the Project file.
+        /// </summary>
+        public XmlDocument Contents { get; set; }
 
-        public ProjectDefinition(string projectPath)
-        {
-            if (Directory.Exists(projectPath))
-            {
-                var files = Directory.GetFiles(projectPath, "*.csproj");
-                if (files.Length == 1)
-                {
-                    projectPath = Path.Combine(projectPath, files[0]);
-                }
-                else if (files.Length == 0)
-                {
-                    files = Directory.GetFiles(projectPath, "*.fsproj");
-                    if (files.Length == 1)
-                    {
-                        projectPath = Path.Combine(projectPath, files[0]);
-                    }
-                }
-            }
+        /// <summary>
+        /// Full path to the project file
+        /// </summary>
+        public string ProjectPath { get; set; }
 
-            if (!File.Exists(projectPath))
-            {
-                throw new ProjectFileNotFoundException(projectPath);
-            }
-
-            ProjectPath = projectPath;
-            _xmlProjectFile = new XmlDocument();
-            _xmlProjectFile.LoadXml(File.ReadAllText(projectPath));
-
-            var sdkType = _xmlProjectFile.DocumentElement.Attributes["Sdk"];
-            SdkType = sdkType?.Value;
-
-            var targetFramework = _xmlProjectFile.GetElementsByTagName("TargetFramework");
-            if (targetFramework.Count > 0)
-            {
-                TargetFramework = targetFramework[0].InnerText;
-            }
-
-            var assemblyName = _xmlProjectFile.GetElementsByTagName("AssemblyName");
-            if (assemblyName.Count > 0)
-            {
-                AssemblyName = (string.IsNullOrWhiteSpace(assemblyName[0].InnerText) ? Path.GetFileNameWithoutExtension(projectPath) : assemblyName[0].InnerText);
-            }
-            else
-            {
-                AssemblyName = Path.GetFileNameWithoutExtension(projectPath);
-            }
-        }
-
+        /// <summary>
+        /// The Solution file path of the project.
+        /// </summary>
+        public string ProjectSolutionPath { get;set; }
+        
         /// <summary>
         /// Value of the Sdk property of the root project element in a .csproj
         /// </summary>
-        public string SdkType { get; private set; }
+        public string SdkType { get; set; }
 
         /// <summary>
         /// Value of the TargetFramework property of the project
         /// </summary>
-        public string TargetFramework { get; private set; }
+        public string TargetFramework { get; set; }
 
         /// <summary>
         /// Value of the AssemblyName property of the project
         /// </summary>
-        public string AssemblyName { get; private set; }
+        public string AssemblyName { get; set; }
 
         /// <summary>
         /// True if we found a docker file corresponding to the .csproj
         /// </summary>
         public bool HasDockerFile => CheckIfDockerFileExists(ProjectPath);
 
-        /// <summary>
-        /// The Solution file path of the project.
-        /// </summary>
-        public string ProjectSolutionPath => GetProjectSolutionFile(ProjectPath);
-
         public string GetMSPropertyValue(string propertyName)
         {
-            var propertyValue = _xmlProjectFile.SelectSingleNode($"//PropertyGroup/{propertyName}")?.InnerText;
+            var propertyValue = Contents.SelectSingleNode($"//PropertyGroup/{propertyName}")?.InnerText;
             return propertyValue;
         }
 
         public string GetPackageReferenceVersion(string packageName)
         {
-            var packageReference = _xmlProjectFile.SelectSingleNode($"//ItemGroup/PackageReference[@Include='{packageName}']") as XmlElement;
+            var packageReference = Contents.SelectSingleNode($"//ItemGroup/PackageReference[@Include='{packageName}']") as XmlElement;
             return packageReference?.GetAttribute("Version");
         }
 
@@ -105,41 +65,6 @@ namespace AWS.Deploy.Common
         {
             var dir = Directory.GetFiles(new FileInfo(projectPath).DirectoryName, "Dockerfile");
             return dir.Length == 1;
-        }
-
-        private string GetProjectSolutionFile(string projectPath)
-        {
-            var projectDirectory = Directory.GetParent(projectPath);
-            var solutionExists = false;
-            while (solutionExists == false && projectDirectory != null)
-            {
-                var files = projectDirectory.GetFiles("*.sln");
-                foreach (var solutionFile in files)
-                {
-                    if (ValidateProjectInSolution(projectPath, solutionFile.FullName))
-                    {
-                        return solutionFile.FullName;
-                    }
-                }
-                projectDirectory = projectDirectory.Parent;
-            }
-            return string.Empty;
-        }
-
-        private bool ValidateProjectInSolution(string projectPath, string solutionFile)
-        {
-            var projectFileName = Path.GetFileName(projectPath);
-            if (string.IsNullOrWhiteSpace(solutionFile) ||
-                string.IsNullOrWhiteSpace(projectFileName))
-            {
-                return false;
-            }
-            List<string> lines = File.ReadAllLines(solutionFile).ToList();
-            var projectLines = lines.Where(x => x.StartsWith("Project"));
-            var projectPaths = projectLines.Select(x => x.Split(',')[1].Replace('\"', ' ').Trim()).ToList();
-
-            //Validate project exists in solution
-            return projectPaths.Select(x => Path.GetFileName(x)).Where(x => x.Equals(projectFileName)).Any();
         }
     }
 }

--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.Common
+{
+    public interface IProjectDefinitionParser
+    {
+        /// <summary>
+        /// Scans<paramref name="projectPath"/> for a valid project file and reads it to
+        /// fully populate a <see cref="ProjectDefinition"/>
+        /// </summary>
+        /// <exception cref="ProjectFileNotFoundException">
+        /// Thrown if no project can be found at <paramref name="projectPath"/>
+        /// </exception>
+        Task<ProjectDefinition> Parse(string projectPath);
+    }
+
+    public class ProjectDefinitionParser : IProjectDefinitionParser
+    {
+        private readonly IFileManager _fileManager;
+        private readonly IDirectoryManager _directoryManager;
+
+        public ProjectDefinitionParser(IFileManager fileManager, IDirectoryManager directoryManager)
+        {
+            _fileManager = fileManager;
+            _directoryManager = directoryManager;
+        }
+
+        public async Task<ProjectDefinition> Parse(string projectPath)
+        {
+            if (_directoryManager.Exists(projectPath))
+            {
+                var files = _directoryManager.GetFiles(projectPath, "*.csproj");
+                if (files.Length == 1)
+                {
+                    projectPath = Path.Combine(projectPath, files[0]);
+                }
+                else if (files.Length == 0)
+                {
+                    files = _directoryManager.GetFiles(projectPath, "*.fsproj");
+                    if (files.Length == 1)
+                    {
+                        projectPath = Path.Combine(projectPath, files[0]);
+                    }
+                }
+            }
+
+            if (!_fileManager.Exists(projectPath))
+            {
+                throw new ProjectFileNotFoundException(projectPath);
+            }
+
+            var xmlProjectFile = new XmlDocument();
+            xmlProjectFile.LoadXml(await _fileManager.ReadAllTextAsync(projectPath));
+
+            var projectDefinition =  new ProjectDefinition
+            {
+                Contents = xmlProjectFile,
+                ProjectPath = projectPath,
+                ProjectSolutionPath = await GetProjectSolutionFile(projectPath)
+            };
+            
+            var targetFramework = xmlProjectFile.GetElementsByTagName("TargetFramework");
+            if (targetFramework.Count > 0)
+            {
+                projectDefinition.TargetFramework = targetFramework[0].InnerText;
+            }
+            
+            projectDefinition.SdkType = xmlProjectFile.DocumentElement.Attributes["Sdk"]?.Value;
+
+            
+            var assemblyName = xmlProjectFile.GetElementsByTagName("AssemblyName");
+            if (assemblyName.Count > 0)
+            {
+                projectDefinition.AssemblyName = (string.IsNullOrWhiteSpace(assemblyName[0].InnerText) ? Path.GetFileNameWithoutExtension(projectPath) : assemblyName[0].InnerText);
+            }
+            else
+            {
+                projectDefinition.AssemblyName = Path.GetFileNameWithoutExtension(projectPath);
+            }
+
+            return projectDefinition;
+        }
+
+        private async Task<string> GetProjectSolutionFile(string projectPath)
+        {
+            var projectDirectory = Directory.GetParent(projectPath);
+            
+            while (projectDirectory != null)
+            {
+                var files = _directoryManager.GetFiles(projectDirectory.FullName, "*.sln");
+                foreach (var solutionFile in files)
+                {
+                    if (await ValidateProjectInSolution(projectPath, solutionFile))
+                    {
+                        return solutionFile;
+                    }
+                }
+                projectDirectory = projectDirectory.Parent;
+            }
+            return string.Empty;
+        }
+
+        private async Task<bool> ValidateProjectInSolution(string projectPath, string solutionFile)
+        {
+            var projectFileName = Path.GetFileName(projectPath);
+            if (string.IsNullOrWhiteSpace(solutionFile) ||
+                string.IsNullOrWhiteSpace(projectFileName))
+            {
+                return false;
+            }
+
+            var lines = await _fileManager.ReadAllLinesAsync(solutionFile);
+            var projectLines = lines.Where(x => x.StartsWith("Project"));
+            var projectPaths = projectLines.Select(x => x.Split(',')[1].Replace('\"', ' ').Trim()).ToList();
+
+            //Validate project exists in solution
+            return projectPaths.Select(x => Path.GetFileName(x)).Any(x => x.Equals(projectFileName));
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -12,7 +12,7 @@ namespace AWS.Deploy.Common
     {
         private const string REPLACE_TOKEN_PROJECT_NAME = "{ProjectName}";
 
-        public string ProjectPath { get; }
+        public string ProjectPath => ProjectDefinition.ProjectPath;
 
         public ProjectDefinition ProjectDefinition { get; }
 
@@ -30,19 +30,16 @@ namespace AWS.Deploy.Common
 
         private readonly Dictionary<string, string> _replacementTokens = new();
 
-        public Recommendation(RecipeDefinition recipe, string projectPath, int computedPriority, Dictionary<string, string> additionalReplacements)
+        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, int computedPriority, Dictionary<string, string> additionalReplacements)
         {
             Recipe = recipe;
-            ProjectPath = projectPath;
+
             ComputedPriority = computedPriority;
 
-            ProjectDefinition = new ProjectDefinition(projectPath);
+            ProjectDefinition = projectDefinition;
             DeploymentBundle = new DeploymentBundle();
 
-            if (File.Exists(projectPath))
-            {
-                _replacementTokens[REPLACE_TOKEN_PROJECT_NAME] = Path.GetFileNameWithoutExtension(ProjectPath);
-            }
+            _replacementTokens[REPLACE_TOKEN_PROJECT_NAME] = Path.GetFileNameWithoutExtension(projectDefinition.ProjectPath);
 
             foreach (var replacement in additionalReplacements)
             {

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -10,10 +10,25 @@ using Newtonsoft.Json;
 
 namespace AWS.Deploy.DockerEngine
 {
+    public interface IDockerEngine
+    {
+        /// <summary>
+        /// Generates a docker file
+        /// </summary>
+        void GenerateDockerFile();
+
+        /// <summary>
+        /// Inspects the Dockerfile associated with the recommendation
+        /// and determines the appropriate Docker Execution Directory,
+        /// if one is not set.
+        /// </summary>
+        void DetermineDockerExecutionDirectory(Recommendation recommendation);
+    }
+
     /// <summary>
     /// Orchestrates the moving parts involved in creating a dockerfile for a project
     /// </summary>
-    public class DockerEngine
+    public class DockerEngine : IDockerEngine
     {
         private readonly ProjectDefinition _project;
         private readonly string _projectPath;

--- a/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
+++ b/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
@@ -1,16 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.IO;
 using System.Threading.Tasks;
 using Amazon.Runtime;
+using AWS.Deploy.Common;
 using AWS.Deploy.Orchestration.CDK;
 
 namespace AWS.Deploy.Orchestration
 {
     public class OrchestratorSession
     {
-        public string ProjectPath { get; set; }
+        public ProjectDefinition ProjectDefinition { get; set; }
         public string AWSProfileName { get; set; }
         public AWSCredentials AWSCredentials { get; set; }
         public string AWSRegion { get; set; }
@@ -22,28 +22,6 @@ namespace AWS.Deploy.Orchestration
         /// </remarks>
         public Task<SystemCapabilities> SystemCapabilities { get; set; }
         public string AWSAccountId { get; set; }
-
-        private string _projectDirectory;
-        public string ProjectDirectory
-        {
-            get => _projectDirectory;
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    _projectDirectory = Directory.GetCurrentDirectory();
-                }
-                else if (File.Exists(value))
-                {
-                    _projectDirectory = Directory.GetParent(value).FullName;
-                }
-                else
-                {
-                    _projectDirectory = value;
-                }
-            }
-        }
-
         public CDKManager CdkManager { get; set; }
     }
 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
@@ -22,5 +22,8 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
         {
             return CreatedDirectories.Contains(path);
         }
+
+        public string[] GetFiles(string projectPath, string searchPattern = null) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -4,7 +4,9 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.DockerEngine;
 using Should;
 using Xunit;
@@ -13,71 +15,22 @@ namespace AWS.Deploy.CLI.UnitTests
 {
     public class DockerTests
     {
-        [Fact]
-        public void DockerGenerateWebAppNoSolution()
+        [Theory]
+        [InlineData("WebAppNoSolution", "")]
+        [InlineData("WebAppWithSolutionSameLevel", "")]
+        [InlineData("WebAppWithSolutionParentLevel", "WebAppWithSolutionParentLevel")]
+        [InlineData("WebAppDifferentAssemblyName", "")]
+        [InlineData("WebAppProjectDependencies", "WebAppProjectDependencies")]
+        [InlineData("WebAppDifferentTargetFramework", "")]
+        [InlineData("ConsoleSdkType", "")]
+        public async Task DockerGenerate(string topLevelFolder, string projectName)
         {
-            var projectPath = ResolvePath("WebAppNoSolution");
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
-            engine.GenerateDockerFile();
+            var projectPath = ResolvePath(Path.Combine(topLevelFolder, projectName));
 
-            AssertDockerFilesAreEqual(projectPath);
-        }
+            var project = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(projectPath);
 
-        [Fact]
-        public void DockerGenerateWebAppWithSolutionSameLevel()
-        {
-            var projectPath = ResolvePath("WebAppWithSolutionSameLevel");
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
-            engine.GenerateDockerFile();
+            var engine = new DockerEngine.DockerEngine(project);
 
-            AssertDockerFilesAreEqual(projectPath);
-        }
-
-        [Fact]
-        public void DockerGenerateWebAppWithSolutionParentLevel()
-        {
-            var projectPath = ResolvePath(Path.Combine("WebAppWithSolutionParentLevel", "WebAppWithSolutionParentLevel"));
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
-            engine.GenerateDockerFile();
-
-            AssertDockerFilesAreEqual(projectPath);
-        }
-
-        [Fact]
-        public void DockerGenerateWebAppDifferentAssemblyName()
-        {
-            var projectPath = ResolvePath("WebAppDifferentAssemblyName");
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
-            engine.GenerateDockerFile();
-
-            AssertDockerFilesAreEqual(projectPath);
-        }
-
-        [Fact]
-        public void DockerGenerateWebAppProjectDependencies()
-        {
-            var projectPath = ResolvePath(Path.Combine("WebAppProjectDependencies", "WebAppProjectDependencies"));
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
-            engine.GenerateDockerFile();
-
-            AssertDockerFilesAreEqual(projectPath);
-        }
-
-        [Fact]
-        public void DockerGenerateWebAppDifferentTargetFramework()
-        {
-            var projectPath = ResolvePath("WebAppDifferentTargetFramework");
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
-            engine.GenerateDockerFile();
-
-            AssertDockerFilesAreEqual(projectPath);
-        }
-
-        [Fact]
-        public void DockerGenerateConsoleSdkType()
-        {
-            var projectPath = ResolvePath("ConsoleSdkType");
-            var engine = new DockerEngine.DockerEngine(new ProjectDefinition(projectPath));
             engine.GenerateDockerFile();
 
             AssertDockerFilesAreEqual(projectPath);

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +22,11 @@ namespace AWS.Deploy.Orchestration.UnitTests
         {
             var text = InMemoryStore[path];
             return Task.FromResult(text);
+        }
+
+        public async Task<string[]> ReadAllLinesAsync(string path)
+        {
+            return (await ReadAllTextAsync(path)).Split(Environment.NewLine);
         }
 
         public Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken = default)


### PR DESCRIPTION
**NOTE:** This needs PR #170 to merge first.  PR is setup to target another feature branch so actual diff can be previewed.

---

**Non-Functional Change**

Promotes testability by moving File IO and Parsing out of `ProjectDefinition` and into `ProjectDefinitionParser` and moves the parsed `ProjectDefinition` into `OrchestratorSession` to eliminate duplicate parsing responsibilities.


Primary Change:
![image](https://user-images.githubusercontent.com/1190907/112243078-30219180-8c0a-11eb-857a-83d0e0b14db1.png)

And:
![image](https://user-images.githubusercontent.com/1190907/112243135-4d566000-8c0a-11eb-9889-59bbb9b8a5da.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
