### PR TITLE
feat: implement `ServerModeSession` utility class

### DIFF
--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -64,6 +64,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.ServerMode.Clien
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AWS.Deploy.Constants", "src\AWS.Deploy.Constants\AWS.Deploy.Constants.shproj", "{F2266C44-C8C5-45AD-AA9B-44F8825BDF63}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Deploy.ServerMode.Client.UnitTests", "test\AWS.Deploy.ServerMode.Client.UnitTests\AWS.Deploy.ServerMode.Client.UnitTests.csproj", "{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{f2266c44-c8c5-45ad-aa9b-44f8825bdf63}*SharedItemsImports = 13
@@ -158,6 +160,10 @@ Global
 		{C533AA26-797A-4A41-BA28-2364B66DAA5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C533AA26-797A-4A41-BA28-2364B66DAA5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C533AA26-797A-4A41-BA28-2364B66DAA5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -186,6 +192,7 @@ Global
 		{1B171F48-D200-407D-A9F2-179E2A602821} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{C533AA26-797A-4A41-BA28-2364B66DAA5F} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{F2266C44-C8C5-45AD-AA9B-44F8825BDF63} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
+		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}

--- a/src/AWS.Deploy.ServerMode.Client/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.ServerMode.Client/CommandLineWrapper.cs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.ServerMode.Client
+{
+    public class CommandLineWrapper
+    {
+        private readonly bool _diagnosticLoggingEnabled;
+
+        public CommandLineWrapper(bool diagnosticLoggingEnabled)
+        {
+            _diagnosticLoggingEnabled = diagnosticLoggingEnabled;
+        }
+
+        public virtual async Task<int> Run(string command, params string[] stdIn)
+        {
+            var arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"/c {command}" : $"-c \"{command}\"";
+
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = GetSystemShell(),
+                Arguments = arguments,
+                UseShellExecute = false, // UseShellExecute must be false in allow redirection of StdIn.
+                RedirectStandardInput = true,
+                CreateNoWindow = !_diagnosticLoggingEnabled, // It allows displaying stdout and stderr on the screen.
+            };
+
+            var process = Process.Start(processStartInfo);
+            if (process == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            foreach (var line in stdIn)
+            {
+                await process.StandardInput.WriteLineAsync(line).ConfigureAwait(false);
+            }
+
+            process.WaitForExit(-1);
+
+            return await Task.FromResult(process.ExitCode).ConfigureAwait(false);
+        }
+
+        private string GetSystemShell()
+        {
+            if (TryGetEnvironmentVariable("COMSPEC", out var comspec))
+            {
+                return comspec!;
+            }
+
+            if (TryGetEnvironmentVariable("SHELL", out var shell))
+            {
+                return shell!;
+            }
+
+            // fallback to defaults
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/sh";
+        }
+
+        private bool TryGetEnvironmentVariable(string variable, out string? value)
+        {
+            value = Environment.GetEnvironmentVariable(variable);
+            return !string.IsNullOrEmpty(value);
+        }
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/Exceptions.cs
+++ b/src/AWS.Deploy.ServerMode.Client/Exceptions.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace AWS.Deploy.ServerMode.Client
+{
+    /// <summary>
+    /// Exception is thrown when deployment tool server failed to start for an unknown reason.
+    /// </summary>
+    public class InternalServerModeException : Exception
+    {
+        public InternalServerModeException(string message) : base(message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Exception is thrown when deployment tool server failed to start due to unavailability of free ports.
+    /// </summary>
+    public class PortUnavailableException : Exception
+    {
+        public PortUnavailableException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
@@ -1,0 +1,243 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Newtonsoft.Json;
+
+namespace AWS.Deploy.ServerMode.Client
+{
+    /// <summary>
+    /// Helper class that allows launching deployment tool in server mode.
+    /// It abstracts the server mode setup, CLI command execution and retries when desired port is unavailable.
+    /// </summary>
+    public interface IServerModeSession
+    {
+        /// <summary>
+        /// Starts deployment tool in server mode.
+        /// It creates symmetric key and tries to setup the server mode.
+        /// It also handles the retries when a desired port is unavailable in the provided range.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="InternalServerModeException">Throws when deployment tool server failed to start for un unknown reason.</exception>
+        /// <exception cref="PortUnavailableException">Throws when deployment tool server failed to start due to unavailability of free ports.</exception>
+        Task Start(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Builds <see cref="IRestAPIClient"/> client using the cached base URL.
+        /// If succeeded, <param name="restApiClient"></param> is initialized with current session client.
+        /// </summary>
+        /// <param name="credentialsGenerator">Func to that provides AWS credentials</param>
+        /// <param name="restApiClient"><see cref="IRestAPIClient"/> client to initialize.</param>
+        /// <returns>True, if <param name="restApiClient"/> is initialized successfully.</returns>
+        bool TryGetRestAPIClient(Func<Task<AWSCredentials>> credentialsGenerator, out IRestAPIClient? restApiClient);
+
+        /// <summary>
+        /// Builds <see cref="IDeploymentCommunicationClient"/> client using the cached base URL.
+        /// If succeeded, <param name="deploymentCommunicationClient"></param> is initialized with current session client.
+        /// </summary>
+        /// <param name="deploymentCommunicationClient"><see cref="DeploymentCommunicationClient"/> client to initialize.</param>
+        /// <returns>True, if <param name="deploymentCommunicationClient"/> is initialized successfully.</returns>
+        bool TryGetDeploymentCommunicationClient(out IDeploymentCommunicationClient? deploymentCommunicationClient);
+
+        /// <summary>
+        /// Returns the status of the deployment server by checking /api/v1/health API.
+        /// Returns true, if the deployment server returns a success HTTP code.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns true, if the deployment server returns a success HTTP code.</returns>
+        Task<bool> IsAlive(CancellationToken cancellationToken);
+    }
+
+    public class ServerModeSession : IServerModeSession, IDisposable
+    {
+        private const int TCP_PORT_ERROR = -100;
+
+        private readonly int _startPort;
+        private readonly int _endPort;
+        private readonly CommandLineWrapper _commandLineWrapper;
+        private readonly HttpClientHandler _httpClientHandler;
+        private readonly TimeSpan _serverTimeout;
+
+        private string? _baseUrl;
+        private Aes? _aes;
+
+        private string HealthUrl
+        {
+            get
+            {
+                if (_baseUrl == null)
+                {
+                    throw new InvalidOperationException($"{nameof(_baseUrl)} must not be null.");
+                }
+
+                return $"{_baseUrl}/api/v1/health";
+            }
+        }
+
+        public ServerModeSession(int startPort = 10000, int endPort = 10100, bool diagnosticLoggingEnabled = false)
+            : this(new CommandLineWrapper(diagnosticLoggingEnabled),
+                new HttpClientHandler(),
+                TimeSpan.FromSeconds(60),
+                startPort,
+                endPort)
+        {
+        }
+
+        public ServerModeSession(CommandLineWrapper commandLineWrapper,
+            HttpClientHandler httpClientHandler,
+            TimeSpan serverTimeout,
+            int startPort = 10000,
+            int endPort = 10100)
+        {
+            _startPort = startPort;
+            _endPort = endPort;
+            _commandLineWrapper = commandLineWrapper;
+            _httpClientHandler = httpClientHandler;
+            _serverTimeout = serverTimeout;
+        }
+
+        public async Task Start(CancellationToken cancellationToken)
+        {
+            var currentProcessId = Process.GetCurrentProcess().Id;
+
+            for (var port = _startPort; port <= _endPort; port++)
+            {
+                _aes = Aes.Create();
+                _aes.GenerateKey();
+                _aes.GenerateIV();
+
+                var keyInfo = new EncryptionKeyInfo(
+                    EncryptionKeyInfo.VERSION_1_0,
+                    Convert.ToBase64String(_aes.Key),
+                    Convert.ToBase64String(_aes.IV));
+
+                var keyInfoStdin = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(keyInfo)));
+
+                var command = $"dotnet aws server-mode --port {port} --parent-pid {currentProcessId} --encryption-keyinfo-stdin";
+                var startServerTask = _commandLineWrapper.Run(command, keyInfoStdin);
+
+                _baseUrl = $"http://localhost:{port}";
+                var isServerAvailableTask = IsServerAvailable(cancellationToken);
+
+                if (isServerAvailableTask == await Task.WhenAny(startServerTask, isServerAvailableTask).ConfigureAwait(false))
+                {
+                    // The server timed out, this isn't a transient error, therefore, we throw
+                    if (!isServerAvailableTask.Result)
+                    {
+                        throw new InternalServerModeException($"\"{command}\" failed for unknown reason.");
+                    }
+
+                    // Server has started, it is safe to return
+                    return;
+                }
+
+                // For -100 errors, we want to check all the ports in the configured port range
+                // If the error code other than -100, this is an unexpected exit code.
+                if (startServerTask.Result != TCP_PORT_ERROR)
+                {
+                    throw new InternalServerModeException($"\"{command}\" failed for unknown reason.");
+                }
+            }
+
+            throw new PortUnavailableException($"Free port unavailable in {_startPort}-{_endPort} range.");
+        }
+
+        public bool TryGetRestAPIClient(Func<Task<AWSCredentials>> credentialsGenerator, out IRestAPIClient? restApiClient)
+        {
+            if (_baseUrl == null || _aes == null)
+            {
+                restApiClient = null;
+                return false;
+            }
+
+            var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(credentialsGenerator, _aes);
+            restApiClient = new RestAPIClient(_baseUrl, httpClient);
+            return true;
+        }
+
+        public bool TryGetDeploymentCommunicationClient(out IDeploymentCommunicationClient? deploymentCommunicationClient)
+        {
+            if (_baseUrl == null || _aes == null)
+            {
+                deploymentCommunicationClient = null;
+                return false;
+            }
+
+            deploymentCommunicationClient = new DeploymentCommunicationClient(_baseUrl);
+            return true;
+        }
+
+        public async Task<bool> IsAlive(CancellationToken cancellationToken)
+        {
+            var client = new HttpClient(_httpClientHandler);
+
+            try
+            {
+                var response = await client.GetAsync(HealthUrl, cancellationToken);
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        #region Private methods
+
+        private Task<bool> IsServerAvailable(CancellationToken cancellationToken)
+        {
+            return WaitUntilHelper.WaitUntilSuccessStatusCode(
+                HealthUrl,
+                _httpClientHandler,
+                TimeSpan.FromMilliseconds(100),
+                _serverTimeout,
+                cancellationToken);
+        }
+
+        #endregion
+
+        #region Disposable
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _aes?.Dispose();
+                _aes = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+        private class EncryptionKeyInfo
+        {
+            public const string VERSION_1_0 = "1.0";
+
+            public string Version { get; set; }
+            public string Key { get; set; }
+            public string IV { get; set; }
+
+            public EncryptionKeyInfo(string version, string key, string iv)
+            {
+                Version = version;
+                Key = key;
+                IV = iv;
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/WaitUntilHelper.cs
+++ b/src/AWS.Deploy.ServerMode.Client/WaitUntilHelper.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.ServerMode.Client
+{
+    internal static class WaitUntilHelper
+    {
+        private static async Task WaitUntil(Func<Task<bool>> predicate, TimeSpan frequency, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            var waitTask = Task.Run(async () =>
+            {
+                while (!await predicate())
+                {
+                    await Task.Delay(frequency, cancellationToken);
+                }
+            });
+
+            if (waitTask != await Task.WhenAny(waitTask, Task.Delay(timeout)))
+            {
+                throw new TimeoutException();
+            }
+        }
+
+        public static async Task<bool> WaitUntilSuccessStatusCode(string url, HttpClientHandler httpClientHandler, TimeSpan frequency, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            var client = new HttpClient(httpClientHandler);
+
+            try
+            {
+                await WaitUntil(async () =>
+                {
+                    try
+                    {
+                        var httpResponseMessage = await client.GetAsync(url, cancellationToken);
+                        return httpResponseMessage.IsSuccessStatusCode;
+                    }
+                    catch (Exception)
+                    {
+                        return false;
+                    }
+                }, frequency, timeout, cancellationToken);
+            }
+            catch (TimeoutException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Should-DotNetStandard" Version="1.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Deploy.ServerMode.Client\AWS.Deploy.ServerMode.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/ServerModeSessionTests.cs
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/ServerModeSessionTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace AWS.Deploy.ServerMode.Client.UnitTests
+{
+    public class ServerModeSessionTests
+    {
+        private readonly ServerModeSession _serverModeSession;
+        private readonly Mock<HttpClientHandler> _httpClientHandlerMock;
+        private readonly Mock<CommandLineWrapper> _commandLineWrapper;
+
+        public ServerModeSessionTests()
+        {
+            _httpClientHandlerMock = new Mock<HttpClientHandler>();
+            _commandLineWrapper = new Mock<CommandLineWrapper>(false);
+            _serverModeSession = new ServerModeSession(_commandLineWrapper.Object, _httpClientHandlerMock.Object, TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public async Task Start()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+
+            // Act
+            var exception = await Record.ExceptionAsync(async () =>
+            {
+                await _serverModeSession.Start(CancellationToken.None);
+            });
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public async Task Start_PortUnavailable()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(-100);
+            MockHttpGet(HttpStatusCode.NotFound, TimeSpan.FromSeconds(5));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<PortUnavailableException>(async () =>
+            {
+                await _serverModeSession.Start(CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task Start_HttpGetThrows()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGetThrows();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InternalServerModeException>(async () =>
+            {
+                await _serverModeSession.Start(CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task Start_HttpGetForbidden()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.Forbidden);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InternalServerModeException>(async () =>
+            {
+                await _serverModeSession.Start(CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task IsAlive_BaseUrlNotInitialized()
+        {
+            // Act
+            var isAlive = await _serverModeSession.IsAlive(CancellationToken.None);
+
+            // Assert
+            Assert.False(isAlive);
+        }
+
+        [Fact]
+        public async Task IsAlive_GetAsyncThrows()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+            await _serverModeSession.Start(CancellationToken.None);
+
+            MockHttpGetThrows();
+
+            // Act
+            var isAlive = await _serverModeSession.IsAlive(CancellationToken.None);
+
+            // Assert
+            Assert.False(isAlive);
+        }
+
+        [Fact]
+        public async Task IsAlive_HttpResponseSuccess()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+            await _serverModeSession.Start(CancellationToken.None);
+
+            // Act
+            var isAlive = await _serverModeSession.IsAlive(CancellationToken.None);
+
+            // Assert
+            Assert.True(isAlive);
+        }
+
+        [Fact]
+        public async Task IsAlive_HttpResponseFailure()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+            await _serverModeSession.Start(CancellationToken.None);
+
+            MockHttpGet(HttpStatusCode.Forbidden);
+
+            // Act
+            var isAlive = await _serverModeSession.IsAlive(CancellationToken.None);
+
+            // Assert
+            Assert.False(isAlive);
+        }
+
+        [Fact]
+        public async Task TryGetRestAPIClient()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+            await _serverModeSession.Start(CancellationToken.None);
+
+            // Act
+            var success = _serverModeSession.TryGetRestAPIClient(CredentialGenerator, out var restApiClient);
+
+            // Assert
+            Assert.True(success);
+            Assert.NotNull(restApiClient);
+        }
+
+        [Fact]
+        public void TryGetRestAPIClient_WithoutStart()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+
+            // Act
+            var success = _serverModeSession.TryGetRestAPIClient(CredentialGenerator, out var restApiClient);
+
+            // Assert
+            Assert.False(success);
+            Assert.Null(restApiClient);
+        }
+
+        [Fact]
+        public async Task TryGetDeploymentCommunicationClient()
+        {
+            // Arrange
+            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            MockHttpGet(HttpStatusCode.OK);
+            await _serverModeSession.Start(CancellationToken.None);
+
+            // Act
+            var success = _serverModeSession.TryGetDeploymentCommunicationClient(out var deploymentCommunicationClient);
+
+            // Assert
+            Assert.True(success);
+            Assert.NotNull(deploymentCommunicationClient);
+        }
+
+        [Fact]
+        public void TryGetDeploymentCommunicationClient_WithoutStart()
+        {
+            var success = _serverModeSession.TryGetDeploymentCommunicationClient(out var deploymentCommunicationClient);
+            Assert.False(success);
+            Assert.Null(deploymentCommunicationClient);
+        }
+
+        private void MockHttpGet(HttpStatusCode httpStatusCode)
+        {
+            var response = new HttpResponseMessage(httpStatusCode);
+
+            _httpClientHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(response);
+        }
+
+        private void MockHttpGet(HttpStatusCode httpStatusCode, TimeSpan delay)
+        {
+            var response = new HttpResponseMessage(httpStatusCode);
+
+            _httpClientHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(response, delay);
+        }
+
+        private void MockHttpGetThrows() =>
+            _httpClientHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Throws(new Exception());
+
+        private void MockCommandLineWrapperRun(int statusCode) =>
+            _commandLineWrapper
+                .Setup(wrapper => wrapper.Run(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(statusCode);
+
+        private void MockCommandLineWrapperRun(int statusCode, TimeSpan delay) =>
+            _commandLineWrapper
+                .Setup(wrapper => wrapper.Run(It.IsAny<string>(), It.IsAny<string[]>()))
+                .ReturnsAsync(statusCode, delay);
+
+        private Task<AWSCredentials> CredentialGenerator() => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ServerModeSession exposes Start method which starts the deployment tools server on a random registered port number for the given process id.

It also offers resiliency for port unavailable error by allow a configurable number of retries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

https://user-images.githubusercontent.com/8882380/120391508-f47b0600-c2e3-11eb-82eb-2e01507927bc.mp4

