### PR TITLE
feat: Add ability to redeploy without any prompts for user input

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -29,6 +29,7 @@ namespace AWS.Deploy.CLI.Commands
         private static readonly Option<string> _optionProjectPath = new("--project-path", () => Directory.GetCurrentDirectory(), "Path to the project to deploy.");
         private static readonly Option<string> _optionStackName = new("--stack-name", "Name the AWS stack to deploy your application to.");
         private static readonly Option<bool> _optionDiagnosticLogging = new(new []{"-d", "--diagnostics"}, "Enable diagnostic output.");
+        private static readonly Option<bool> _optionDisableInteractive = new(new []{ "--disable-interactive" }, "Disable interactivity to redeploy without any prompts for user input.");
 
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
@@ -111,14 +112,16 @@ namespace AWS.Deploy.CLI.Commands
                 _optionProjectPath,
                 _optionStackName,
                 _optionDiagnosticLogging,
+                _optionDisableInteractive
             };
 
-            deployCommand.Handler = CommandHandler.Create<string, string, string, string, bool, bool>(async (profile, region, projectPath, stackName, saveCdkProject, diagnostics) =>
+            deployCommand.Handler = CommandHandler.Create<string, string, string, string, bool, bool, bool>(async (profile, region, projectPath, stackName, saveCdkProject, diagnostics, disableInteractive) =>
             {
                 try
                 {
                     _toolInteractiveService.Diagnostics = diagnostics;
-
+                    _toolInteractiveService.DisableInteractive = disableInteractive;
+                    
                     var previousSettings = PreviousDeploymentSettings.ReadSettings(projectPath, null);
 
                     var awsCredentials = await _awsUtilities.ResolveAWSCredentials(profile, previousSettings.Profile);

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -175,7 +175,8 @@ namespace AWS.Deploy.CLI.Commands
 
             var configurableOptionSettings = selectedRecommendation.Recipe.OptionSettings.Union(deploymentBundleDefinition.Parameters);
 
-            await ConfigureDeployment(selectedRecommendation, configurableOptionSettings, false);
+            if (!_toolInteractiveService.DisableInteractive)
+                await ConfigureDeployment(selectedRecommendation, configurableOptionSettings, false);
 
             var cloudApplication = new CloudApplication(cloudApplicationName, string.Empty);
 

--- a/src/AWS.Deploy.CLI/ConsoleInteractiveServiceImpl.cs
+++ b/src/AWS.Deploy.CLI/ConsoleInteractiveServiceImpl.cs
@@ -20,6 +20,7 @@ namespace AWS.Deploy.CLI
         }
 
         public bool Diagnostics { get; set; }
+        public bool DisableInteractive { get; set; }
 
         public void WriteDebugLine(string message)
         {

--- a/src/AWS.Deploy.CLI/IToolInteractiveService.cs
+++ b/src/AWS.Deploy.CLI/IToolInteractiveService.cs
@@ -14,6 +14,7 @@ namespace AWS.Deploy.CLI
 
         string ReadLine();
         bool Diagnostics { get; set; }
+        bool DisableInteractive { get; set; }
         ConsoleKeyInfo ReadKey(bool intercept);
     }
 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Services/InMemoryInteractiveService.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Services/InMemoryInteractiveService.cs
@@ -134,6 +134,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
         }
 
         public bool Diagnostics { get; set; }
+        public bool DisableInteractive { get; set; }
 
         public ConsoleKeyInfo ReadKey(bool intercept)
         {

--- a/test/AWS.Deploy.CLI.UnitTests/TestToolInteractiveServiceImpl.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TestToolInteractiveServiceImpl.cs
@@ -81,6 +81,8 @@ namespace AWS.Deploy.CLI.UnitTests
         }
 
         public Queue<ConsoleKeyInfo> InputConsoleKeyInfos { get; } = new Queue<ConsoleKeyInfo>();
+        public bool DisableInteractive { get; set; }
+
         public ConsoleKeyInfo ReadKey(bool intercept)
         {
             if(InputConsoleKeyInfos.Count == 0)


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4887

*Description of changes:*
This PR adds a `disable-interactive` flag which can be passed as a CLI argument. This flag allows a redeployment to be performed without any user prompts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
