### PR TITLE
chore: Enable TreatWarningsAsErrors by adding this property to src/Directory.Build.props file

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR adds the TreatWarningsAsErrors property to all projects located at `..\aws-dotnet-deploy\src` by adding a `Directory.Build.props` file inside the `src` folder
https://sim.amazon.com/issues/DOTNET-5004