### PR TITLE
build: add ability to roll forward to run versions higher than netcoreapp3.1

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/aws/aws-dotnet-deploy</PackageProjectUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1570;1591</NoWarn>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -112,6 +112,10 @@ namespace AWS.Deploy.CLI.Commands
                 var existingCloudApplicationMetadata = await _templateMetadataReader.LoadCloudApplicationMetadata(deployedApplication.Name);
 
                 selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, deployedApplication.RecipeId, StringComparison.InvariantCultureIgnoreCase));
+
+                if (selectedRecommendation == null)
+                    throw new FailedToCompatibleRecipeException("A compatible recipe was not found for the deployed application.");
+
                 selectedRecommendation.ApplyPreviousSettings(existingCloudApplicationMetadata.Settings);
 
                 var header = $"Loading {deployedApplication.Name} settings:";

--- a/src/AWS.Deploy.CLI/ConsoleInteractiveServiceImpl.cs
+++ b/src/AWS.Deploy.CLI/ConsoleInteractiveServiceImpl.cs
@@ -16,18 +16,18 @@ namespace AWS.Deploy.CLI
 
         public string ReadLine()
         {
-            return Console.ReadLine();
+            return Console.ReadLine() ?? string.Empty;
         }
 
         public bool Diagnostics { get; set; }
 
-        public void WriteDebugLine(string message)
+        public void WriteDebugLine(string? message)
         {
             if (_diagnosticLoggingEnabled)
                 Console.WriteLine($"DEBUG: {message}");
         }
 
-        public void WriteErrorLine(string message)
+        public void WriteErrorLine(string? message)
         {
             var color = Console.ForegroundColor;
 
@@ -42,12 +42,12 @@ namespace AWS.Deploy.CLI
             }
         }
 
-        public void WriteLine(string message)
+        public void WriteLine(string? message)
         {
             Console.WriteLine(message);
         }
 
-        public void Write(string message)
+        public void Write(string? message)
         {
             Console.Write(message);
         }

--- a/src/AWS.Deploy.CLI/ConsoleOrchestratorLogger.cs
+++ b/src/AWS.Deploy.CLI/ConsoleOrchestratorLogger.cs
@@ -14,17 +14,17 @@ namespace AWS.Deploy.CLI
             _interactiveService = interactiveService;
         }
 
-        public void LogErrorMessageLine(string message)
+        public void LogErrorMessageLine(string? message)
         {
             _interactiveService.WriteErrorLine(message);
         }
 
-        public void LogMessageLine(string message)
+        public void LogMessageLine(string? message)
         {
             _interactiveService.WriteLine(message);
         }
 
-        public void LogDebugLine(string message)
+        public void LogDebugLine(string? message)
         {
             _interactiveService.WriteDebugLine(message);
         }

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -198,7 +198,7 @@ namespace AWS.Deploy.CLI
                 if (userInputConfiguration.CurrentValue != null && string.IsNullOrEmpty(userInputConfiguration.CurrentValue.ToString()))
                     defaultValue = Constants.CLI.EMPTY_LABEL;
                 else
-                    defaultValue = userInputConfiguration.CreateNew ? Constants.CLI.CREATE_NEW_LABEL : userInputConfiguration.DisplaySelector(options.FirstOrDefault());
+                    defaultValue = userInputConfiguration.CreateNew || !options.Any() ? Constants.CLI.CREATE_NEW_LABEL : userInputConfiguration.DisplaySelector(options.First());
             }
 
             if (optionStrings.Any())
