### PR TITLE
fix: Modified ECS cluster name regex validation

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -125,9 +125,9 @@
                         {
                             "ValidatorType": "Regex",
                             "Configuration" : {
-                                "Regex": "^([A-Za-z0-9-]{1,255})$",
+                                "Regex": "^([A-Za-z0-9_-]{1,255})$",
                                 "AllowEmptyString": true,
-                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens and can't be longer than 255 character in length."
+                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens, underscores and can't be longer than 255 character in length."
                             }
                         }
                     ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -134,9 +134,9 @@
                         {
                             "ValidatorType": "Regex",
                             "Configuration" : {
-                                "Regex": "^([A-Za-z0-9-]{1,255})$",
+                                "Regex": "^([A-Za-z0-9_-]{1,255})$",
                                 "AllowEmptyString": true,
-                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens and can't be longer than 255 character in length."
+                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens, underscores and can't be longer than 255 character in length."
                             }
                         }
                     ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -134,9 +134,9 @@
                         {
                             "ValidatorType": "Regex",
                             "Configuration" : {
-                                "Regex": "^([A-Za-z0-9-]{1,255})$",
+                                "Regex": "^([A-Za-z0-9_-]{1,255})$",
                                 "AllowEmptyString": true,
-                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens and can't be longer than 255 character in length."
+                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens, underscores and can't be longer than 255 character in length."
                             }
                         }
                     ],


### PR DESCRIPTION
*Description of changes:*

Previously the ECS service model did not allow underscores to be a part of the cluster name - [link](https://github.com/aws/aws-sdk-net/blob/51023cdd2a7ee03ac3cc80aa01da56a1fe8296d0/generator/ServiceModels/ecs/ecs-2014-11-13.normal.json#L1810)
However, the current model allows underscore characters - [link](https://github.com/aws/aws-sdk-net/blob/master/generator/ServiceModels/ecs/ecs-2014-11-13.normal.json#L1815)

This PR modifies the regex validation on ECS cluster name to accommodate underscore characters


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
