### PR TITLE
fix: Child option settings IDs are displayed instead of names and DependsOn property not respected

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -413,7 +413,8 @@ namespace AWS.Deploy.CLI.Commands
                         case OptionSettingValueType.Object:
                             foreach (var childSetting in setting.ChildOptionSettings)
                             {
-                                await ConfigureDeployment(recommendation, childSetting);
+                                if (recommendation.IsOptionSettingDisplayable(childSetting))
+                                    await ConfigureDeployment(recommendation, childSetting);
                             }
                             break;
                         default:
@@ -464,7 +465,14 @@ namespace AWS.Deploy.CLI.Commands
 
             if (objectValues != null)
             {
-                _consoleUtilities.DisplayValues(objectValues, "\t");
+                var displayableValues = new Dictionary<string, object>();
+                foreach (var child in optionSetting.ChildOptionSettings)
+                {
+                    if (!objectValues.ContainsKey(child.Id))
+                        continue;
+                    displayableValues.Add(child.Name, objectValues[child.Id]);
+                }
+                _consoleUtilities.DisplayValues(displayableValues, "\t");
             }
         }
     }

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -402,6 +402,10 @@ namespace AWS.Deploy.CLI
                         _interactiveService.WriteLine($"{indent}{key}: {stringValue}");
                     }
                 }
+                else if (value is bool boolValue)
+                {
+                    _interactiveService.WriteLine($"{indent}{key}: {boolValue}");
+                }
             }
         }
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -12,9 +12,9 @@ namespace AWS.Deploy.Common.Recipes
     {
         private object _valueOverride;
 
-        public T GetValue<T>(IDictionary<string, string> replacementTokens, bool ignoreDefaultValue = false)
+        public T GetValue<T>(IDictionary<string, string> replacementTokens, bool ignoreDefaultValue = false, IDictionary<string, bool> displayableOptionSettings = null)
         {
-            var value = GetValue(replacementTokens, ignoreDefaultValue);
+            var value = GetValue(replacementTokens, ignoreDefaultValue, displayableOptionSettings);
             if (value == null)
             {
                 return default;
@@ -23,7 +23,7 @@ namespace AWS.Deploy.Common.Recipes
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(value));
         }
 
-        public object GetValue(IDictionary<string, string> replacementTokens, bool ignoreDefaultValue = false)
+        public object GetValue(IDictionary<string, string> replacementTokens, bool ignoreDefaultValue = false, IDictionary<string, bool> displayableOptionSettings = null)
         {
             if (_valueOverride != null)
             {
@@ -36,6 +36,15 @@ namespace AWS.Deploy.Common.Recipes
                 foreach (var childOptionSetting in ChildOptionSettings)
                 {
                     var childValue = childOptionSetting.GetValue(replacementTokens, ignoreDefaultValue);
+
+                    if (
+                        displayableOptionSettings != null &&
+                        displayableOptionSettings.TryGetValue(childOptionSetting.Id, out bool isDisplayable))
+                    {
+                        if (!isDisplayable)
+                            continue;
+                    }
+
                     if (childValue != null)
                     {
                         objectValue[childOptionSetting.Id] = childValue;

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -107,12 +107,28 @@ namespace AWS.Deploy.Common
 
         public T GetOptionSettingValue<T>(OptionSettingItem optionSetting, bool ignoreDefaultValue = false)
         {
-            return optionSetting.GetValue<T>(_replacementTokens, ignoreDefaultValue);
+            var displayableOptionSettings = new Dictionary<string, bool>();
+            if (optionSetting.Type == OptionSettingValueType.Object)
+            {
+                foreach (var childOptionSetting in optionSetting.ChildOptionSettings)
+                {
+                    displayableOptionSettings.Add(childOptionSetting.Id, IsOptionSettingDisplayable(childOptionSetting));
+                }
+            }
+            return optionSetting.GetValue<T>(_replacementTokens, ignoreDefaultValue, displayableOptionSettings);
         }
 
         public object GetOptionSettingValue(OptionSettingItem optionSetting, bool ignoreDefaultValue = false)
         {
-            return optionSetting.GetValue(_replacementTokens, ignoreDefaultValue);
+            var displayableOptionSettings = new Dictionary<string, bool>();
+            if (optionSetting.Type == OptionSettingValueType.Object)
+            {
+                foreach (var childOptionSetting in optionSetting.ChildOptionSettings)
+                {
+                    displayableOptionSettings.Add(childOptionSetting.Id, IsOptionSettingDisplayable(childOptionSetting));
+                }
+            }
+            return optionSetting.GetValue(_replacementTokens, ignoreDefaultValue, displayableOptionSettings);
         }
 
         public T GetOptionSettingDefaultValue<T>(OptionSettingItem optionSetting)


### PR DESCRIPTION
*Issue #, if available:*
* Child option settings IDs are displayed instead of names
* DependsOn property not respected in Child option settings
* Child option settings of type Bool are not being displayed

*Description of changes:*
**Before**
![PR199-Before](https://user-images.githubusercontent.com/53088140/116099179-b4d45500-a679-11eb-88c8-4fd3cf451c85.gif)

**After**
![PR199-After](https://user-images.githubusercontent.com/53088140/116099906-6d9a9400-a67a-11eb-9516-af25955c1658.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
