### PR TITLE
Feature/recipe info user agent metric

### DIFF
--- a/src/AWS.Deploy.CLI/Program.cs
+++ b/src/AWS.Deploy.CLI/Program.cs
@@ -222,7 +222,6 @@ namespace AWS.Deploy.CLI
         /// </summary>
         private static void SetExecutionEnvironment()
         {
-            const string envName = "AWS_EXECUTION_ENV";
             const string awsDotnetDeployCLI = "aws-dotnet-deploy-cli";
 
             var assemblyVersion = typeof(Program).Assembly
@@ -233,14 +232,14 @@ namespace AWS.Deploy.CLI
             var envValue = new StringBuilder();
 
             // If there is an existing execution environment variable add this tool as a suffix.
-            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envName)))
+            if(!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableKeys.AWS_EXECUTION_ENV)))
             {
-                envValue.Append($"{Environment.GetEnvironmentVariable(envName)}_");
+                envValue.Append($"{Environment.GetEnvironmentVariable(EnvironmentVariableKeys.AWS_EXECUTION_ENV)}_");
             }
 
             envValue.Append($"{awsDotnetDeployCLI}_{assemblyVersion?.InformationalVersion}");
 
-            Environment.SetEnvironmentVariable(envName, envValue.ToString());
+            Environment.SetEnvironmentVariable(EnvironmentVariableKeys.AWS_EXECUTION_ENV, envValue.ToString());
         }
     }
 }

--- a/src/AWS.Deploy.Common/EnvironmentVariableKeys.cs
+++ b/src/AWS.Deploy.Common/EnvironmentVariableKeys.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common
+{
+    /// <summary>
+    /// Contains shared environment variable keys
+    /// </summary>
+    public static class EnvironmentVariableKeys
+    {
+        public const string AWS_EXECUTION_ENV = "AWS_EXECUTION_ENV";
+    }
+}

--- a/src/AWS.Deploy.Orchestration/Utilities/ICommandLineWrapper.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/ICommandLineWrapper.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +33,14 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// By default, <see cref="Process.StandardInput"/>, <see cref="Process.StandardOutput"/> and <see cref="Process.StandardError"/> will be redirected.
         /// Set this to false to avoid redirection.
         /// </param>
+        /// <param name="environmentVariables">
+        /// <see cref="command"/> is executed as a child process of running process which inherits the parent process's environment variables.
+        /// <see cref="environmentVariables"/> allows to add (replace if exists) extra environment variables to the child process.
+        /// <remarks>
+        /// AWS Execution Environment string to append in AWS_EXECUTION_ENV env var.
+        /// AWS SDK calls made while executing <see cref="command"/> will have User-Agent string containing
+        /// </remarks>
+        /// </param>
         /// <param name="cancelToken">
         /// <see cref="CancellationToken"/>
         /// </param>
@@ -41,6 +50,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             bool streamOutputToInteractiveService = true,
             Action<TryRunResult> onComplete = null,
             bool redirectIO = true,
+            IDictionary<string, string> environmentVariables = null,
             CancellationToken cancelToken = default);
     }
 
@@ -69,6 +79,14 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// By default, <see cref="Process.StandardInput"/>, <see cref="Process.StandardOutput"/> and <see cref="Process.StandardError"/> will be redirected.
         /// Set this to false to avoid redirection.
         /// </param>
+        /// <param name="environmentVariables">
+        /// <see cref="command"/> is executed as a child process of running process which inherits the parent process's environment variables.
+        /// <see cref="environmentVariables"/> allows to add (replace if exists) extra environment variables to the child process.
+        /// <remarks>
+        /// AWS Execution Environment string to append in AWS_EXECUTION_ENV env var.
+        /// AWS SDK calls made while executing <see cref="command"/> will have User-Agent string containing
+        /// </remarks>
+        /// </param>
         /// <param name="cancelToken">
         /// <see cref="CancellationToken"/>
         /// </param>
@@ -78,6 +96,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             string workingDirectory = "",
             bool streamOutputToInteractiveService = false,
             bool redirectIO = true,
+            IDictionary<string, string> environmentVariables = null,
             CancellationToken cancelToken = default)
         {
             var result = new TryRunResult();
@@ -88,7 +107,8 @@ namespace AWS.Deploy.Orchestration.Utilities
                 streamOutputToInteractiveService,
                 onComplete: runResult => result = runResult,
                 redirectIO: redirectIO,
-                cancelToken);
+                environmentVariables: environmentVariables,
+                cancelToken: cancelToken);
 
             return result;
         }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolCommandLineWrapper.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolCommandLineWrapper.cs
@@ -49,7 +49,14 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
     {
         public List<CommandLineRunObject> CommandsToExecute = new List<CommandLineRunObject>();
 
-        public Task Run(string command, string workingDirectory = "", bool streamOutputToInteractiveService = true, Action<TryRunResult> onComplete = null, bool redirectIO = true, CancellationToken cancelToken = default)
+        public Task Run(
+            string command,
+            string workingDirectory = "",
+            bool streamOutputToInteractiveService = true,
+            Action<TryRunResult> onComplete = null,
+            bool redirectIO = true,
+            IDictionary<string, string> environmentVariables = null,
+            CancellationToken cancelToken = default)
         {
             CommandsToExecute.Add(new CommandLineRunObject
             {

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestCommandLineWrapper.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestCommandLineWrapper.cs
@@ -21,6 +21,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
             bool streamOutputToInteractiveService = true,
             Action<TryRunResult> onComplete = null,
             bool redirectIO = true,
+            IDictionary<string, string> environmentVariables = null,
             CancellationToken cancelToken = default)
         {
             Commands.Add((command, workingDirectory, streamOutputToInteractiveService));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`AWS_EXECUTION_ENV` value for a Beanstalk deployment: `aws-dotnet-deploy-cli_0.4.2_AspNetAppElasticBeanstalkLinux_0.1.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
