### PR TITLE
chore: Local NuGet cache is now created for all configurations

### DIFF
--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -77,8 +77,7 @@
     </Task>
   </UsingTask>
 
-<!-- TODO: we need to find a better fix for execute SetupLocalCache than skipping in Release configuration -->
-<Target Name="SetupNuGetCache" AfterTargets="Pack" Condition=" '$(Configuration)' != 'Release' ">
+<Target Name="SetupNuGetCache" AfterTargets="Pack">
 
   <SetupLocalCache NuGetPackage="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg"/>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
chore: Local NuGet cache is now created for all configurations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
