### PR TITLE
Add support for profiles that are configured for MFA

### DIFF
--- a/src/AWS.Deploy.CLI/ConsoleInteractiveServiceImpl.cs
+++ b/src/AWS.Deploy.CLI/ConsoleInteractiveServiceImpl.cs
@@ -46,5 +46,15 @@ namespace AWS.Deploy.CLI
         {
             Console.WriteLine(message);
         }
+
+        public void Write(string message)
+        {
+            Console.Write(message);
+        }
+
+        public ConsoleKeyInfo ReadKey(bool intercept)
+        {
+            return Console.ReadKey(intercept);
+        }
     }
 }

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using AWS.Deploy.Common;
 
 namespace AWS.Deploy.CLI
@@ -432,6 +433,35 @@ namespace AWS.Deploy.CLI
 
                 _interactiveService.WriteLine($"Invalid option. The selected option should be between 1 and {options.Count}.");
             }
+        }
+
+        public string ReadSecretFromConsole()
+        {
+            var code = new StringBuilder();
+            while (true)
+            {
+                ConsoleKeyInfo i = _interactiveService.ReadKey(true);
+                if (i.Key == ConsoleKey.Enter)
+                {
+                    break;
+                }
+                else if (i.Key == ConsoleKey.Backspace)
+                {
+                    if (code.Length > 0)
+                    {
+                        code.Remove(code.Length - 1, 1);
+                        _interactiveService.Write("\b \b");
+                    }
+                }
+                // i.Key > 31: Skip the initial ascii control characters like ESC and tab. The space character is 32.
+                // KeyChar == '\u0000' if the key pressed does not correspond to a printable character, e.g. F1, Pause-Break, etc
+                else if ((int)i.Key > 31 && i.KeyChar != '\u0000')
+                {
+                    code.Append(i.KeyChar);
+                    _interactiveService.Write("*");
+                }
+            }
+            return code.ToString().Trim();
         }
     }
 }

--- a/src/AWS.Deploy.CLI/IToolInteractiveService.cs
+++ b/src/AWS.Deploy.CLI/IToolInteractiveService.cs
@@ -1,16 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace AWS.Deploy.CLI
 {
     public interface IToolInteractiveService
     {
+        void Write(string message);
         void WriteLine(string message);
         void WriteDebugLine(string message);
         void WriteErrorLine(string message);
 
         string ReadLine();
         bool Diagnostics { get; set; }
+        ConsoleKeyInfo ReadKey(bool intercept);
     }
 
     public static class ToolInteractiveServiceExtensions

--- a/src/AWS.Deploy.CLI/Utilities/AssumeRoleMfaTokenCodeCallback.cs
+++ b/src/AWS.Deploy.CLI/Utilities/AssumeRoleMfaTokenCodeCallback.cs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Amazon.Runtime;
+
+namespace AWS.Deploy.CLI.Utilities
+{
+    /// <summary>
+    /// Handle the callback from AWSCredentials when an MFA token code is required.
+    /// </summary>
+    internal class AssumeRoleMfaTokenCodeCallback
+    {
+        private readonly AssumeRoleAWSCredentialsOptions _options;
+        private readonly IToolInteractiveService _toolInteractiveService;
+
+        internal AssumeRoleMfaTokenCodeCallback(IToolInteractiveService toolInteractiveService, AssumeRoleAWSCredentialsOptions options)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _options = options;
+        }
+
+        internal string Execute()
+        {
+            _toolInteractiveService.WriteLine();
+            _toolInteractiveService.WriteLine($"Enter MFA code for {_options.MfaSerialNumber}: ");
+            var consoleUtilites = new ConsoleUtilities(_toolInteractiveService);
+            var code = consoleUtilites.ReadSecretFromConsole();
+            
+            return code;
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/TestToolInteractiveServiceImpl.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TestToolInteractiveServiceImpl.cs
@@ -66,5 +66,30 @@ namespace AWS.Deploy.CLI.UnitTests
 
             return false;
         }
+
+        public void Write(string message)
+        {
+            OutputMessages.Add(message);
+        }
+
+        public void QueueConsoleInfos(params ConsoleKey[] keys)
+        {
+            foreach(var key in keys)
+            {
+                InputConsoleKeyInfos.Enqueue(new ConsoleKeyInfo(key.ToString()[0], key, false, false, false));
+            }
+        }
+
+        public Queue<ConsoleKeyInfo> InputConsoleKeyInfos { get; } = new Queue<ConsoleKeyInfo>();
+        public ConsoleKeyInfo ReadKey(bool intercept)
+        {
+            if(InputConsoleKeyInfos.Count == 0)
+            {
+                throw new Exception("No queued console key infos");
+            }
+
+            return InputConsoleKeyInfos.Dequeue();
+        }
     }
 }
+


### PR DESCRIPTION
*Description of changes:*
Hook up a callback to the AssumeRoleAWSCredentials object for the user to enter an MFA token. This is a port for the MFA support in Amazon.Lambda.Tools.

![MFAExperience](https://user-images.githubusercontent.com/1653751/114634450-65545900-9c77-11eb-9b55-2a1a38239286.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Closes #141 
