### PR TITLE
chore: Treat all warnings as errors

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -16,6 +16,7 @@
     <LangVersion>Latest</LangVersion>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/aws/aws-dotnet-deploy</PackageProjectUrl>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -5,6 +5,7 @@
     <LangVersion>Latest</LangVersion>
     <AssemblyName>AWS.Deploy.Common</AssemblyName>
     <RootNamespace>AWS.Deploy.Common</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.DockerEngine/AWS.Deploy.DockerEngine.csproj
+++ b/src/AWS.Deploy.DockerEngine/AWS.Deploy.DockerEngine.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>AWS.Deploy.DockerEngine</RootNamespace>
     <AssemblyName>AWS.Deploy.DockerEngine</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -5,6 +5,7 @@
     <LangVersion>Latest</LangVersion>
     <AssemblyName>AWS.Deploy.Orchestration</AssemblyName>
     <RootNamespace>AWS.Deploy.Orchestration</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -10,6 +10,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/aws/aws-dotnet-deploy</PackageProjectUrl>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Recipes/AWS.Deploy.Recipes.csproj
+++ b/src/AWS.Deploy.Recipes/AWS.Deploy.Recipes.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AWS.Deploy.Recipes</AssemblyName>
     <RootNamespace>AWS.Deploy.Recipes</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds the TreatWarningsAsErrors property to all projects located at ..\aws-dotnet-deploy\src
https://sim.amazon.com/issues/DOTNET-5004