### PR TITLE
fix: fix invalid date format exception thrown from VS Toolkit

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/ServerModeHttpClient.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeHttpClient.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.ServerMode.Client
                 {"awsAccessKeyId", credentials.AccessKey },
                 {"awsSecretKey", credentials.SecretKey },
                 {"requestId", Guid.NewGuid().ToString() },
-                {"issueDate", DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo) }
+                {"issueDate", DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffZ", DateTimeFormatInfo.InvariantInfo) }
             };
 
             if(!string.IsNullOrEmpty(credentials.Token))


### PR DESCRIPTION
*Issue #, if available:*
IDE-5162

*Description of changes:*
Fix for the error:
"'DateTimeInvalidLocalFormat' : 'A UTC DateTime is being converted to text in a format that is only correct for local times. This can happen when calling DateTime.ToString using the 'z' format specifier, which will include a local time zone offset in the output. In that case, either use the 'Z' format specifier, which designates a UTC time, or use the 'o' format string, which is the recommended way to persist a DateTime in text. This can also occur when passing a DateTime to be serialized by XmlConvert or DataSet. If using XmlConvert.ToString, pass in XmlDateTimeSerializationMode.RoundtripKind to serialize correctly. If using DataSet, set the DateTimeMode on the DataColumn object to DataSetDateTime.Utc. '"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
