### PR TITLE
Adding a check to see if an AllowedValue has an entry in the ValueMap…

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -334,7 +334,7 @@ namespace AWS.Deploy.CLI.Commands
             {
                 var userInputConfig = new UserInputConfiguration<string>
                 {
-                    DisplaySelector = x => setting.ValueMapping[x],
+                    DisplaySelector = x => setting.ValueMapping.ContainsKey(x) ? setting.ValueMapping[x] : x,
                     DefaultSelector = x => x.Equals(currentValue),
                     CreateNew = false
                 };


### PR DESCRIPTION
*Issue #, if available:*
#172 

*Description of changes:*
Added a one-line change to check if there is an entry in the ValueMapping for an AllowedValue before assigning to the DisplaySelector, in order to avoid key errors - if a value isn't found fall back onto the AllowedValue string instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
