### PR TITLE
chore: move CDKManager dependency out of OrchestratorSession

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -12,6 +12,7 @@ using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.DockerEngine;
 using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Recipes;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
@@ -23,6 +24,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
         private readonly ICdkProjectHandler _cdkProjectHandler;
+        private readonly ICDKManager _cdkManager;
         private readonly IDeploymentBundleHandler _deploymentBundleHandler;
         private readonly IDockerEngine _dockerEngine;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
@@ -38,6 +40,7 @@ namespace AWS.Deploy.CLI.Commands
             IToolInteractiveService toolInteractiveService,
             IOrchestratorInteractiveService orchestratorInteractiveService,
             ICdkProjectHandler cdkProjectHandler,
+            ICDKManager cdkManager,
             IDeploymentBundleHandler deploymentBundleHandler,
             IDockerEngine dockerEngine,
             IAWSResourceQueryer awsResourceQueryer,
@@ -60,6 +63,7 @@ namespace AWS.Deploy.CLI.Commands
             _cloudApplicationNameGenerator = cloudApplicationNameGenerator;
             _consoleUtilities = consoleUtilities;
             _session = session;
+            _cdkManager = cdkManager;
         }
 
         public async Task ExecuteAsync(string stackName, bool saveCdkProject)
@@ -69,6 +73,7 @@ namespace AWS.Deploy.CLI.Commands
                     _session,
                     _orchestratorInteractiveService,
                     _cdkProjectHandler,
+                    _cdkManager,
                     _awsResourceQueryer,
                     _deploymentBundleHandler,
                     _dockerEngine,

--- a/src/AWS.Deploy.CLI/Program.cs
+++ b/src/AWS.Deploy.CLI/Program.cs
@@ -107,8 +107,7 @@ namespace AWS.Deploy.CLI
                         AWSRegion = awsRegion,
                         AWSAccountId = callerIdentity.Account,
                         ProjectDefinition = projectDefinition,
-                        SystemCapabilities = systemCapabilities,
-                        CdkManager = cdkManager
+                        SystemCapabilities = systemCapabilities
                     };
 
                     var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory);
@@ -119,6 +118,7 @@ namespace AWS.Deploy.CLI
                         toolInteractiveService,
                         orchestratorInteractiveService,
                         new CdkProjectHandler(orchestratorInteractiveService, commandLineWrapper),
+                        cdkManager,
                         new DeploymentBundleHandler(commandLineWrapper, awsResourceQueryer, orchestratorInteractiveService, directoryManager, zipFileManager),
                         new DockerEngine.DockerEngine(projectDefinition),
                         awsResourceQueryer,

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -20,6 +20,7 @@ namespace AWS.Deploy.Orchestration
         private const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
 
         private readonly ICdkProjectHandler _cdkProjectHandler;
+        private readonly ICDKManager _cdkManager;
         private readonly IOrchestratorInteractiveService _interactiveService;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
         private readonly IDeploymentBundleHandler _deploymentBundleHandler;
@@ -32,6 +33,7 @@ namespace AWS.Deploy.Orchestration
             OrchestratorSession session,
             IOrchestratorInteractiveService interactiveService,
             ICdkProjectHandler cdkProjectHandler,
+            ICDKManager cdkManager,
             IAWSResourceQueryer awsResourceQueryer,
             IDeploymentBundleHandler deploymentBundleHandler,
             IDockerEngine dockerEngine,
@@ -40,6 +42,7 @@ namespace AWS.Deploy.Orchestration
             _session = session;
             _interactiveService = interactiveService;
             _cdkProjectHandler = cdkProjectHandler;
+            _cdkManager = cdkManager;
             _awsResourceQueryer = awsResourceQueryer;
             _deploymentBundleHandler = deploymentBundleHandler;
             _dockerEngine = dockerEngine;
@@ -71,7 +74,7 @@ namespace AWS.Deploy.Orchestration
             if (recommendation.Recipe.DeploymentType == DeploymentTypes.CdkProject)
             {
                 _interactiveService.LogMessageLine("AWS CDK is being configured.");
-                await _session.CdkManager.EnsureCompatibleCDKExists(CDKConstants.DeployToolWorkspaceDirectoryRoot, CDKConstants.MinimumCDKVersion);
+                await _cdkManager.EnsureCompatibleCDKExists(CDKConstants.DeployToolWorkspaceDirectoryRoot, CDKConstants.MinimumCDKVersion);
             }
 
             switch (recommendation.Recipe.DeploymentType)

--- a/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
+++ b/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using AWS.Deploy.Common;
-using AWS.Deploy.Orchestration.CDK;
 
 namespace AWS.Deploy.Orchestration
 {
@@ -22,6 +21,5 @@ namespace AWS.Deploy.Orchestration
         /// </remarks>
         public Task<SystemCapabilities> SystemCapabilities { get; set; }
         public string AWSAccountId { get; set; }
-        public CDKManager CdkManager { get; set; }
     }
 }


### PR DESCRIPTION
*Description of changes:*

**Non Functional Change**

`CDKManager` is a dependency used by `Orchestrator`.  Moved it out of `OrchestratorSession`, which is meant to model session state, and constructor injected through `DeployCommand` and into `Orchestrator`

![image](https://user-images.githubusercontent.com/1190907/113523430-6f31da00-955c-11eb-8966-5020efbe4a3a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
