### PR TITLE
fix: Update EBS platformArn regex validation to make the account ID as optional

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -242,8 +242,8 @@
                 {
                     "ValidatorType": "Regex",
                     "Configuration" : {
-                        "Regex": "arn:[^:]+:elasticbeanstalk:[^:]*:[0-9]{12}:platform/.+",
-                        "ValidationFailedMessage": "Invalid ElasticBeanstalkPlatform Arn. The ARN should contain the arn:[PARTITION]:elasticbeanstalk namespace, followed by the region, the account ID, and then the resource path. For example - arn:aws:elasticbeanstalk:us-east-2:123456789012:platform/MyPlatform/1.0 is a valid Arn. For more information visit https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.policies.arn.html"
+                        "Regex": "arn:[^:]+:elasticbeanstalk:[^:]+:[^:]*:platform/.+",
+                        "ValidationFailedMessage": "Invalid ElasticBeanstalkPlatform Arn. The ARN should contain the arn:[PARTITION]:elasticbeanstalk namespace, followed by the region, an optional account ID, and then the resource path. For example - arn:aws:elasticbeanstalk:us-east-2:123456789012:platform/MyPlatform/1.0 is a valid Arn. For more information visit https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.policies.arn.html"
                     }
                 }
             ]

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
@@ -65,16 +65,16 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         }
 
         [Theory]
-        [InlineData("arn:aws:elasticbeanstalk::123456789012:platform/MyPlatform", true)]
-        [InlineData("arn:aws-cn:elasticbeanstalk::123456789012:platform/MyPlatform", true)]
-        [InlineData("arn:aws:elasticbeanstalk::123456789012:platform/MyPlatform/v1.0", true)]
-        [InlineData("arn:aws:elasticbeanstalk::123456789012:platform/", false)] //no resource path
-        [InlineData("arn:aws:elasticbeanstack::123456789012:platform/MyPlatform", false)] //Typo elasticbeanstack instead of elasticbeanstalk
-        [InlineData("arn:aws:elasticbeanstalk::1234567890121234:platform/MyPlatform", false)] //invalid account ID
+        [InlineData("arn:aws:elasticbeanstalk:us-east-1:123456789012:platform/MyPlatform", true)]
+        [InlineData("arn:aws-cn:elasticbeanstalk:us-west-1:123456789012:platform/MyPlatform", true)]
+        [InlineData("arn:aws:elasticbeanstalk:eu-west-1:123456789012:platform/MyPlatform/v1.0", true)]
+        [InlineData("arn:aws:elasticbeanstalk:us-west-2::platform/MyPlatform/v1.0", true)]
+        [InlineData("arn:aws:elasticbeanstalk:us-east-1:123456789012:platform/", false)] //no resource path
+        [InlineData("arn:aws:elasticbeanstack:eu-west-1:123456789012:platform/MyPlatform", false)] //Typo elasticbeanstack instead of elasticbeanstalk
         public void ElasticBeanstalkPlatformArnValidationTest(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
-            optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:elasticbeanstalk:[^:]*:[0-9]{12}:platform/.+"));
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:elasticbeanstalk:[^:]+:[^:]*:platform/.+"));
             Validate(optionSettingItem, value, isValid);
         }
 


### PR DESCRIPTION
*Description of changes:*
* Fixed regex validation to make the account ID as optional in Elastic Beanstalk platformArn.
* Included valid regions in the test-cases.

![image](https://user-images.githubusercontent.com/36622308/122797913-fc4c1b80-d28d-11eb-959b-607acb15963a.png)

The above image shows all the default settings when performing a deployment with an Elastic Beanstalk recipe. As seen, the platform ARN does not contain the account-ID

The regex has been inferred from this [doc](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.policies.arn.html)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
