### PR TITLE
feat: server mode exits with code -100 if port is in use

### DIFF
--- a/src/AWS.Deploy.CLI/CommandReturnCodes.cs
+++ b/src/AWS.Deploy.CLI/CommandReturnCodes.cs
@@ -29,5 +29,10 @@ namespace AWS.Deploy.CLI
         /// decorated with <see cref="AWSDeploymentExpectedExceptionAttribute"/>
         /// </summary>
         public const int USER_ERROR = 1;
+        /// <summary>
+        /// A command could not finish because of a problem
+        /// using a TCP port that is already in use.
+        /// </summary>
+        public const int TCP_PORT_ERROR = -100;
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -315,6 +315,8 @@ namespace AWS.Deploy.CLI.Commands
                     var serverMode = new ServerModeCommand(toolInteractiveService, port, parentPid, encryptionKeyInfoStdIn);
 
                     await serverMode.ExecuteAsync();
+
+                    return CommandReturnCodes.SUCCESS;
                 }
                 catch (Exception e) when (e.IsAWSDeploymentExpectedException())
                 {
@@ -325,6 +327,14 @@ namespace AWS.Deploy.CLI.Commands
                         _toolInteractiveService.WriteErrorLine(string.Empty);
                         _toolInteractiveService.WriteErrorLine(e.Message);
                     }
+
+                    if (e is TcpPortInUseException)
+                    {
+                        return CommandReturnCodes.TCP_PORT_ERROR;
+                    }
+
+                    // bail out with an non-zero return code.
+                    return CommandReturnCodes.USER_ERROR;
                 }
                 catch (Exception e)
                 {
@@ -332,6 +342,8 @@ namespace AWS.Deploy.CLI.Commands
                     _toolInteractiveService.WriteErrorLine(
                         "Unhandled exception.  This is a bug.  Please copy the stack trace below and file a bug at https://github.com/aws/aws-dotnet-deploy. " +
                         e.PrettyPrint());
+
+                    return CommandReturnCodes.UNHANDLED_EXCEPTION;
                 }
             });
 

--- a/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
 using System.Security.Cryptography;
 using System.Diagnostics;
 using System.Threading;
@@ -33,6 +36,9 @@ namespace AWS.Deploy.CLI.Commands
             _interactiveService.WriteLine("Server mode is an experimental feature being developed to allow communication between this CLI and the AWS Toolkit for Visual Studio. Expect behavior changes and API changes as server mode is being developed.");
 
             IEncryptionProvider encryptionProvider = CreateEncryptionProvider();
+
+            if (IsPortInUse(_port))
+                throw new TcpPortInUseException("The port you have selected is currently in use by another process.");
 
             var url = $"http://localhost:{_port}";
 
@@ -138,6 +144,14 @@ namespace AWS.Deploy.CLI.Commands
                     return true;
                 }
             }
+        }
+        
+        private bool IsPortInUse(int port)
+        {
+            var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var listeners = ipGlobalProperties.GetActiveTcpListeners();
+
+            return listeners.Any(x => x.Port == port);
         }
     }
 }

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -61,4 +61,13 @@ namespace AWS.Deploy.CLI
     {
         public SystemCapabilitiesNotProvidedException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if TCP port is in use by another process.
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class TcpPortInUseException : Exception
+    {
+        public TcpPortInUseException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.Commands;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class ServerModeTests
+    {
+        [Fact]
+        public async Task TcpPortIsInUseTest()
+        {
+            var serverModeCommand1 = new ServerModeCommand(new TestToolInteractiveServiceImpl(), 1234, null, false);
+            var serverModeCommand2 = new ServerModeCommand(new TestToolInteractiveServiceImpl(), 1234, null, false);
+
+            var serverModeTask1 = serverModeCommand1.ExecuteAsync();
+            var serverModeTask2 = serverModeCommand2.ExecuteAsync();
+
+            await Task.WhenAny(serverModeTask1, serverModeTask2);
+
+            Assert.False(serverModeTask1.IsCompleted);
+
+            Assert.True(serverModeTask2.IsCompleted);
+            Assert.True(serverModeTask2.IsFaulted);
+
+            Assert.NotNull(serverModeTask2.Exception);
+            Assert.Single(serverModeTask2.Exception.InnerExceptions);
+
+            Assert.IsType<TcpPortInUseException>(serverModeTask2.Exception.InnerException);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5084

*Description of changes:*
feat: server mode exits with code -100 if port is in use

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
