### PR TITLE
feat: add GetConfigSettings API to retrieve Option Setting Items in Server Mode

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -27,6 +27,7 @@ using AWS.Deploy.CLI.Extensions;
 using AWS.Deploy.Orchestration.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Amazon.Runtime;
+using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.CLI.ServerMode.Controllers
 {
@@ -125,6 +126,59 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             }
 
             return Ok(output);
+        }
+
+        /// <summary>
+        /// Gets the list of updatable option setting items for the selected recommendation.
+        /// </summary>
+        [HttpGet("session/<sessionId>/settings")]
+        [SwaggerOperation(OperationId = "GetConfigSettings")]
+        [SwaggerResponse(200, type: typeof(GetOptionSettingsOutput))]
+        [Authorize]
+        public IActionResult GetConfigSettings(string sessionId)
+        {
+            var state = _stateServer.Get(sessionId);
+            if (state == null)
+            {
+                return NotFound($"Session ID {sessionId} not found.");
+            }
+
+            if (state.SelectedRecommendation == null)
+            {
+                return NotFound($"A deployment target is not set for Session ID {sessionId}.");
+            }
+
+            var orchestrator = CreateOrchestrator(state);
+
+            var deploymentBundleDefinition = orchestrator.GetDeploymentBundleDefinition(state.SelectedRecommendation);
+
+            var configurableOptionSettings = state.SelectedRecommendation.Recipe.OptionSettings.Union(deploymentBundleDefinition.Parameters);
+
+            var output = new GetOptionSettingsOutput();
+            output.OptionSettings = ListOptionSettingSummary(state.SelectedRecommendation, configurableOptionSettings);
+
+            return Ok(output);
+        }
+
+        private List<OptionSettingItemSummary> ListOptionSettingSummary(Recommendation recommendation, IEnumerable<OptionSettingItem> configurableOptionSettings)
+        {
+            var optionSettingItems = new List<OptionSettingItemSummary>();
+
+            foreach (var setting in configurableOptionSettings)
+            {
+                var settingSummary = new OptionSettingItemSummary(setting.Id, setting.Name, setting.Description, setting.Type.ToString())
+                {
+                    TypeHint = setting.TypeHint?.ToString(),
+                    Value = recommendation.GetOptionSettingValue(setting),
+                    Advanced = setting.AdvancedSetting,
+                    Updatable = (!recommendation.IsExistingCloudApplication || setting.Updatable) && recommendation.IsOptionSettingDisplayable(setting),
+                    ChildOptionSettings = ListOptionSettingSummary(recommendation, setting.ChildOptionSettings)
+                };
+
+                optionSettingItems.Add(settingSummary);
+            }
+
+            return optionSettingItems;
         }
 
         /// <summary>

--- a/src/AWS.Deploy.CLI/ServerMode/Models/GetOptionSettingsOutput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/GetOptionSettingsOutput.cs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class GetOptionSettingsOutput
+    {
+        public IList<OptionSettingItemSummary> OptionSettings { get; set; } = new List<OptionSettingItemSummary>();
+    }
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class OptionSettingItemSummary
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+
+        public object? Value { get; set; }
+
+        public string Type { get; set; }
+
+        public string? TypeHint { get; set; }
+
+        public bool Advanced { get; set; }
+
+        public bool Updatable { get; set; }
+
+        public List<OptionSettingItemSummary> ChildOptionSettings { get; set; } = new();
+
+        public OptionSettingItemSummary(string id, string name, string description, string type)
+        {
+            Id = id;
+            Name = name;
+            Description = description;
+            Type = type;
+        }
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -62,6 +62,17 @@ namespace AWS.Deploy.ServerMode.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<GetRecommendationsOutput> GetRecommendationsAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
+        /// <summary>Gets the list of updatable option setting items for the selected recommendation.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<GetOptionSettingsOutput> GetConfigSettingsAsync(string sessionId);
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Gets the list of updatable option setting items for the selected recommendation.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<GetOptionSettingsOutput> GetConfigSettingsAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
+    
         /// <summary>Gets the list of existing deployments that are compatible with the session's project.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -430,6 +441,87 @@ namespace AWS.Deploy.ServerMode.Client
                         if (status_ == 200)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<GetRecommendationsOutput>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+    
+        /// <summary>Gets the list of updatable option setting items for the selected recommendation.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<GetOptionSettingsOutput> GetConfigSettingsAsync(string sessionId)
+        {
+            return GetConfigSettingsAsync(sessionId, System.Threading.CancellationToken.None);
+        }
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Gets the list of updatable option setting items for the selected recommendation.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<GetOptionSettingsOutput> GetConfigSettingsAsync(string sessionId, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/v1/Deployment/session/<sessionId>/settings?");
+            if (sessionId != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("sessionId") + "=").Append(System.Uri.EscapeDataString(ConvertToString(sessionId, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+    
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+    
+                    PrepareRequest(client_, request_, urlBuilder_);
+    
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+    
+                    PrepareRequest(client_, request_, url_);
+    
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+    
+                        ProcessResponse(client_, response_);
+    
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<GetOptionSettingsOutput>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -922,6 +1014,15 @@ namespace AWS.Deploy.ServerMode.Client
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class GetOptionSettingsOutput 
+    {
+        [Newtonsoft.Json.JsonProperty("optionSettings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<OptionSettingItemSummary> OptionSettings { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
     public partial class GetRecommendationsOutput 
     {
         [Newtonsoft.Json.JsonProperty("recommendations", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -936,6 +1037,39 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public SystemStatus Status { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class OptionSettingItemSummary 
+    {
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Value { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Type { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("typeHint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string TypeHint { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("advanced", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool Advanced { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("updatable", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool Updatable { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("childOptionSettings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<OptionSettingItemSummary> ChildOptionSettings { get; set; }
     
     
     }

--- a/src/AWS.Deploy.ServerMode.ClientGenerator/AWS.Deploy.ServerMode.ClientGenerator.csproj
+++ b/src/AWS.Deploy.ServerMode.ClientGenerator/AWS.Deploy.ServerMode.ClientGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
IDE-5165

*Description of changes:*
feat: add GetConfigSettings API to retrieve Option Setting Items in Server Mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