@@ -306,12 +306,14 @@ namespace AWS.Deploy.CLI
             while (true)
             {
                 var keyPairDirectory = _interactiveService.ReadLine();
-                if (Directory.Exists(keyPairDirectory))
+                if (keyPairDirectory != null &&
+                    Directory.Exists(keyPairDirectory))
                 {
                     var projectFolder = new FileInfo(projectPath).Directory;
                     var keyPairDirectoryInfo = new DirectoryInfo(keyPairDirectory);
 
-                    if (projectFolder.FullName.Equals(keyPairDirectoryInfo.FullName))
+                    if (projectFolder != null &&
+                        projectFolder.FullName.Equals(keyPairDirectoryInfo.FullName))
                     {
                         _interactiveService.WriteLine(string.Empty);
                         _interactiveService.WriteLine("EC2 Key Pair is a private secret key and it is recommended to not save the key in the project directory where it could be checked into source control.");

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -70,4 +70,13 @@ namespace AWS.Deploy.CLI
     {
         public TcpPortInUseException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if unable to find a compatible recipe.
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class FailedToCompatibleRecipeException : Exception
+    {
+        public FailedToCompatibleRecipeException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.CLI/IToolInteractiveService.cs
+++ b/src/AWS.Deploy.CLI/IToolInteractiveService.cs
@@ -7,10 +7,10 @@ namespace AWS.Deploy.CLI
 {
     public interface IToolInteractiveService
     {
-        void Write(string message);
-        void WriteLine(string message);
-        void WriteDebugLine(string message);
-        void WriteErrorLine(string message);
+        void Write(string? message);
+        void WriteLine(string? message);
+        void WriteDebugLine(string? message);
+        void WriteErrorLine(string? message);
 
         string ReadLine();
         bool Diagnostics { get; set; }

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -181,7 +181,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             if(!string.IsNullOrEmpty(input.NewDeploymentRecipeId) &&
                !string.IsNullOrEmpty(input.NewDeploymentName))
             {
-                state.SelectedRecommendation = state.NewRecommendations.FirstOrDefault(x => string.Equals(input.NewDeploymentRecipeId, x.Recipe.Id));
+                state.SelectedRecommendation = state.NewRecommendations?.FirstOrDefault(x => string.Equals(input.NewDeploymentRecipeId, x.Recipe.Id));
                 if(state.SelectedRecommendation == null)
                 {
                     return NotFound($"Recommendation {input.NewDeploymentRecipeId} not found.");
@@ -195,13 +195,13 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 var serviceProvider = CreateSessionServiceProvider(state);
                 var templateMetadataReader = serviceProvider.GetRequiredService<ITemplateMetadataReader>();
 
-                var existingDeployment = state.ExistingDeployments.FirstOrDefault(x => string.Equals(input.ExistingDeploymentName, x.Name));
+                var existingDeployment = state.ExistingDeployments?.FirstOrDefault(x => string.Equals(input.ExistingDeploymentName, x.Name));
                 if (existingDeployment == null)
                 {
                     return NotFound($"Existing deployment {input.ExistingDeploymentName} not found.");
                 }
 
-                state.SelectedRecommendation = state.NewRecommendations.FirstOrDefault(x => string.Equals(existingDeployment.RecipeId, x.Recipe.Id));
+                state.SelectedRecommendation = state.NewRecommendations?.FirstOrDefault(x => string.Equals(existingDeployment.RecipeId, x.Recipe.Id));
                 if (state.SelectedRecommendation == null)
                 {
                     return NotFound($"Recommendation {input.NewDeploymentRecipeId} used in existing deployment {existingDeployment.RecipeId} not found.");

--- a/src/AWS.Deploy.CLI/ServerMode/Hubs/DeploymentCommunicationHub.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Hubs/DeploymentCommunicationHub.cs
@@ -12,9 +12,9 @@ namespace AWS.Deploy.CLI.ServerMode.Hubs
     public interface IDeploymentCommunicationHub
     {
         Task JoinSession(string sessionId);
-        Task OnLogDebugLine(string logs);
-        Task OnLogErrorMessageLine(string logs);
-        Task OnLogMessageLine(string logs);
+        Task OnLogDebugLine(string? logs);
+        Task OnLogErrorMessageLine(string? logs);
+        Task OnLogMessageLine(string? logs);
     }
 
     public class DeploymentCommunicationHub : Hub<IDeploymentCommunicationHub>

--- a/src/AWS.Deploy.CLI/ServerMode/Services/SessionOrchestratorInteractiveService.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/SessionOrchestratorInteractiveService.cs
@@ -23,17 +23,17 @@ namespace AWS.Deploy.CLI.ServerMode.Services
             _hubContext = hubContext;
         }
 
-        public void LogDebugLine(string message)
+        public void LogDebugLine(string? message)
         {
             _hubContext.Clients.Group(_sessionId).OnLogDebugLine(message);
         }
 
-        public void LogErrorMessageLine(string message)
+        public void LogErrorMessageLine(string? message)
         {
             _hubContext.Clients.Group(_sessionId).OnLogErrorMessageLine(message);
         }
 
-        public void LogMessageLine(string message)
+        public void LogMessageLine(string? message)
         {
             _hubContext.Clients.Group(_sessionId).OnLogMessageLine(message);
         }

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -127,6 +127,15 @@ namespace AWS.Deploy.Common
     }
 
     /// <summary>
+    /// Exception thrown if Project Path contains an invalid path
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class InvalidProjectPathException : Exception
+    {
+        public InvalidProjectPathException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
+
+    /// <summary>
     /// Indicates a specific strongly typed Exception can be anticipated.
     /// Whoever throws this error should also present the user with helpful information
     /// on what wrong and how to fix it.  This is the preferred UX.

--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -79,7 +79,8 @@ namespace AWS.Deploy.Common
 
         private bool CheckIfDockerFileExists(string projectPath)
         {
-            var dir = Directory.GetFiles(new FileInfo(projectPath).DirectoryName, "Dockerfile");
+            var dir = Directory.GetFiles(new FileInfo(projectPath).DirectoryName ??
+                                         throw new InvalidProjectPathException("The project path is invalid."), "Dockerfile");
             return dir.Length == 1;
         }
     }

--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -72,13 +72,13 @@ namespace AWS.Deploy.Common
             var targetFramework = xmlProjectFile.GetElementsByTagName("TargetFramework");
             if (targetFramework.Count > 0)
             {
-                projectDefinition.TargetFramework = targetFramework[0].InnerText;
+                projectDefinition.TargetFramework = targetFramework[0]?.InnerText;
             }
 
             var assemblyName = xmlProjectFile.GetElementsByTagName("AssemblyName");
             if (assemblyName.Count > 0)
             {
-                projectDefinition.AssemblyName = (string.IsNullOrWhiteSpace(assemblyName[0].InnerText) ? Path.GetFileNameWithoutExtension(projectPath) : assemblyName[0].InnerText);
+                projectDefinition.AssemblyName = (string.IsNullOrWhiteSpace(assemblyName[0]?.InnerText) ? Path.GetFileNameWithoutExtension(projectPath) : assemblyName[0]?.InnerText);
             }
             else
             {

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -126,9 +126,12 @@ namespace AWS.Deploy.DockerEngine
         {
             var content = ProjectUtilities.ReadDockerFileConfig();
             var definitions = JsonConvert.DeserializeObject<List<ImageDefinition>>(content);
-            var mappings = definitions.Where(x => x.SdkType.Equals(_project.SdkType)).FirstOrDefault();
+            var mappings = definitions.FirstOrDefault(x => x.SdkType.Equals(_project.SdkType));
+            if (mappings == null)
+                throw new UnsupportedProjectException($"The project with SDK Type {_project.SdkType} is not supported.");
 
-            return mappings.ImageMapping.FirstOrDefault(x => x.TargetFramework.Equals(_project.TargetFramework));
+            return mappings.ImageMapping.FirstOrDefault(x => x.TargetFramework.Equals(_project.TargetFramework))
+                ?? throw new UnsupportedProjectException($"The project with Target Framework {_project.TargetFramework} is not supported.");
         }
 
         /// <summary>

--- a/src/AWS.Deploy.DockerEngine/DockerFile.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerFile.cs
@@ -63,7 +63,7 @@ namespace AWS.Deploy.DockerEngine
                     projects += $"COPY [\"{projectList[i]}\", \"{projectList[i].Substring(0, projectList[i].LastIndexOf("/") + 1)}\"]" + (i < projectList.Count - 1 ? Environment.NewLine : "");
                 }
 
-                projectPath = projectList.Where(x => x.EndsWith(_projectName)).FirstOrDefault();
+                projectPath = projectList.First(x => x.EndsWith(_projectName));
                 if (projectPath.LastIndexOf("/") > -1)
                 {
                     projectFolder = projectPath.Substring(0, projectPath.LastIndexOf("/"));

--- a/src/AWS.Deploy.DockerEngine/Exceptions.cs
+++ b/src/AWS.Deploy.DockerEngine/Exceptions.cs
@@ -24,4 +24,9 @@ namespace AWS.Deploy.DockerEngine
     {
         public DockerEngineExceptionBase(string message) : base(message) { }
     }
+
+    public class UnsupportedProjectException : DockerEngineExceptionBase
+    {
+        public UnsupportedProjectException(string message) : base(message) { }
+    }
 }

--- a/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
+++ b/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
@@ -13,10 +13,14 @@ namespace AWS.Deploy.Orchestration
     {
         public string Build(CloudApplication cloudApplication, Recommendation recommendation)
         {
+            var projectPath = new FileInfo(recommendation.ProjectPath).Directory?.FullName;
+            if (string.IsNullOrEmpty(projectPath))
+                throw new InvalidProjectPathException("The project path provided is invalid.");
+
             // General Settings
             var appSettingsContainer = new RecipeConfiguration<Dictionary<string, object>>(
                 cloudApplication.StackName,
-                new FileInfo(recommendation.ProjectPath).Directory.FullName,
+                projectPath,
                 recommendation.Recipe.Id,
                 recommendation.Recipe.Version,
                 new ()

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -138,7 +138,9 @@ namespace AWS.Deploy.Orchestration
         private string GetDockerExecutionDirectory(Recommendation recommendation)
         {
             var dockerExecutionDirectory = recommendation.DeploymentBundle.DockerExecutionDirectory;
-            var dockerFileDirectory = new FileInfo(recommendation.ProjectPath).Directory.FullName;
+            var dockerFileDirectory = new FileInfo(recommendation.ProjectPath).Directory?.FullName;
+            if (dockerFileDirectory == null)
+                throw new InvalidProjectPathException("The project path is invalid.");
             var projectSolutionPath = GetProjectSolutionFile(recommendation.ProjectPath);
 
             if (string.IsNullOrEmpty(dockerExecutionDirectory))
@@ -149,7 +151,8 @@ namespace AWS.Deploy.Orchestration
                 }
                 else
                 {
-                    dockerExecutionDirectory = new FileInfo(projectSolutionPath).Directory.FullName;
+                    var projectSolutionDirectory = new FileInfo(projectSolutionPath).Directory?.FullName;
+                    dockerExecutionDirectory = projectSolutionDirectory ?? throw new InvalidSolutionPathException("The solution path is invalid.");
                 }
             }
 
@@ -158,7 +161,9 @@ namespace AWS.Deploy.Orchestration
 
         private string GetDockerFilePath(Recommendation recommendation)
         {
-            var dockerFileDirectory = new FileInfo(recommendation.ProjectPath).Directory.FullName;
+            var dockerFileDirectory = new FileInfo(recommendation.ProjectPath).Directory?.FullName;
+            if (dockerFileDirectory == null)
+                throw new InvalidProjectPathException("The project path is invalid.");
 
             return Path.Combine(dockerFileDirectory, "Dockerfile");
         }

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -128,4 +128,22 @@ namespace AWS.Deploy.Orchestration
     {
         public InvalidRecipePathException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Exception thrown if Solution Path contains an invalid path
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class InvalidSolutionPathException : Exception
+    {
+        public InvalidSolutionPathException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
+
+    /// <summary>
+    /// Exception thrown if AWS Deploy Recipes CDK Common Product Version is invalid.
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class InvalidAWSDeployRecipesCDKCommonVersionException : Exception
+    {
+        public InvalidAWSDeployRecipesCDKCommonVersionException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Orchestration/IOrchestratorInteractiveService.cs
+++ b/src/AWS.Deploy.Orchestration/IOrchestratorInteractiveService.cs
@@ -5,10 +5,10 @@ namespace AWS.Deploy.Orchestration
 {
     public interface IOrchestratorInteractiveService
     {
-        void LogErrorMessageLine(string message);
+        void LogErrorMessageLine(string? message);
 
-        void LogMessageLine(string message);
+        void LogMessageLine(string? message);
 
-        void LogDebugLine(string message);
+        void LogDebugLine(string? message);
     }
 }

--- a/src/AWS.Deploy.Orchestration/RecommendationEngine/FileExistsTest.cs
+++ b/src/AWS.Deploy.Orchestration/RecommendationEngine/FileExistsTest.cs
@@ -16,6 +16,11 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
         public override Task<bool> Execute(RecommendationTestInput input)
         {
             var directory = Path.GetDirectoryName(input.ProjectDefinition.ProjectPath);
+
+            if (directory == null ||
+                input.Test.Condition.FileName == null)
+                return Task.FromResult(false);
+
             var result = (Directory.GetFiles(directory, input.Test.Condition.FileName).Length == 1);
             return Task.FromResult(result);
         }

--- a/src/AWS.Deploy.Orchestration/TemplateEngine.cs
+++ b/src/AWS.Deploy.Orchestration/TemplateEngine.cs
@@ -61,7 +61,8 @@ namespace AWS.Deploy.Orchestration
 
                 // CDK Template projects can parameterize the version number of the AWS.Deploy.Recipes.CDK.Common package. This avoid
                 // projects having to be modified every time the package version is bumped.
-                { "AWSDeployRecipesCDKCommonVersion", FileVersionInfo.GetVersionInfo(typeof(Constants.CloudFormationIdentifier).Assembly.Location).ProductVersion }
+                { "AWSDeployRecipesCDKCommonVersion", FileVersionInfo.GetVersionInfo(typeof(Constants.CloudFormationIdentifier).Assembly.Location).ProductVersion
+                                                      ?? throw new InvalidAWSDeployRecipesCDKCommonVersionException("The version number of the AWS.Deploy.Recipes.CDK.Common package is invalid.") }
             };
 
             foreach(var option in recommendation.Recipe.OptionSettings)

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitionLocator.cs
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitionLocator.cs
@@ -10,7 +10,7 @@ namespace AWS.Deploy.Recipes
         public static string FindDeploymentBundleDefinitionPath()
         {
             var assemblyPath = typeof(DeploymentBundleDefinitionLocator).Assembly.Location;
-            var deploymentBundleDefinitionPath = Path.Combine(Directory.GetParent(assemblyPath).FullName, "DeploymentBundleDefinitions");
+            var deploymentBundleDefinitionPath = Path.Combine(Directory.GetParent(assemblyPath)!.FullName, "DeploymentBundleDefinitions");
             return deploymentBundleDefinitionPath;
         }
     }

--- a/src/AWS.Deploy.Recipes/RecipeLocator.cs
+++ b/src/AWS.Deploy.Recipes/RecipeLocator.cs
@@ -10,7 +10,7 @@ namespace AWS.Deploy.Recipes
         public static string FindRecipeDefinitionsPath()
         {
             var assemblyPath = typeof(RecipeLocator).Assembly.Location;
-            var recipePath = Path.Combine(Directory.GetParent(assemblyPath).FullName, "RecipeDefinitions");
+            var recipePath = Path.Combine(Directory.GetParent(assemblyPath)!.FullName, "RecipeDefinitions");
             return recipePath;
         }
     }

--- a/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
+++ b/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Product>AWS .NET deployment tool Server Mode Client</Product>
     <Description>Package to access the APIs exposed by the deployment tool server mode. This package is not intended for direct usage.</Description>
     <PackageId>AWS.Deploy.ServerMode.Client</PackageId>

--- a/src/AWS.Deploy.ServerMode.ClientGenerator/Program.cs
+++ b/src/AWS.Deploy.ServerMode.ClientGenerator/Program.cs
@@ -55,10 +55,16 @@ namespace AWS.Deploy.ServerMode.ClientGenerator
         {
             var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
 
-            while (!string.Equals(dir.Name, "src"))
+            while (!string.Equals(dir?.Name, "src"))
             {
+                if (dir == null)
+                    break;
+
                 dir = dir.Parent;
             }
+
+            if (dir == null)
+                throw new Exception("Could not determine file path of current directory.");
 
             return Path.Combine(dir.FullName, "AWS.Deploy.ServerMode.Client", codeFile);
         }


### PR DESCRIPTION
*Issue #, if available:*
Closes #224 

*Description of changes:*
Add NET5 as a target framework
Fix nullability issues caused as a result of adding NET5 as a TF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
