### PR TITLE
feat: remove ECR repository on delete-deployment for ECS Fargate based deployments

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -215,7 +215,8 @@ namespace AWS.Deploy.CLI.Commands
                         awsOption.Region = RegionEndpoint.GetBySystemName(awsRegion);
                     });
 
-                    await new DeleteDeploymentCommand(_awsClientFactory, _toolInteractiveService, _consoleUtilities).ExecuteAsync(deploymentName);
+                    await new DeleteDeploymentCommand(_awsClientFactory, _toolInteractiveService, _consoleUtilities, _awsResourceQueryer)
+                        .ExecuteAsync(deploymentName);
 
                     return CommandReturnCodes.SUCCESS;
                 }

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -76,7 +76,7 @@ namespace AWS.Deploy.Orchestration
             await InitiateDockerLogin();
 
             var tagSuffix = sourceTag.Split(":")[1];
-            var repository = await SetupECRRepository(cloudApplication.StackName.ToLower());
+            var repository = await SetupECRRepository(cloudApplication.StackName.ToLower(), recommendation.Recipe.Id);
             var targetTag = $"{repository.RepositoryUri}:{tagSuffix}";
 
             await TagDockerImage(sourceTag, targetTag);
@@ -248,9 +248,9 @@ namespace AWS.Deploy.Orchestration
                 throw new DockerLoginFailedException("Failed to login to Docker");
         }
 
-        private async Task<Repository> SetupECRRepository(string ecrRepositoryName)
+        private async Task<Repository> SetupECRRepository(string repositoryName, string recipeId)
         {
-            var existingRepositories = await _awsResourceQueryer.GetECRRepositories(new List<string> { ecrRepositoryName });
+            var existingRepositories = await _awsResourceQueryer.GetECRRepositories(new List<string> { repositoryName });
 
             if (existingRepositories.Count == 1)
             {
@@ -258,7 +258,7 @@ namespace AWS.Deploy.Orchestration
             }
             else
             {
-                return await _awsResourceQueryer.CreateECRRepository(ecrRepositoryName);
+                return await _awsResourceQueryer.CreateECRRepository(repositoryName, recipeId);
             }
         }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ECRHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ECRHelper.cs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.ECR;
+using Amazon.ECR.Model;
+using AWS.Deploy.Recipes.CDK.Common;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class ECRHelper
+    {
+        private readonly IAmazonECR _ecrClient;
+
+        public ECRHelper(IAmazonECR ecrClient)
+        {
+            _ecrClient = ecrClient;
+        }
+
+        public async Task<bool> IsRepositoryDeleted(string repositoryName)
+        {
+            var repositories = await GetRepositories(new List<string>
+            {
+                repositoryName
+            });
+
+            foreach (var repository in repositories)
+            {
+                var tags = await ListTagsForResource(repository.RepositoryArn);
+                if (tags.Any(tag => tag.Key.Equals(CloudFormationIdentifierConstants.STACK_TAG)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public async Task<List<Repository>> GetRepositories(List<string> repositoryNames)
+        {
+            var request = new DescribeRepositoriesRequest
+            {
+                RepositoryNames = repositoryNames
+            };
+
+            try
+            {
+                return await _ecrClient.Paginators
+                    .DescribeRepositories(request)
+                    .Repositories
+                    .ToListAsync();
+            }
+            catch (RepositoryNotFoundException)
+            {
+                return new List<Repository>();
+            }
+        }
+
+        public async Task<List<Tag>> ListTagsForResource(string resourceArn)
+        {
+            var request = new ListTagsForResourceRequest
+            {
+                ResourceArn = resourceArn
+            };
+
+            var response = await _ecrClient.ListTagsForResourceAsync(request);
+
+            return response.Tags;
+        }
+
+        public async Task DeleteRepository(string repositoryName)
+        {
+            var request = new DeleteRepositoryRequest
+            {
+                RepositoryName = repositoryName,
+                Force = true
+            };
+
+            try
+            {
+                await _ecrClient.DeleteRepositoryAsync(request);
+            }
+            catch (RepositoryNotFoundException)
+            {
+                // Repository does not exit, no action required.
+            }
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -12,13 +12,16 @@ using Amazon.IdentityManagement.Model;
 using Amazon.SecurityToken.Model;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
+using Tag = Amazon.ECR.Model.Tag;
 
 namespace AWS.Deploy.CLI.UnitTests.Utilities
 {
     public class TestToolAWSResourceQueryer : IAWSResourceQueryer
     {
         public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
-        public Task<Repository> CreateECRRepository(string repositoryName) => throw new NotImplementedException();
+        public Task DeleteECRRepository(string repositoryName) => throw new NotImplementedException();
+        public Task<Repository> CreateECRRepository(string name, string recipeId) => throw new NotImplementedException();
+        public Task<List<Tag>> ListTagsForECRResource(string resourceArn) => throw new NotImplementedException();
         public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
         public Task<GetCallerIdentityResponse> GetCallerIdentity() => throw new NotImplementedException();
 


### PR DESCRIPTION
*Issue #161

*Description of changes:*
AWS.Deploy.CLI adds aws-dotnet-deploy tag (with value recipe id as value). At the time of deletion, deployment tool checks whether the tag is present or not and deletes only when tag is present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
