### PR TITLE
fix: Only set AWS credentials for processes that require it

### DIFF
--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -43,7 +43,8 @@ namespace AWS.Deploy.CLI.Utilities
             Action<TryRunResult>? onComplete = null,
             bool redirectIO = true,
             IDictionary<string, string>? environmentVariables = null,
-            CancellationToken cancelToken = default)
+            CancellationToken cancelToken = default,
+            bool needAwsCredentials = false)
         {
             StringBuilder strOutput = new StringBuilder();
             StringBuilder strError = new StringBuilder();
@@ -74,7 +75,9 @@ namespace AWS.Deploy.CLI.Utilities
             }
 
             UpdateEnvironmentVariables(processStartInfo, environmentVariables);
-            _processStartInfoAction?.Invoke(processStartInfo);
+
+            if (needAwsCredentials)
+                _processStartInfoAction?.Invoke(processStartInfo);
 
             var process = Process.Start(processStartInfo);
             if (null == process)

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -50,13 +50,15 @@ namespace AWS.Deploy.Orchestration
             _interactiveService.LogMessageLine("Starting deployment of CDK Project");
 
             // Ensure region is bootstrapped
-            await _commandLineWrapper.Run($"npx cdk bootstrap aws://{session.AWSAccountId}/{session.AWSRegion}");
+            await _commandLineWrapper.Run($"npx cdk bootstrap aws://{session.AWSAccountId}/{session.AWSRegion}",
+                needAwsCredentials: true);
 
             // Handover to CDK command line tool
             // Use a CDK Context parameter to specify the settings file that has been serialized.
             await _commandLineWrapper.Run( $"npx cdk deploy --require-approval never -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
                 workingDirectory: cdkProjectPath,
-                environmentVariables: environmentVariables);
+                environmentVariables: environmentVariables,
+                needAwsCredentials: true);
         }
 
         private async Task<string> CreateCdkProjectForDeployment(Recommendation recommendation, OrchestratorSession session)

--- a/src/AWS.Deploy.Orchestration/Utilities/ICommandLineWrapper.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/ICommandLineWrapper.cs
@@ -51,7 +51,8 @@ namespace AWS.Deploy.Orchestration.Utilities
             Action<TryRunResult>? onComplete = null,
             bool redirectIO = true,
             IDictionary<string, string>? environmentVariables = null,
-            CancellationToken cancelToken = default);
+            CancellationToken cancelToken = default,
+            bool needAwsCredentials = false);
 
         /// <summary>
         /// Configure the child process that executes the command passed as parameter in <see cref="Run"/> method.
@@ -103,7 +104,8 @@ namespace AWS.Deploy.Orchestration.Utilities
             bool streamOutputToInteractiveService = false,
             bool redirectIO = true,
             IDictionary<string, string>? environmentVariables = null,
-            CancellationToken cancelToken = default)
+            CancellationToken cancelToken = default,
+            bool needAwsCredentials = false)
         {
             var result = new TryRunResult();
 
@@ -114,7 +116,8 @@ namespace AWS.Deploy.Orchestration.Utilities
                 onComplete: runResult => result = runResult,
                 redirectIO: redirectIO,
                 environmentVariables: environmentVariables,
-                cancelToken: cancelToken);
+                cancelToken: cancelToken,
+                needAwsCredentials: needAwsCredentials);
 
             return result;
         }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolCommandLineWrapper.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolCommandLineWrapper.cs
@@ -57,7 +57,8 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             Action<TryRunResult> onComplete = null,
             bool redirectIO = true,
             IDictionary<string, string> environmentVariables = null,
-            CancellationToken cancelToken = default)
+            CancellationToken cancelToken = default,
+            bool needAwsCredentials = false)
         {
             CommandsToExecute.Add(new CommandLineRunObject
             {

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestCommandLineWrapper.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestCommandLineWrapper.cs
@@ -23,7 +23,8 @@ namespace AWS.Deploy.Orchestration.UnitTests
             Action<TryRunResult> onComplete = null,
             bool redirectIO = true,
             IDictionary<string, string> environmentVariables = null,
-            CancellationToken cancelToken = default)
+            CancellationToken cancelToken = default,
+            bool needAwsCredentials = false)
         {
             Commands.Add((command, workingDirectory, streamOutputToInteractiveService));
             onComplete?.Invoke(Results.Last());


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5136

*Description of changes:*
Currently we are setting the AWS credentials as environment variables for every command line process. This PR aims to mitigate that by only setting the credentials for processes that require it.

The following processes need AWS credentials:
1. Docker Login Command - This command needs the credentials to generate authorization tokens which are passed as `--username` and `--password` arguments. These tokens are generate by calling the appropriate API using the ECR service client - [proof](https://github.com/aws/aws-dotnet-deploy/blob/main/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs#L206)
2. CDK Bootstrap command - The credentials need to be passed as environment variables.
3. CDK deploy command - The credentials need to be passed as environment variables.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
