### PR TITLE
OptionSettingItems Input Validation

### DIFF
--- a/docs/OptionSettingsItems-input-validation.md
+++ b/docs/OptionSettingsItems-input-validation.md
@@ -1,0 +1,222 @@
+# OptionSettingItems Input Validation Design Document
+_DOTNET-4952_
+
+## Summary
+Need mechanism to indicate an `OptionSettingItem` is required (ie non empty value) or has additional input validations:
+ - less than 64 characters
+ - no whitespace characters
+ - no non-ascii characters
+ - value is from list of acceptable values
+ - is positive number
+ - is number within bounds
+
+Deployment should be blocked if there are any OptionSettingItems with invalid values.
+
+## Proposed Design
+
+Unqiue validation classes will be created and will implement a new interface:
+
+```csharp
+public interface IOptionSettingItemValidator
+{
+    OptionSettingItemValidationResult Validate(object input);
+}
+
+public class OptionSettingItemValidationResult
+{
+    public bool IsValid { get; set; }
+    public string ValidationFailedMessage { get;set; }
+}
+```
+
+OptionSettingItems will then contain a collection of 0 or more `IOptionSettingItemValidator`s:
+
+```csharp
+public class OptionSettingItem
+{
+     public List<IOptionSettingItemValidator> Validators { get; set; }
+}
+```
+
+### Validation
+
+`OptionSettingItem.SetValueOverride` will be updated to validate the override value by passing it to each Validator.  If any validator indicates the value is not valid, an exception is thrown:
+
+```csharp
+public void SetValueOverride(object valueOverride)
+{
+    foreach (var validator in this.Validators)
+    {
+        var result = validator.Validate(valueOverride);
+        if (!result.IsValid)
+            throw new ValidationFailedException
+            {
+                ValidationResult = result
+            };
+    }
+
+    // value is saved
+}
+```
+
+### Serialization of Recipes
+
+`RecipeDefinition`s are stored as json and deseiralized from _*.recipe_ files.  Therefor the Validators must also be Json Serializable.  To faciliate polymorphism, recipe json will need to define the type of the validator.
+
+In the example, below the **Example Setting** item has two Validators, `RequiredValidator` and `RegexValidator`:
+
+```json
+// Minimal Recipe to highlight OptionSettingsItem.Validators
+{  
+  "Name": "Example Recipe",  
+  "OptionSettings": [
+    {      
+      "Name": "Example Setting",
+      "Type": "String",
+      "DefaultValue": null,
+      "Validators": [
+        {
+          "$type": "AWS.Deploy.Common.Recipes.RequiredValidator, AWS.Deploy.Common",
+          "ValidationFailedMessage": "Value can not be empty"
+        },
+        {
+          "$type": "AWS.Deploy.Common.Recipes.RegexValidator, AWS.Deploy.Common",
+          "Regex": "[a-zA-Z]{3,20}",
+          "ValidationFailedMessage": "Letters only, 3 to 20 characters in length"
+        }
+      ],
+      "AllowedValues": [],
+      "ValueMapping": {}
+    }
+  ],
+  "RecipePriority": 0
+}
+```
+
+This requires the recipe to be deserialzied using customized [TypeNameHandling](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_TypeNameHandling.htm):
+
+```csharp
+var settings = new JsonSerializerSettings
+{
+    TypeNameHandling = TypeNameHandling.Auto
+};
+var recipe = JsonConvert.DeserializeObject<RecipeDefintion>(json, settings);
+```
+
+### Validator Configuration
+
+Validator can declare any additional configuration they need in as Properties in the validator class.  And, as the validator is deserialized from json, any Property can be customized inside the recipe.  For examle:
+
+```csharp
+public class RangeValidator : IOptionSettingItemValidator
+{
+    public int Min { get; set; } = int.MinValue;
+    public int Max { get;set; } = int.MaxValue;
+
+    public string ValidationFailedMessage { get; set; } =
+        "Value must be greater than or equal to {{Min}} and less than or equal to {{Max}}";
+}
+```
+#### Message Customization
+
+Each validator is responsible for rendering a validation failed message and can control how it allows recipe authors to customize the message.
+
+In the `RangeValidator` example above, a recipe author can customize `ValidationFailedMessage`.  Additionally, `RangeValidator` suppots two replacement tokens `{{Min}}` and `{{Max}}`.  This allows a recipe author greater flexability:
+
+```json
+{
+    "$type": "AWS.Deploy.Common.Recipes.RangeValidator, AWS.Deploy.Common",
+    "Min": "2",
+    "Min": "10",
+    "ValidationFailedMessage": "Setting can not be more than {{Max}}"
+}
+```
+
+### Dependencies
+
+Because Validators will be deserialized as part of a `RecipeDefinition` they need to have parameterless constructors and therefore can't use Constructor Injection.
+
+Validators are currently envisoned to be relatively simple to the point where they shouldn't need any dependencies.  If dependencies in are needed in the future, we can explore adding an `Initialize` method that uses the ServiceLocation (anti-)pattern:
+
+```csharp
+public interface IOptionSettingItemValidator
+{
+    /// <summary>
+    /// One possibile solution if we need to create a Validator that needs 
+    /// dependencies.
+    /// </summary>
+    void Initialize(IServiceLocator serviceLocator);
+}
+```
+
+### Extensability
+
+This design would facilitate validators being defined in external code; assuming that the project as a whole allows recipe authors to include 3rd party assemblies and the 3rd party assembly is already loaded.  If those preconditions are met, a recipe author can, in json, reference any validator type in an assembly that is loaded by the tool.
+
+#### Recipe Schema
+
+Any 3rd party Validators will not be added to the `aws-deploy-recipe-schema.json` file.
+
+### Allowed Values / Value Mapping
+
+`OptionSettingItem` defines:
+
+```csharp
+public class OptionSettingItem
+{
+    /// <summary>
+    /// The allowed values for the setting.
+    /// </summary>
+    public IList<string> AllowedValues { get; set; } = new List<string>();
+
+    /// <summary>
+    /// The value mapping for allowed values. The key of the dictionary is what is sent to services
+    /// and the value is the display value shown to users.
+    /// </summary>
+    public IDictionary<string, string> ValueMapping { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    // additional properties not shown
+}
+```
+
+I considered migrating `AllowedValues` to become a Validator, however `AllowedValues` and `ValueMapping` are tightly intergrated into UIs in order to render custom UI prompts, like the one below, that I decided they should remain as is and not be ported to a Validator:
+
+```
+Task CPU:
+The number of CPU units used by the task. See the following for details on CPU values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-task-defs
+1: 256 (.25 vCPU) (default)
+2: 512 (.5 vCPU)
+3: 1024 (1 vCPU)
+4: 2048 (2 vCPU)
+5: 4096 (4 vCPU)
+Choose option (default 1):
+```
+
+## WIP
+
+- Ideally keep validation targeted to just the incoming value.
+- Support validating the entire "Recommendation" as a separate level of validation.
+- support validation warnings?
+
+### Validation Scenarios
+
+#### CPU & Memory Pair
+
+Certain memory configurations are only available based on certain CPU configurations and vice versa.  For example, selecting 0.25GB of memory may only be valid if CPU is below 2vCPU.
+
+**Design:**
+- OptionSettingsItems will use `OptionSettingItem.AllowedValues` to restrict what the user can select for vCPU and Memory.  However, it will not have context to enforce limitations based on what has been selected for CPU.
+- UI can optionally implement a custom TypeHint that can restrict which value pairs are recommended and has access to the full `Recommendation` object.
+- A `MemoryCpuRecommendationValidator` will run after the user has indicated they have no more configuration changes and wishes to deploy.  It will be able to access both CPU and Memory `OptionSettingItem` values to ensure they are compatible.
+- _Justification:_ The validation system should not force the UX into a state where it is impossible to select a value.  For example, say the a 8 vCPU config requires at least 16 GB memory.  The 16 GB memory requires at least 8 vCPU.  The default values are 0.25 vCPU and 1 GB Memory. If we performed validation at the `OptionSettingItem` level, it would not be possible to change CPU to 8 and Memory to 16GB, as a change to CPU would always be incompatible with the existing Memory selection, and vice versa.
+
+#### Region limited EC2 Instances
+
+Not every AWS Region supports EC2 Instance Type.  Additionanlly, this list is dynamic as new EC2 instance types are introduced in a subset of Regions, or existing Regions get new capabilities.
+
+**Design:**
+
+- InstanceType TypeHint will present users with values valid for selected Region.
+- The `InstanceTypeOptionSettingItemValidator` will only validate that the EC2 type selected is in a known list; it will not have the context of which Region has been selected.
+- The `InstanceTypeRecommendationValidator` has access to the `OrchestratorSession` and can see which 
+Region is targetd.  It can then provide a validation error if the selected EC2 InstanceType is not available in the current region.

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Common
 {
@@ -106,6 +107,14 @@ namespace AWS.Deploy.Common
     public class FailedToCreateDeploymentBundleException : Exception
     {
         public FailedToCreateDeploymentBundleException(string message, Exception innerException = null) : base(message, innerException) { }
+    }
+
+    /// <summary>
+    /// Thrown if <see cref="OptionSettingItem.SetValueOverride"/> is given an invalid value.
+    /// </summary>
+    public class ValidationFailedException : Exception
+    {
+        public ValidationResult ValidationResult { get; set; }
     }
 
     /// <summary>

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AWS.Deploy.Common.Recipes.Validation;
 using Newtonsoft.Json;
 
 namespace AWS.Deploy.Common.Recipes
@@ -62,6 +63,11 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         public bool Updatable { get; set; }
 
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public List<OptionSettingItemValidatorConfig> Validators { get; set; } = new ();
+        
         /// <summary>
         /// The allowed values for the setting.
         /// </summary>

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Common.Recipes
 {
@@ -78,6 +79,11 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         public List<OptionSettingItem> OptionSettings { get; set; } = new ();
 
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public List<RecipeValidatorConfig> Validators { get; set; } = new ();
+        
         /// <summary>
         /// The priority of the recipe. The highest priority is the top choice for deploying to.
         /// </summary>

--- a/src/AWS.Deploy.Common/Recipes/Validation/FargateTaskSizeCpuMemoryLimitsRecipeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/FargateTaskSizeCpuMemoryLimitsRecipeValidator.cs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Enforces Fargate cpu and memory conditional requirements:
+    /// <para/> CPU value  Memory value (MiB)
+    /// <para/> 256 (.25 vCPU)  512 (0.5 GB), 1024 (1 GB), 2048 (2 GB)
+    /// <para/> 512 (.5 vCPU)   1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB)
+    /// <para/> 1024 (1 vCPU)   2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) 
+    /// <para/> 2048 (2 vCPU)   Between 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) 
+    /// <para/> 4096 (4 vCPU)   Between 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB)
+    /// <para />
+    /// See https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_definition_parameters.html#task_size
+    /// for more details.
+    /// </summary>
+    public class FargateTaskSizeCpuMemoryLimitsRecipeValidator : IRecipeValidator
+    {
+        private readonly Dictionary<string, string[]> _cpuMemoryMap = new()
+        {
+            { "256", new[] { "512", "1024", "2048" } },
+            { "512", new[] { "1024", "2048", "3072", "4096" } },
+            { "1024", new[] { "2048", "3072", "4096", "5120", "6144", "7168", "8192" } },
+            { "2048", BuildMemoryArray(4096, 16384).ToArray() },
+            { "4096", BuildMemoryArray(8192, 30720).ToArray()}
+        };
+
+        private static IEnumerable<string> BuildMemoryArray(int start, int end, int increment = 1024)
+        {
+            while (start <= end)
+            {
+                yield return start.ToString();
+                start += increment;
+            }
+        }
+
+        /// <summary>
+        /// Supports replacement tokens {{cpu}}, {{memory}}, and {{memoryList}}
+        /// </summary>
+        public string ValidationFailedMessage { get; set; } =
+            "Cpu value {{cpu}} is not compatible with value {{memory}}.  Allowed values are {{memoryList}}";
+
+        public string InvalidCpuValueValidationFailedMessage {get;set;}
+
+        /// <inheritdoc cref="FargateTaskSizeCpuMemoryLimitsRecipeValidator"/>
+        public ValidationResult Validate(RecipeDefinition recipe, IDeployToolValidationContext deployValidationContext)
+        {
+            var cpuItem = recipe.OptionSettings.FirstOrDefault(x => x.Id == "TaskCpu");
+            var memoryItem = recipe.OptionSettings.FirstOrDefault(x => x.Id == "TaskMemory");
+
+            // If we can't find the cpu/memory OptionSettingItem
+            // bail out as 'valid'
+            if (null == cpuItem || null == memoryItem)
+            {
+                return ValidationResult.Valid();
+            }
+
+            var cpu = cpuItem.GetValue<string>();
+            var memory = memoryItem.GetValue<string>();
+
+            if (!_cpuMemoryMap.ContainsKey(cpu))
+            {
+                // this could happen, but shouldn't.
+                // either there is mismatch between _cpuMemoryMap and the AllowedValues
+                // or the UX flow calling in here doesn't enforce AllowedValues.
+                var message = InvalidCpuValueValidationFailedMessage.Replace("{{cpu}}", cpu);
+
+                return ValidationResult.Failed(message);
+            }
+
+            var validMemoryValues = _cpuMemoryMap[cpu];
+
+            if (validMemoryValues.Contains(memory))
+            {
+                return ValidationResult.Valid();
+            }
+
+            var failed =
+                ValidationFailedMessage
+                    .Replace("{{cpu}}", cpu)
+                    .Replace("{{memory}}", memory)
+                    .Replace("{{memoryList}}", string.Join(", ", validMemoryValues));
+
+            return ValidationResult.Failed(failed);
+
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/IDeployToolValidationContext.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IDeployToolValidationContext.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Captures some basic information about the context the deployment tool is being running in.
+    /// Originally, this is to support <see cref="IRecipeValidator"/> implementations having the ability
+    /// to customize validation based on things like <see cref="AWSRegion"/>.
+    /// <para />
+    /// WARNING: Please be careful adding additional properties to this interface or trying to re-purpose this interface
+    /// for something other than validation.  Consider if it instead makes more sense to use
+    /// Interface Segregation to define a different interface for your use case.   It's fine for OrchestratorSession
+    /// to implement multiple interfaces.
+    /// </summary>
+    public interface IDeployToolValidationContext
+    {
+        ProjectDefinition ProjectDefinition { get; }
+        string AWSRegion { get; }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public interface IOptionSettingItemValidator
+    {
+        ValidationResult Validate(object input);
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public interface IRecipeValidator
+    {
+        ValidationResult Validate(RecipeDefinition recipe, IDeployToolValidationContext deployValidationContext);
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorConfig.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorConfig.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class OptionSettingItemValidatorConfig
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public OptionSettingItemValidatorList ValidatorType {get;set;}
+        public object Configuration {get;set;}
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public enum OptionSettingItemValidatorList
+    {
+        /// <summary>
+        /// Must be paired with <see cref="RangeValidator"/>
+        /// </summary>
+        Range,
+        /// <summary>
+        /// Must be paired with <see cref="RegexValidator"/>
+        /// </summary>
+        Regex,
+        /// <summary>
+        /// Must be paired with <see cref="RequiredValidator"/>
+        /// </summary>
+        Required
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/RangeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RangeValidator.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class RangeValidator : IOptionSettingItemValidator
+    {
+        public int Min { get; set; } = int.MinValue;
+        public int Max { get;set; } = int.MaxValue;
+
+        /// <summary>
+        /// Supports replacement tokens {{Min}} and {{Max}}
+        /// </summary>
+        public string ValidationFailedMessage { get; set; } =
+            "Value must be greater than or equal to {{Min}} and less than or equal to {{Max}}";
+
+        public ValidationResult Validate(object input)
+        {
+            if (int.TryParse(input?.ToString(), out var result) &&
+                result >= Min &&
+                result <= Max)
+            {
+                return ValidationResult.Valid();
+            }
+
+            var message =
+                ValidationFailedMessage
+                    .Replace("{{Min}}", Min.ToString())
+                    .Replace("{{Max}}", Max.ToString());
+
+            return ValidationResult.Failed(message);
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorConfig.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorConfig.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class RecipeValidatorConfig
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RecipeValidatorList ValidatorType {get;set;}
+        public object Configuration {get;set;}
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public enum RecipeValidatorList
+    {
+        /// <summary>
+        /// Must be paired with <see cref="FargateTaskSizeCpuMemoryLimitsRecipeValidator"/>
+        /// </summary>
+        FargateTaskSizeCpuMemoryLimits
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/RegexValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RegexValidator.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.RegularExpressions;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class RegexValidator : IOptionSettingItemValidator
+    {
+        public string Regex { get; set; } = "(.*)";
+        public string ValidationFailedMessage { get; set; } = "Value must match Regex {{Regex}}";
+
+        public ValidationResult Validate(object input)
+        {
+            var regex = new Regex(Regex);
+
+            var message = ValidationFailedMessage.Replace("{{Regex}}", Regex);
+
+            return new ValidationResult
+            {
+                IsValid = regex.IsMatch(input?.ToString() ?? ""),
+                ValidationFailedMessage = message
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/RequiredValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RequiredValidator.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class RequiredValidator : IOptionSettingItemValidator
+    {
+        public string ValidationFailedMessage { get; set; } = "Value can not be empty";
+
+        public ValidationResult Validate(object input) =>
+            new()
+            {
+                IsValid = !string.IsNullOrEmpty(input?.ToString()),
+                ValidationFailedMessage = ValidationFailedMessage
+            };
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidationResult.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidationResult.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class ValidationResult
+    {
+        public bool IsValid { get; set; }
+        public string ValidationFailedMessage { get;set; }
+
+        public static ValidationResult Failed(string message)
+        {
+            return new ValidationResult
+            {
+                IsValid = false,
+                ValidationFailedMessage = message
+            };
+        }
+
+        public static ValidationResult Valid()
+        {
+            return new ValidationResult
+            {
+                IsValid = true
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Builds <see cref="IOptionSettingItemValidator"/> and <see cref="IRecipeValidator"/> instances.
+    /// </summary>
+    public static class ValidatorFactory
+    {
+        private static readonly Dictionary<OptionSettingItemValidatorList, Type> _optionSettingItemValidatorTypeMapping = new()
+        {
+            { OptionSettingItemValidatorList.Range, typeof(RangeValidator) },
+            { OptionSettingItemValidatorList.Regex, typeof(RegexValidator) },
+            { OptionSettingItemValidatorList.Required, typeof(RequiredValidator) }
+        };
+
+        private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()
+        {
+            { RecipeValidatorList.FargateTaskSizeCpuMemoryLimits, typeof(FargateTaskSizeCpuMemoryLimitsRecipeValidator) }
+        };
+
+        public static IOptionSettingItemValidator[] BuildValidators(this OptionSettingItem optionSettingItem)
+        {
+            return optionSettingItem.Validators
+                .Select(v => Activate(v.ValidatorType, v.Configuration,_optionSettingItemValidatorTypeMapping))
+                .OfType<IOptionSettingItemValidator>()
+                .ToArray();
+        }
+
+        public static IRecipeValidator[] BuildValidators(this RecipeDefinition recipeDefinition)
+        {
+            return recipeDefinition.Validators
+                .Select(v => Activate(v.ValidatorType, v.Configuration,_recipeValidatorTypeMapping))
+                .OfType<IRecipeValidator>()
+                .ToArray();
+        }
+
+        private static object Activate<TValidatorList>(TValidatorList validatorType, object configuration, Dictionary<TValidatorList, Type> typeMappings)
+        {
+            if (null == configuration)
+            {
+                return Activator.CreateInstance(typeMappings[validatorType]);
+            }
+
+            if (configuration is JObject jObject)
+            {
+                return jObject.ToObject(typeMappings[validatorType]);
+            }
+
+            return configuration;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
+++ b/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
@@ -4,10 +4,11 @@
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Orchestration
 {
-    public class OrchestratorSession
+    public class OrchestratorSession : IDeployToolValidationContext
     {
         public ProjectDefinition ProjectDefinition { get; set; }
         public string AWSProfileName { get; set; }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -65,7 +65,10 @@
 
     ],
 
-
+    "Validators": [
+        {
+            "ValidatorType": "FargateTaskSizeCpuMemoryLimits"
+        }],
 
     "OptionSettings": [
         {
@@ -135,7 +138,16 @@
             "Type": "Int",
             "DefaultValue": 3,
             "AdvancedSetting": false,
-            "Updatable": true
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "Range",
+                    "Configuration" : {
+                        "Min": 1,
+                        "Max": 5000
+                    }
+                }
+            ]
         },
         {
             "Id": "ApplicationIAMRole",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -29,7 +29,7 @@
         "Id": {
             "type": "string",
             "title": "Unique ID for the recipe",
-            "description": "The unqiue id for the recipe. This value should never been change once the recipe is released because it will be stored in user config files.",
+            "description": "The unique id for the recipe. This value should never been change once the recipe is released because it will be stored in user config files.",
             "minLength": 1
         },
         "Name": {
@@ -87,6 +87,9 @@
         },
         "OptionSettings": {
             "$ref": "#/definitions/OptionSettings"
+        },
+        "Validators": {
+            "$ref": "#/definitions/Validators"
         }
     },
     "definitions": {
@@ -279,7 +282,38 @@
                 }
             }
         },
-
+        "Validators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ValidatorType": {
+                        "type": "string",
+                        "enum": [
+                            "FargateTaskSizeCpuMemoryLimits"
+                        ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "ValidatorType": { "const": "FargateTaskSizeCpuMemoryLimits" } }
+                        },
+                        "then": {
+                            "properties": {
+                                "Configuration": {
+                                    "properties": {
+                                        "InvalidCpuValueValidationFailedMessage": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
         "OptionSettings": {
             "type": "array",
             "items": { "$ref": "#/definitions/OptionSetting" }
@@ -402,6 +436,81 @@
                         "ServicePrincipal": {
                             "type": [ "string", "null" ]
                         }
+                    }
+                },
+                "Validators": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "ValidatorType": {
+                                "type": "string",
+                                "enum": [
+                                    "Range",
+                                    "Regex",
+                                    "Required"
+                                ]
+                            }
+                        },
+                        "allOf": [
+                            {
+                                "if": {
+                                    "properties": { "ValidatorType": { "const": "Range" } }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "Configuration": {
+                                            "properties": {
+                                                "Min": {
+                                                    "type": "integer"
+                                                },
+                                                "Max": {
+                                                    "type": "integer"
+                                                },
+                                                "ValidationFailedMessage": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": { "ValidatorType": { "const": "Regex" } }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "Configuration": {
+                                            "properties": {
+                                                "Regex": {
+                                                    "type": "string"
+                                                },
+                                                "ValidationFailedMessage": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": { "ValidatorType": { "const": "Required" } }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "Configuration": {
+                                            "properties": {
+                                                "ValidationFailedMessage": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
@@ -11,4 +11,12 @@
     <ProjectReference Include="..\..\src\AWS.Deploy.Common\AWS.Deploy.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Should-DotNetStandard" Version="1.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+  </ItemGroup>
+
 </Project>

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using Should;
+using Xunit;
+using Xunit.Abstractions;
+
+// Justification: False Positives with assertions, also test class
+// ReSharper disable PossibleNullReferenceException
+
+namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
+{
+    /// <summary>
+    /// Tests for the interaction between <see cref="OptionSettingItem.SetValueOverride"/>
+    /// and <see cref="IOptionSettingItemValidator"/>
+    /// </summary>
+    public class OptionSettingsItemValidationTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public OptionSettingsItemValidationTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("-10")]
+        [InlineData("100")]
+        public void InvalidInputInMultipleValidatorsThrowsException(string invalidValue)
+        {
+            var optionSettingItem = new OptionSettingItem
+            {
+                Validators = new()
+                {
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Required
+                    },
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Range,
+                        Configuration = new RangeValidator
+                        {
+                            Min = 7,
+                            Max = 10
+                        }
+                    }
+                }
+            };
+
+            ValidationFailedException exception = null;
+
+            // ACT
+            try
+            {
+                optionSettingItem.SetValueOverride(invalidValue);
+            }
+            catch (ValidationFailedException e)
+            {
+                exception = e;
+            }
+
+            exception.ShouldNotBeNull();
+
+            _output.WriteLine(exception.ValidationResult.ValidationFailedMessage);
+        }
+
+        [Fact]
+        public void InvalidInputInSingleValidatorThrowsException()
+        {
+            var invalidValue = "lowercase_only";
+            var optionSettingItem = new OptionSettingItem
+            {
+                Validators = new()
+                {
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Regex,
+                        Configuration = new RegexValidator
+                        {
+                            Regex = "^[A-Z]*$"
+                        }
+                    }
+                }
+            };
+
+            ValidationFailedException exception = null;
+
+            // ACT
+            try
+            {
+                optionSettingItem.SetValueOverride(invalidValue);
+            }
+            catch (ValidationFailedException e)
+            {
+                exception = e;
+            }
+
+            exception.ShouldNotBeNull();
+            exception.ValidationResult.ValidationFailedMessage.ShouldContain("[A-Z]*");
+
+        }
+
+        [Fact]
+        public void ValidInputDoesNotThrowException()
+        {
+            var validValue = 8;
+
+            var optionSettingItem = new OptionSettingItem
+            {
+                Validators = new()
+                {
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Range,
+                        Configuration = new RangeValidator
+                        {
+                            Min = 7,
+                            Max = 10
+                        }
+                    },
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Required
+                    }
+                }
+            };
+
+            ValidationFailedException exception = null;
+
+            // ACT
+            try
+            {
+                optionSettingItem.SetValueOverride(validValue);
+            }
+            catch (ValidationFailedException e)
+            {
+                exception = e;
+            }
+
+            exception.ShouldBeNull();
+        }
+
+        
+        /// <remarks>
+        /// This tests a decent amount of plumbing for a unit test, but
+        /// helps tests several important concepts.
+        /// </remarks>
+        [Fact]
+        public void CustomValidatorMessagePropagatesToValidationException()
+        {
+            // ARRANGE
+            var customValidationMessage = "Custom Validation Message: Testing!";
+            var invalidValue = 100;
+
+            var optionSettingItem = new OptionSettingItem
+            {
+                Validators = new()
+                {
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Range,
+                        Configuration = new RangeValidator
+                        {
+                            Min = 7,
+                            Max = 10,
+                            ValidationFailedMessage = customValidationMessage
+                        }
+                    }
+                }
+            };
+
+            ValidationFailedException exception = null;
+
+            // ACT
+            try
+            {
+                optionSettingItem.SetValueOverride(invalidValue);
+            }
+            catch (ValidationFailedException e)
+            {
+                exception = e;
+            }
+
+            exception.ShouldNotBeNull();
+            exception.ValidationResult.ValidationFailedMessage.ShouldEqual(customValidationMessage);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
@@ -1,0 +1,178 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.Runtime.Internal;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using Newtonsoft.Json;
+using Should;
+using Xunit;
+
+// Justification: False Positives with assertions, also test class
+// ReSharper disable PossibleNullReferenceException
+
+namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
+{
+    /// <summary>
+    /// Tests for <see cref="ValidatorFactory"/>
+    /// </summary>
+    public class ValidatorFactoryTests
+    {
+        [Fact]
+        public void HasABindingForAllOptionSettingItemValidators()
+        {
+            // ARRANGE
+            var allValidators = Enum.GetValues(typeof(OptionSettingItemValidatorList));
+
+            var optionSettingItem = new OptionSettingItem
+            {
+                Validators =
+                    allValidators
+                        .Cast<OptionSettingItemValidatorList>()
+                        .Select(validatorType =>
+                            new OptionSettingItemValidatorConfig
+                            {
+                                ValidatorType = validatorType
+                            }
+                        )
+                        .ToList()
+            };
+
+            // ACT
+            var validators = optionSettingItem.BuildValidators();
+
+            // ASSERT
+            validators.Length.ShouldEqual(allValidators.Length);
+        }
+
+        [Fact]
+        public void HasABindingForAllRecipeValidators()
+        {
+            // ARRANGE
+            var allValidators = Enum.GetValues(typeof(RecipeValidatorList));
+
+            var recipeDefinition = new RecipeDefinition
+            {
+                Validators =
+                    allValidators
+                        .Cast<RecipeValidatorList>()
+                        .Select(validatorType =>
+                            new RecipeValidatorConfig
+                            {
+                                ValidatorType = validatorType
+                            }
+                        )
+                        .ToList()
+            };
+
+            // ACT
+            var validators = recipeDefinition.BuildValidators();
+
+            // ASSERT
+            validators.Length.ShouldEqual(allValidators.Length);
+        }
+
+        /// <summary>
+        /// Make sure we build correctly when coming from json
+        /// </summary>
+        [Fact]
+        public void CanBuildRehydratedOptionSettingsItem()
+        {
+            // ARRANGE
+            var expectedValidator = new RequiredValidator
+            {
+                ValidationFailedMessage = "Custom Test Message"
+            };
+
+            var optionSettingItem = new OptionSettingItem
+            {
+                Name = "Test Item",
+                Validators = new List<OptionSettingItemValidatorConfig>
+                {
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Required,
+                        Configuration = expectedValidator
+                    }
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(optionSettingItem, Formatting.Indented);
+
+            var deserialized = JsonConvert.DeserializeObject<OptionSettingItem>(json);
+
+            // ACT
+            var validators = deserialized.BuildValidators();
+
+            // ASSERT
+            validators.Length.ShouldEqual(1);
+            validators.First().ShouldBeType(expectedValidator.GetType());
+            validators.OfType<RequiredValidator>().First().ValidationFailedMessage.ShouldEqual(expectedValidator.ValidationFailedMessage);
+        }
+
+        /// <summary>
+        /// This tests captures the behavior of the system.  Requirements for this area are a little unclear
+        /// and can be adjusted as needed.  This test is not meant to show 'ideal' behavior; only 'current'
+        /// behavior.
+        /// <para />
+        /// This test behavior is dependent on using intermediary json.  If you just
+        /// used a fully populated <see cref="OptionSettingItem"/>, this test would behave differently.
+        /// Coming from json, <see cref="OptionSettingItemValidatorConfig.ValidatorType"/> wins,
+        /// coming from object model <see cref="OptionSettingItemValidatorConfig.Configuration"/> wins.
+        /// </summary>
+        [Fact]
+        public void WhenValidatorTypeAndConfigurationHaveAMismatchThenValidatorTypeWins()
+        {
+            // ARRANGE
+            var optionSettingItem = new OptionSettingItem
+            {
+                Name = "Test Item",
+                Validators = new List<OptionSettingItemValidatorConfig>
+                {
+                    new OptionSettingItemValidatorConfig
+                    {
+                        ValidatorType = OptionSettingItemValidatorList.Regex,
+                        // Required can only map to RequiredValidator, this setup doesn't make sense:
+                        Configuration = new RangeValidator
+                        {
+                            Min = 1
+                        }
+                    }
+                }
+            };
+            
+            var json = JsonConvert.SerializeObject(optionSettingItem, Formatting.Indented);
+
+            var deserialized = JsonConvert.DeserializeObject<OptionSettingItem>(json);
+
+            Exception exception = null;
+            IOptionSettingItemValidator[] validators = null;
+
+            // ACT
+            try
+            {
+                validators = deserialized.BuildValidators();
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // ASSERT
+            exception.ShouldBeNull();
+
+            // we have our built validator
+            validators.ShouldNotBeNull();
+            validators.Length.ShouldEqual(1);
+
+            // things get a little odd, the type is correct,
+            // but the output messages is going to be from the RangeValidator.
+            validators.First().ShouldBeType<RegexValidator>();
+            validators.OfType<RegexValidator>().First().ValidationFailedMessage.ShouldEqual(
+                new RangeValidator().ValidationFailedMessage);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
+using System.Net.Http;
 using Should;
 using AWS.Deploy.Common;
 using Xunit;


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4952

*Description of changes:*



Need a mechanism to indicate an `OptionSettingItem` is required (ie non empty value) or has additional input validations.

**Progress:**
 - [x] Initial Design Review
 - [x] Initial Implementation
 - [ ] Update Design Doc with changes: 
    - Use enum instead of serializing `$type`
    -  Support validation based on other Items or Context (ie target Region)
    - Section on how to add new Validator
 - [x] Update Implementation to add support for entire Recipe Validation
 - [x] Update Implementation to change serialization strategy to use ValidatorList enums
 - [x] Unit Tests Option Settings Validation
 - [x] Unit Test Validator Factory / Json Deserialization
 - [ ] Unit Test Recipe Validation
 - [ ] Update `aws-deploy-recipe-schema.json`
 - [ ] Update recipe files to use Validators
 - [ ] Member documentation (marked with `/// TODO`)

![image](https://user-images.githubusercontent.com/1190907/113637338-301d8a80-9629-11eb-9689-caa8d44780e7.png)

![image](https://user-images.githubusercontent.com/1190907/113637394-5ba07500-9629-11eb-826a-17b98e747526.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
