### PR TITLE
feat: add integration tests for Blazor, ECS Fargate (Service & Scheduled Task) and WebApps (Beanstalk and ECS Fargate Service)

### DIFF
--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -56,6 +56,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ContosoUniversity", "testap
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ContosoUniversityBackendService", "testapps\ContosoUniversityBackendService\ContosoUniversityBackendService.csproj", "{AC7B0880-00CB-41E0-996C-B4C99103CEF9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Deploy.CLI.IntegrationTests", "test\AWS.Deploy.CLI.IntegrationTests\AWS.Deploy.CLI.IntegrationTests.csproj", "{001A0CE1-CCCE-4006-8CAC-AD18E37060A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -134,6 +136,10 @@ Global
 		{AC7B0880-00CB-41E0-996C-B4C99103CEF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC7B0880-00CB-41E0-996C-B4C99103CEF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC7B0880-00CB-41E0-996C-B4C99103CEF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{001A0CE1-CCCE-4006-8CAC-AD18E37060A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{001A0CE1-CCCE-4006-8CAC-AD18E37060A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{001A0CE1-CCCE-4006-8CAC-AD18E37060A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{001A0CE1-CCCE-4006-8CAC-AD18E37060A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -158,6 +164,7 @@ Global
 		{4AD9D400-3F3D-4076-B34C-0F88576C1889} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 		{6EDCA334-3317-44A4-A017-2A8D810EE7A7} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
 		{AC7B0880-00CB-41E0-996C-B4C99103CEF9} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
+		{001A0CE1-CCCE-4006-8CAC-AD18E37060A3} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.79" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Deploy.CLI\AWS.Deploy.CLI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\testapps\**\*">
+      <Link>testapps\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Remove="..\..\testapps\**\bin\**" />
+    <None Remove="..\..\testapps\**\obj\**" />
+    <None Remove="..\..\testapps\**\docker\**\*" />
+  </ItemGroup>
+
+</Project>

--- a/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static System.Net.WebRequestMethods;
+
+namespace AWS.Deploy.CLI.IntegrationTests
+{
+    [Collection("Serial")]
+    public class BlazorWasmTests : IDisposable
+    {
+        private readonly HttpHelper _httpHelper;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly InMemoryInteractiveService _interactiveService;
+        private readonly App _app;
+        private string _stackName;
+        private bool _isDisposed;
+
+        public BlazorWasmTests()
+        {
+            _httpHelper = new HttpHelper();
+
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _app = serviceProvider.GetService<App>();
+            Assert.NotNull(_app);
+
+            _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
+            Assert.NotNull(_interactiveService);
+        }
+
+        [Theory]
+        [InlineData("testapps", "BlazorWasm31", "BlazorWasm31.csproj")]
+        [InlineData("testapps", "BlazorWasm50", "BlazorWasm50.csproj")]
+        public async Task DefaultConfigurations(params string[] components)
+        {
+            _stackName = $"{components[1]}{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            // Arrange input for deploy
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default option settings
+            await _interactiveService.StdInWriter.WriteAsync("y"); // Blazor webassembly confirmation
+            await _interactiveService.StdInWriter.FlushAsync();
+
+            // Deploy
+            var deployArgs = new[] { "deploy", "--project-path", Path.Combine(components), "--stack-name", _stackName };
+            await _app.Run(deployArgs);
+
+            // Verify application is deployed and running
+            Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+            var deployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+
+            // Example URL string: BlazorWasm5068e7a879d5ee.EndpointURL = http://blazorwasm5068e7a879d5ee-blazorhostc7106839-a2585dcq9xve.s3-website-us-west-2.amazonaws.com/
+            var applicationUrl = deployStdOut.First(line => line.StartsWith($"{_stackName}.EndpointURL"))
+                .Split("=")[1]
+                .Trim();
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _httpHelper.WaitUntilSuccessStatusCode(applicationUrl, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            // Arrange input for delete
+            await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
+            await _interactiveService.StdInWriter.FlushAsync();
+            var deleteArgs = new[] { "delete-deployment", _stackName };
+
+            // Delete
+            await _app.Run(deleteArgs);
+
+            // Verify application is delete
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                if (!isStackDeleted)
+                {
+                    _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~BlazorWasmTests()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudWatchLogs;
+using Amazon.ECS;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests
+{
+    [Collection("Serial")]
+    public class ConsoleAppTests : IDisposable
+    {
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly ECSHelper _ecsHelper;
+        private readonly CloudWatchLogsHelper _cloudWatchLogsHelper;
+        private readonly App _app;
+        private readonly InMemoryInteractiveService _interactiveService;
+        private bool _isDisposed;
+        private string _stackName;
+
+        public ConsoleAppTests()
+        {
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            var ecsClient = new AmazonECSClient();
+            _ecsHelper = new ECSHelper(ecsClient);
+
+            var cloudWatchLogsClient = new AmazonCloudWatchLogsClient();
+            _cloudWatchLogsHelper = new CloudWatchLogsHelper(cloudWatchLogsClient);
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _app = serviceProvider.GetService<App>();
+            Assert.NotNull(_app);
+
+            _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
+            Assert.NotNull(_interactiveService);
+        }
+
+        [Theory]
+        [InlineData("testapps", "ConsoleAppService", "ConsoleAppService.csproj")]
+        [InlineData("testapps", "ConsoleAppTask", "ConsoleAppTask.csproj")]
+        public async Task DefaultConfigurations(params string[] components)
+        {
+            _stackName = $"{components[1]}{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            // Arrange input for deploy
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default option settings
+            await _interactiveService.StdInWriter.FlushAsync();
+
+            // Deploy
+            var deployArgs = new[] { "deploy", "--project-path", Path.Combine(components), "--stack-name", _stackName };
+            await _app.Run(deployArgs);
+
+            // Verify application is deployed and running
+            Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+            var cluster = await _ecsHelper.GetCluster(_stackName);
+            Assert.Equal("ACTIVE", cluster.Status);
+
+            // Verify CloudWatch logs
+            var logGroup = await _ecsHelper.GetLogGroup(_stackName);
+            var logMessages = await _cloudWatchLogsHelper.GetLogMessages(logGroup);
+            Assert.Contains("Hello World!", logMessages);
+
+            // Arrange input for delete
+            await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
+            await _interactiveService.StdInWriter.FlushAsync();
+            var deleteArgs = new[] { "delete-deployment", _stackName };
+
+            // Delete
+            await _app.Run(deleteArgs);
+
+            // Verify application is delete
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                if (!isStackDeleted)
+                {
+                    _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~ConsoleAppTests()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Extensions/ReadAllLinesStreamReaderExtension.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Extensions/ReadAllLinesStreamReaderExtension.cs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Extensions
+{
+    public static class ReadAllLinesStreamReaderExtension
+    {
+        /// <summary>
+        /// Reads all lines of the stream into a string list
+        /// </summary>
+        /// <param name="reader">Reader that allows line by line reading</param>
+        /// <returns>Read lines</returns>
+        public static IEnumerable<string> ReadAllLines(this StreamReader reader)
+        {
+            var lines = new List<string>();
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                lines.Add(line);
+            }
+
+            return lines;
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Extensions/TestServiceCollectionExtension.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Extensions/TestServiceCollectionExtension.cs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.CLI.Commands;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using AWS.Deploy.CLI.Utilities;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Extensions;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.CDK;
+using AWS.Deploy.Orchestration.Data;
+using AWS.Deploy.Orchestration.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Extensions
+{
+    public static class TestServiceCollectionExtension
+    {
+        /// <summary>
+        /// Extension method for <see cref="IServiceCollection"/> that injects essential app dependencies for testing.
+        /// </summary>
+        /// <param name="serviceCollection"><see cref="IServiceCollection"/> instance that holds the app dependencies.</param>
+        public static void AddTestServices(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton<InMemoryInteractiveService>();
+            serviceCollection.AddSingleton<IToolInteractiveService>(serviceProvider => serviceProvider.GetService<InMemoryInteractiveService>());
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudFormationHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudFormationHelper.cs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class CloudFormationHelper
+    {
+        private readonly IAmazonCloudFormation _cloudFormationClient;
+
+        public CloudFormationHelper(IAmazonCloudFormation cloudFormationClient)
+        {
+            _cloudFormationClient = cloudFormationClient;
+        }
+
+        public async Task<StackStatus> GetStackStatus(string stackName)
+        {
+            var stack = await GetStackAsync(stackName);
+            return stack.StackStatus;
+        }
+
+        public async Task<bool> IsStackDeleted(string stackName)
+        {
+            try
+            {
+                await GetStackAsync(stackName);
+            }
+            catch (AmazonCloudFormationException cloudFormationException) when (cloudFormationException.Message.Equals($"Stack with id {stackName} does not exist"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task DeleteStack(string stackName)
+        {
+            var request = new DeleteStackRequest()
+            {
+                StackName = stackName
+            };
+
+            await _cloudFormationClient.DeleteStackAsync(request);
+        }
+
+        private async Task<Stack> GetStackAsync(string stackName)
+        {
+            var response = await _cloudFormationClient.DescribeStacksAsync(new DescribeStacksRequest
+            {
+                StackName = stackName
+            });
+
+            return response.Stacks.Count == 0 ? null : response.Stacks[0];
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudWatchLogsHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudWatchLogsHelper.cs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudWatchLogs;
+using Amazon.CloudWatchLogs.Model;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class CloudWatchLogsHelper
+    {
+        private readonly IAmazonCloudWatchLogs _client;
+
+        public CloudWatchLogsHelper(IAmazonCloudWatchLogs client)
+        {
+            _client = client;
+        }
+
+        public async Task<IEnumerable<string>> GetLogMessages(string logGroup)
+        {
+            var logStream = await GetLatestLogStream(logGroup);
+            return await GetLogMessages(logGroup, logStream);
+        }
+
+        private async Task<IEnumerable<string>> GetLogMessages(string logGroup, string logStreamName)
+        {
+            var request = new GetLogEventsRequest
+            {
+                LogGroupName = logGroup,
+                LogStreamName = logStreamName
+            };
+            ;
+            var logMessages = new List<string>();
+
+            var listStacksPaginator = _client.Paginators.GetLogEvents(request);
+            await foreach (var response in listStacksPaginator.Responses)
+            {
+                // When there are no new events, Events list is returned empty.
+                // Therefore, we want to stop the paginator and return the response.
+                // Otherwise, paginator will end up in an infinite loop.
+                if (response.Events.Count == 0)
+                {
+                    break;
+                }
+
+                var messages = response.Events.Select(e => e.Message);
+                logMessages.AddRange(messages);
+            }
+
+            return logMessages;
+        }
+
+        private async Task<string> GetLatestLogStream(string logGroup)
+        {
+            var request = new DescribeLogStreamsRequest
+            {
+                LogGroupName = logGroup
+            };
+
+            var response = await _client.DescribeLogStreamsAsync(request);
+            return response.LogStreams.FirstOrDefault()?.LogStreamName;
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ECSHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ECSHelper.cs
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.ECS;
+using Amazon.ECS.Model;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class ECSHelper
+    {
+        private readonly IAmazonECS _client;
+
+        public ECSHelper(IAmazonECS client)
+        {
+            _client = client;
+        }
+
+        public async Task<string> GetLogGroup(string clusterName)
+        {
+            var taskDefinition = await GetTaskDefinition(clusterName);
+            return await GetAwsLogGroup(taskDefinition);
+        }
+
+        public async Task<Cluster> GetCluster(string clusterName)
+        {
+            var request = new DescribeClustersRequest
+            {
+                Clusters = new List<string>
+                {
+                    clusterName
+                }
+            };
+            var response = await _client.DescribeClustersAsync(request);
+            return response.Clusters.First();
+        }
+
+        private async Task<string> GetTaskDefinition(string clusterName)
+        {
+            var request = new ListTaskDefinitionsRequest();
+
+            var response = await _client.ListTaskDefinitionsAsync(request);
+            return response.TaskDefinitionArns.First(taskDefinitionArn =>
+            {
+                // Example: arn:aws:ecs:us-west-2:727033484140:task-definition/ConsoleAppServiceTaskDefinition6663F6FD:1
+                var taskDefinitionName = taskDefinitionArn.Split('/')[1];
+                return taskDefinitionName.StartsWith(clusterName);
+            });
+        }
+
+        private async Task<string> GetAwsLogGroup(string taskDefinition)
+        {
+            var request = new DescribeTaskDefinitionRequest
+            {
+                TaskDefinition = taskDefinition
+            };
+
+            var response = await _client.DescribeTaskDefinitionAsync(request);
+            var containerDefinition = response.TaskDefinition.ContainerDefinitions.First();
+            return containerDefinition.LogConfiguration.Options["awslogs-group"];
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/HttpHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/HttpHelper.cs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class HttpHelper
+    {
+        public async Task WaitUntilSuccessStatusCode(string url, TimeSpan frequency, TimeSpan timeout)
+        {
+            using var client = new HttpClient();
+
+            try
+            {
+                await WaitUntilHelper.WaitUntil(async () =>
+                {
+                    var httpResponseMessage = await client.GetAsync(url);
+                    return httpResponseMessage.IsSuccessStatusCode;
+                }, frequency, timeout);
+            }
+            catch (TimeoutException)
+            {
+                Assert.True(false, $"{url} URL is not reachable.");
+            }
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/WaitUntilHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/WaitUntilHelper.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public static class WaitUntilHelper
+    {
+        /// <summary>
+        /// Wait for <see cref="timeout"/> TimeSpan until <see cref="Predicate{T}"/> isn't satisfied
+        /// </summary>
+        /// <param name="predicate">Termination condition for breaking the wait loop</param>
+        /// <param name="frequency">Interval between the two executions of the task</param>
+        /// <param name="timeout">Interval for timeout, if timeout passes, methods throws <see cref="TimeoutException"/></param>
+        /// <exception cref="TimeoutException">Throws when timeout passes</exception>
+        public static async Task WaitUntil(Func<Task<bool>> predicate, TimeSpan frequency, TimeSpan timeout)
+        {
+            var waitTask = Task.Run(async () =>
+            {
+                while (!await predicate())
+                {
+                    await Task.Delay(frequency);
+                }
+            });
+
+            if (waitTask != await Task.WhenAny(waitTask, Task.Delay(timeout)))
+            {
+                throw new TimeoutException();
+            }
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveService.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveService.cs
@@ -47,6 +47,27 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             StdInWriter = new StreamWriter(stdIn);
         }
 
+        public void Write(string message)
+        {
+            Console.Write(message);
+            Debug.Write(message);
+
+            // Save BaseStream position, it must be only modified the consumer of StdOutReader
+            // After writing to the BaseStream, we will reset it to the original position.
+            var stdOutReaderPosition = StdOutReader.BaseStream.Position;
+
+            // Reset the BaseStream to the last save position to continue writing from where we left.
+            _stdOutWriter.BaseStream.Position = _stdOutWriterPosition;
+            _stdOutWriter.Write(message);
+            _stdOutWriter.Flush();
+
+            // Save the BaseStream position for future writes.
+            _stdOutWriterPosition = _stdOutWriter.BaseStream.Position;
+
+            // Reset the BaseStream position to the original position
+            StdOutReader.BaseStream.Position = stdOutReaderPosition;
+        }
+
         public void WriteLine(string message)
         {
             Console.WriteLine(message);
@@ -113,5 +134,27 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
         }
 
         public bool Diagnostics { get; set; }
+
+        public ConsoleKeyInfo ReadKey(bool intercept)
+        {
+            var stdInWriterPosition = StdInWriter.BaseStream.Position;
+
+            // Reset the BaseStream to the last save position to continue writing from where we left.
+            _stdInReader.BaseStream.Position = _stdInReaderPosition;
+
+            var keyChar = _stdInReader.Read();
+            var key = new ConsoleKeyInfo((char)keyChar, (ConsoleKey)keyChar, false, false, false);
+
+            // Save the BaseStream position for future reads.
+            _stdInReaderPosition = _stdInReader.BaseStream.Position;
+
+            // Reset the BaseStream position to the original position
+            StdInWriter.BaseStream.Position = stdInWriterPosition;
+
+            Console.WriteLine(key);
+            Debug.WriteLine(key);
+
+            return key;
+        }
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveService.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveService.cs
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Services
+{
+    public class InMemoryInteractiveService : IToolInteractiveService
+    {
+        private long _stdOutWriterPosition;
+        private long _stdErrorWriterPosition;
+        private long _stdInReaderPosition;
+        private readonly StreamWriter _stdOutWriter;
+        private readonly StreamWriter _stdErrorWriter;
+        private readonly StreamReader _stdInReader;
+
+        /// <summary>
+        /// Allows consumers to write string to the BaseStream
+        /// which will be returned on <see cref="ReadLine"/> method call.
+        /// </summary>
+        public StreamWriter StdInWriter { get; }
+
+        /// <summary>
+        /// Allows consumers to read string which are written via <see cref="WriteLine"/>
+        /// </summary>
+        public StreamReader StdOutReader { get; }
+
+        /// <summary>
+        /// Allows consumers to read string which are written via <see cref="WriteErrorLine"/>
+        /// </summary>
+        public StreamReader StdErrorReader { get; }
+
+        public InMemoryInteractiveService()
+        {
+            var stdOut = new MemoryStream();
+            _stdOutWriter = new StreamWriter(stdOut);
+            StdOutReader = new StreamReader(stdOut);
+
+            var stdError = new MemoryStream();
+            _stdErrorWriter = new StreamWriter(stdError);
+            StdErrorReader = new StreamReader(stdError);
+
+            var stdIn = new MemoryStream();
+            _stdInReader = new StreamReader(stdIn);
+            StdInWriter = new StreamWriter(stdIn);
+        }
+
+        public void WriteLine(string message)
+        {
+            Console.WriteLine(message);
+            Debug.WriteLine(message);
+
+            // Save BaseStream position, it must be only only modified the consumer of StdOutReader
+            // After writing to the BaseStream, we will reset it to the original position.
+            var stdOutReaderPosition = StdOutReader.BaseStream.Position;
+
+            // Reset the BaseStream to the last save position to continue writing from where we left.
+            _stdOutWriter.BaseStream.Position = _stdOutWriterPosition;
+            _stdOutWriter.WriteLine(message);
+            _stdOutWriter.Flush();
+
+            // Save the BaseStream position for future writes.
+            _stdOutWriterPosition = _stdOutWriter.BaseStream.Position;
+
+            // Reset the BaseStream position to the original position
+            StdOutReader.BaseStream.Position = stdOutReaderPosition;
+        }
+
+        public void WriteDebugLine(string message) => throw new System.NotImplementedException();
+
+        public void WriteErrorLine(string message)
+        {
+            Console.WriteLine(message);
+            Debug.WriteLine(message);
+
+            // Save BaseStream position, it must be only only modified the consumer of StdErrorReader
+            // After writing to the BaseStream, we will reset it to the original position.
+            var stdErrorReaderPosition = StdErrorReader.BaseStream.Position;
+
+            // Reset the BaseStream to the last save position to continue writing from where we left.
+            _stdErrorWriter.BaseStream.Position = _stdErrorWriterPosition;
+            _stdErrorWriter.WriteLine(message);
+            _stdErrorWriter.Flush();
+
+            // Save the BaseStream position for future writes.
+            _stdErrorWriterPosition = _stdErrorWriter.BaseStream.Position;
+
+            // Reset the BaseStream position to the original position
+            StdErrorReader.BaseStream.Position = stdErrorReaderPosition;
+        }
+
+        public string ReadLine()
+        {
+            var stdInWriterPosition = StdInWriter.BaseStream.Position;
+
+            // Reset the BaseStream to the last save position to continue writing from where we left.
+            _stdInReader.BaseStream.Position = _stdInReaderPosition;
+
+            var readLine = _stdInReader.ReadLine();
+
+            // Save the BaseStream position for future reads.
+            _stdInReaderPosition = _stdInReader.BaseStream.Position;
+
+            // Reset the BaseStream position to the original position
+            StdInWriter.BaseStream.Position = stdInWriterPosition;
+
+            Console.WriteLine(readLine);
+            Debug.WriteLine(readLine);
+
+            return readLine;
+        }
+
+        public bool Diagnostics { get; set; }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveService.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveService.cs
@@ -52,7 +52,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             Console.WriteLine(message);
             Debug.WriteLine(message);
 
-            // Save BaseStream position, it must be only only modified the consumer of StdOutReader
+            // Save BaseStream position, it must be only modified the consumer of StdOutReader
             // After writing to the BaseStream, we will reset it to the original position.
             var stdOutReaderPosition = StdOutReader.BaseStream.Position;
 
@@ -75,7 +75,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             Console.WriteLine(message);
             Debug.WriteLine(message);
 
-            // Save BaseStream position, it must be only only modified the consumer of StdErrorReader
+            // Save BaseStream position, it must be only modified the consumer of StdErrorReader
             // After writing to the BaseStream, we will reset it to the original position.
             var stdErrorReaderPosition = StdErrorReader.BaseStream.Position;
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Services
+{
+    public class InMemoryInteractiveServiceTests
+    {
+        [Fact]
+        public void WriteLine()
+        {
+            var service = new InMemoryInteractiveService();
+
+            service.WriteLine("Line 1");
+            service.WriteLine("Line 2");
+            service.WriteLine("Line 3");
+
+            Assert.Equal("Line 1", service.StdOutReader.ReadLine());
+            Assert.Equal("Line 2", service.StdOutReader.ReadLine());
+            Assert.Equal("Line 3", service.StdOutReader.ReadLine());
+
+            service.WriteLine("Line 4");
+            service.WriteLine("Line 5");
+            service.WriteLine("Line 6");
+
+            Assert.Equal("Line 4", service.StdOutReader.ReadLine());
+            Assert.Equal("Line 5", service.StdOutReader.ReadLine());
+            Assert.Equal("Line 6", service.StdOutReader.ReadLine());
+        }
+
+        [Fact]
+        public void WriteErrorLine()
+        {
+            var service = new InMemoryInteractiveService();
+
+            service.WriteErrorLine("Error Line 1");
+            service.WriteErrorLine("Error Line 2");
+            service.WriteErrorLine("Error Line 3");
+
+            Assert.Equal("Error Line 1", service.StdErrorReader.ReadLine());
+            Assert.Equal("Error Line 2", service.StdErrorReader.ReadLine());
+            Assert.Equal("Error Line 3", service.StdErrorReader.ReadLine());
+
+            service.WriteErrorLine("Error Line 4");
+            service.WriteErrorLine("Error Line 5");
+            service.WriteErrorLine("Error Line 6");
+
+            Assert.Equal("Error Line 4", service.StdErrorReader.ReadLine());
+            Assert.Equal("Error Line 5", service.StdErrorReader.ReadLine());
+            Assert.Equal("Error Line 6", service.StdErrorReader.ReadLine());
+        }
+
+        [Fact]
+        public void ReadLine()
+        {
+            var service = new InMemoryInteractiveService();
+
+            service.StdInWriter.WriteLine("Line 1");
+            service.StdInWriter.WriteLine("Line 2");
+            service.StdInWriter.WriteLine("Line 3");
+            service.StdInWriter.Flush();
+
+            Assert.Equal("Line 1", service.ReadLine());
+            Assert.Equal("Line 2", service.ReadLine());
+            Assert.Equal("Line 3", service.ReadLine());
+
+            service.StdInWriter.WriteLine("Line 4");
+            service.StdInWriter.WriteLine("Line 5");
+            service.StdInWriter.WriteLine("Line 6");
+            service.StdInWriter.Flush();
+
+            Assert.Equal("Line 4", service.ReadLine());
+            Assert.Equal("Line 5", service.ReadLine());
+            Assert.Equal("Line 6", service.ReadLine());
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
@@ -1,12 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Services
 {
     public class InMemoryInteractiveServiceTests
     {
+        [Fact]
+        public void Write()
+        {
+            var service = new InMemoryInteractiveService();
+
+            service.Write("Hello");
+
+            Assert.Equal("Hello", service.StdOutReader.ReadToEnd());
+
+            service.Write("World");
+
+            Assert.Equal("World", service.StdOutReader.ReadToEnd());
+        }
+
         [Fact]
         public void WriteLine()
         {
@@ -73,6 +88,30 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             Assert.Equal("Line 4", service.ReadLine());
             Assert.Equal("Line 5", service.ReadLine());
             Assert.Equal("Line 6", service.ReadLine());
+        }
+
+        [Fact]
+        public void ReadKey()
+        {
+            var service = new InMemoryInteractiveService();
+
+            service.StdInWriter.Write(ConsoleKey.A);
+            service.StdInWriter.Write(ConsoleKey.B);
+            service.StdInWriter.Write(ConsoleKey.C);
+            service.StdInWriter.Flush();
+
+            Assert.Equal(ConsoleKey.A, service.ReadKey(false).Key);
+            Assert.Equal(ConsoleKey.B, service.ReadKey(false).Key);
+            Assert.Equal(ConsoleKey.C, service.ReadKey(false).Key);
+
+            service.StdInWriter.Write(ConsoleKey.D);
+            service.StdInWriter.Write(ConsoleKey.E);
+            service.StdInWriter.Write(ConsoleKey.F);
+            service.StdInWriter.Flush();
+
+            Assert.Equal(ConsoleKey.D, service.ReadKey(false).Key);
+            Assert.Equal(ConsoleKey.E, service.ReadKey(false).Key);
+            Assert.Equal(ConsoleKey.F, service.ReadKey(false).Key);
         }
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Environment = System.Environment;
+
+namespace AWS.Deploy.CLI.IntegrationTests
+{
+    [Collection("Serial")]
+    public class WebAppNoDockerFileTests : IDisposable
+    {
+        private readonly HttpHelper _httpHelper;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly App _app;
+        private readonly InMemoryInteractiveService _interactiveService;
+        private bool _isDisposed;
+        private string _stackName;
+
+        public WebAppNoDockerFileTests()
+        {
+            _httpHelper = new HttpHelper();
+
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _app = serviceProvider.GetService<App>();
+            Assert.NotNull(_app);
+
+            _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
+            Assert.NotNull(_interactiveService);
+        }
+
+        [Fact]
+        public async Task DefaultConfigurations()
+        {
+            _stackName = $"WebAppNoDockerFile{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            // Arrange input for deploy
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine);
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine);
+            await _interactiveService.StdInWriter.FlushAsync();
+
+            // Deploy
+            var projectPath = Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj");
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName };
+            await _app.Run(deployArgs);
+
+            // Verify application is deployed and running
+            Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+            var deployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+
+            // Example: WebAppNoDockerFile-3cf258f103d2.EndpointURL = http://52.36.216.238/
+            var applicationUrl = deployStdOut.First(line => line.StartsWith($"{_stackName}.EndpointURL"))
+                .Split("=")[1]
+                .Trim();
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _httpHelper.WaitUntilSuccessStatusCode(applicationUrl, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            // Arrange input for delete
+            await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
+            await _interactiveService.StdInWriter.FlushAsync();
+            var deleteArgs = new[] { "delete-deployment", _stackName };
+
+            // Delete
+            await _app.Run(deleteArgs);
+
+            // Verify application is delete
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                if (!isStackDeleted)
+                {
+                    _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~WebAppNoDockerFileTests()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
@@ -1,0 +1,125 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using Amazon.CloudFormation;
+using Amazon.ECS;
+using Amazon.ECS.Model;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace AWS.Deploy.CLI.IntegrationTests
+{
+    [Collection("Serial")]
+    public class WebAppWithDockerFileTests : IDisposable
+    {
+        private readonly HttpHelper _httpHelper;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly ECSHelper _ecsHelper;
+        private readonly App _app;
+        private readonly InMemoryInteractiveService _interactiveService;
+        private bool _isDisposed;
+        private string _stackName;
+
+        public WebAppWithDockerFileTests()
+        {
+            _httpHelper = new HttpHelper();
+
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            var ecsClient = new AmazonECSClient();
+            _ecsHelper = new ECSHelper(ecsClient);
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _app = serviceProvider.GetService<App>();
+            Assert.NotNull(_app);
+
+            _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
+            Assert.NotNull(_interactiveService);
+        }
+
+        [Fact]
+        public async Task DefaultConfigurations()
+        {
+            _stackName = $"WebAppWithDockerFile{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            // Arrange input for deploy
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine);
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine);
+            await _interactiveService.StdInWriter.FlushAsync();
+
+            // Deploy
+            var projectPath = Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj");
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName };
+            await _app.Run(deployArgs);
+
+            // Verify application is deployed and running
+            Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+            var cluster = await _ecsHelper.GetCluster(_stackName);
+            Assert.Equal("ACTIVE", cluster.Status);
+
+            var deployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+
+            // Example: WebAppWithDockerFile3d078c3ca551.FargateServiceServiceURL47701F45 = http://WebAp-Farga-12O3W5VNB5OLC-166471465.us-west-2.elb.amazonaws.com
+            var applicationUrl = deployStdOut.First(line => line.StartsWith($"{_stackName}.FargateServiceServiceURL"))
+                .Split("=")[1]
+                .Trim();
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _httpHelper.WaitUntilSuccessStatusCode(applicationUrl, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            // Arrange input for delete
+            await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
+            await _interactiveService.StdInWriter.FlushAsync();
+            var deleteArgs = new[] { "delete-deployment", _stackName };
+
+            // Delete
+            await _app.Run(deleteArgs);
+
+            // Verify application is delete
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                if (!isStackDeleted)
+                {
+                    _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~WebAppWithDockerFileTests()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/testapps/ConsoleAppService/Dockerfile
+++ b/testapps/ConsoleAppService/Dockerfile
@@ -1,13 +1,16 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# Dockerfile paths are adjusted to allow docker build from the root of the repository
+# This is required for integration tests
 
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
-COPY ["ConsoleAppService.csproj", ""]
-RUN dotnet restore "ConsoleAppService.csproj"
-COPY . .
+COPY ["testapps/ConsoleAppService/ConsoleAppService.csproj", "testapps/ConsoleAppService/"]
+RUN dotnet restore "testapps/ConsoleAppService/ConsoleAppService.csproj"
+COPY "testapps/ConsoleAppService/" "testapps/ConsoleAppService/"
+WORKDIR "/src/testapps/ConsoleAppService"
 RUN dotnet build "ConsoleAppService.csproj" -c Release -o /app/build
 
 FROM build AS publish

--- a/testapps/ConsoleAppTask/Dockerfile
+++ b/testapps/ConsoleAppTask/Dockerfile
@@ -1,13 +1,16 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# Dockerfile paths are adjusted to allow docker build from the root of the repository
+# This is required for integration tests
 
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
-COPY ["ConsoleAppTask.csproj", ""]
-RUN dotnet restore "ConsoleAppTask.csproj"
-COPY . .
+COPY ["testapps/ConsoleAppTask/ConsoleAppTask.csproj", "testapps/ConsoleAppTask/"]
+RUN dotnet restore "testapps/ConsoleAppTask/ConsoleAppTask.csproj"
+COPY "testapps/ConsoleAppTask/" "testapps/ConsoleAppTask/"
+WORKDIR "/src/testapps/ConsoleAppTask"
 RUN dotnet build "ConsoleAppTask.csproj" -c Release -o /app/build
 
 FROM build AS publish

--- a/testapps/WebAppWithDockerFile/Dockerfile
+++ b/testapps/WebAppWithDockerFile/Dockerfile
@@ -1,4 +1,6 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# Dockerfile paths are adjusted to allow docker build from the root of the repository
+# This is required for integration tests
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
@@ -7,9 +9,10 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
-COPY ["WebAppWithDockerFile.csproj", ""]
-RUN dotnet restore "WebAppWithDockerFile.csproj"
-COPY . .
+COPY ["testapps/WebAppWithDockerFile/WebAppWithDockerFile.csproj", "testapps/WebAppWithDockerFile/"]
+RUN dotnet restore "testapps/WebAppWithDockerFile/WebAppWithDockerFile.csproj"
+COPY "testapps/WebAppWithDockerFile/" "testapps/WebAppWithDockerFile/"
+WORKDIR "/src/testapps/WebAppWithDockerFile"
 RUN dotnet build "WebAppWithDockerFile.csproj" -c Release -o /app/build
 
 FROM build AS publish


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes adds automated integration tests that performs end to end testing for all five supported recipes with default configurations. A typical test case starts with deployment and ends at deleting the application.

At the end of the test, regardless of the outcome, test clears the resources created by implementing IDisposable.

`InMemoryInteractiveService` allows tests to capture stdout/stderr and provide stdin using Streams.

Note: we don't run the integration tests as part of the Checks. I verified, they pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
