### PR TITLE
fix: Use RecipeConfiguration to inject values for account ID and region in the generated CDK project.

### DIFF
--- a/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
+++ b/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
@@ -11,7 +11,7 @@ namespace AWS.Deploy.Orchestration
 {
     public class CdkAppSettingsSerializer
     {
-        public string Build(CloudApplication cloudApplication, Recommendation recommendation)
+        public string Build(CloudApplication cloudApplication, Recommendation recommendation, OrchestratorSession session)
         {
             var projectPath = new FileInfo(recommendation.ProjectPath).Directory?.FullName;
             if (string.IsNullOrEmpty(projectPath))
@@ -23,6 +23,8 @@ namespace AWS.Deploy.Orchestration
                 projectPath,
                 recommendation.Recipe.Id,
                 recommendation.Recipe.Version,
+                session.AWSAccountId,
+                session.AWSRegion,
                 new ()
                 )
             {

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -40,7 +40,7 @@ namespace AWS.Deploy.Orchestration
             var cdkProjectPath = await CreateCdkProjectForDeployment(recommendation, session);
 
             // Write required configuration in appsettings.json
-            var appSettingsBody = _appSettingsBuilder.Build(cloudApplication, recommendation);
+            var appSettingsBody = _appSettingsBuilder.Build(cloudApplication, recommendation, session);
             var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
             using (var appSettingsFile = new StreamWriter(appSettingsFilePath))
             {

--- a/src/AWS.Deploy.Recipes.CDK.Common/RecipeConfiguration.cs
+++ b/src/AWS.Deploy.Recipes.CDK.Common/RecipeConfiguration.cs
@@ -56,6 +56,16 @@ namespace AWS.Deploy.Recipes.CDK.Common
         /// </summary>
         public T Settings { get; set; }
 
+        /// <summary>
+        /// The Region used during deployment. 
+        /// </summary>
+        public string AWSRegion { get; set; }
+
+        /// <summary>
+        /// The account ID used during deployment.
+        /// </summary>
+        public string AWSAccountId { get; set; }
+
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
         /// The warnings are disabled since a parameterless constructor will allow non-nullable properties to be initialized with null values.
@@ -66,13 +76,16 @@ namespace AWS.Deploy.Recipes.CDK.Common
         }
 #nullable restore warnings
 
-        public RecipeConfiguration(string stackName, string projectPath, string recipeId, string recipeVersion, T settings)
+        public RecipeConfiguration(string stackName, string projectPath, string recipeId, string recipeVersion,
+             string awsAccountId, string awsRegion,  T settings)
         {
             StackName = stackName;
             ProjectPath = projectPath;
             RecipeId = recipeId;
             RecipeVersion = recipeVersion;
-            Settings = settings;
+            AWSAccountId = awsAccountId;
+            AWSRegion = awsRegion;
+            Settings = settings;   
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/.template.config/template.json
@@ -14,18 +14,6 @@
     "sourceName": "AspNetAppEcsFargate",
     "preferNameDirectory": true,
     "symbols": {
-        "AWSAccountId": {
-            "type": "parameter",
-            "description": "Specifies the AWS Account ID",
-            "replaces": "AWSAccountId",
-            "datatype": "string"
-        },
-        "AWSRegion": {
-            "type": "parameter",
-            "description": "Specifies the AWS Region",
-            "replaces": "AWSRegion",
-            "datatype": "string"
-        },
         "AWSDeployRecipesCDKCommonVersion": {
             "type": "parameter",
             "description": "The version number of AWS.Deploy.Recipes.CDK.Common to use",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Program.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Program.cs
@@ -23,8 +23,8 @@ namespace AspNetAppEcsFargate
             {
                 Env = new Environment
                 {
-                    Account = "AWSAccountId",
-                    Region = "AWSRegion"
+                    Account = recipeConfiguration.AWSAccountId,
+                    Region = recipeConfiguration.AWSRegion
                 }
             }), recipeConfiguration);
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
@@ -14,18 +14,6 @@
     "sourceName": "AspNetAppElasticBeanstalkLinux",
     "preferNameDirectory": true,
     "symbols": {
-        "AWSAccountId": {
-            "type": "parameter",
-            "description": "Specifies the AWS Account ID",
-            "replaces": "AWSAccountId",
-            "datatype": "string"
-        },
-        "AWSRegion": {
-            "type": "parameter",
-            "description": "Specifies the AWS Region",
-            "replaces": "AWSRegion",
-            "datatype": "string"
-        },
         "AWSDeployRecipesCDKCommonVersion": {
             "type": "parameter",
             "description": "The version number of AWS.Deploy.Recipes.CDK.Common to use",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Program.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Program.cs
@@ -21,8 +21,8 @@ namespace AspNetAppElasticBeanstalkLinux
             {
                 Env = new Environment
                 {
-                    Account = "AWSAccountId",
-                    Region = "AWSRegion"
+                    Account = recipeConfiguration.AWSAccountId,
+                    Region = recipeConfiguration.AWSRegion
                 }
             }), recipeConfiguration);
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/.template.config/template.json
@@ -14,18 +14,6 @@
     "sourceName": "ConsoleAppECSFargateScheduleTask",
     "preferNameDirectory": true,
     "symbols": {
-        "AWSAccountId": {
-            "type": "parameter",
-            "description": "Specifies the AWS Account ID",
-            "replaces": "AWSAccountId",
-            "datatype": "string"
-        },
-        "AWSRegion": {
-            "type": "parameter",
-            "description": "Specifies the AWS Region",
-            "replaces": "AWSRegion",
-            "datatype": "string"
-        },
         "AWSDeployRecipesCDKCommonVersion": {
             "type": "parameter",
             "description": "The version number of AWS.Deploy.Recipes.CDK.Common to use",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Program.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Program.cs
@@ -18,8 +18,8 @@ namespace BlazorWasm
             {
                 Env = new Environment
                 {
-                    Account = "AWSAccountId",
-                    Region = "AWSRegion"
+                    Account = recipeConfiguration.AWSAccountId,
+                    Region = recipeConfiguration.AWSRegion
                 }
             }), recipeConfiguration);
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/.template.config/template.json
@@ -14,18 +14,6 @@
     "sourceName": "ConsoleAppECSFargateScheduleTask",
     "preferNameDirectory": true,
     "symbols": {
-        "AWSAccountId": {
-            "type": "parameter",
-            "description": "Specifies the AWS Account ID",
-            "replaces": "AWSAccountId",
-            "datatype": "string"
-        },
-        "AWSRegion": {
-            "type": "parameter",
-            "description": "Specifies the AWS Region",
-            "replaces": "AWSRegion",
-            "datatype": "string"
-        },
         "AWSDeployRecipesCDKCommonVersion": {
             "type": "parameter",
             "description": "The version number of AWS.Deploy.Recipes.CDK.Common to use",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/Program.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/Program.cs
@@ -21,8 +21,8 @@ namespace ConsoleAppECSFargateScheduleTask
             {
                 Env = new Environment
                 {
-                    Account = "AWSAccountId",
-                    Region = "AWSRegion"
+                    Account = recipeConfiguration.AWSAccountId,
+                    Region = recipeConfiguration.AWSRegion
                 }
             }), recipeConfiguration);
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/.template.config/template.json
@@ -14,18 +14,6 @@
     "sourceName": "ConsoleAppEcsFargateService",
     "preferNameDirectory": true,
     "symbols": {
-        "AWSAccountId": {
-            "type": "parameter",
-            "description": "Specifies the AWS Account ID",
-            "replaces": "AWSAccountId",
-            "datatype": "string"
-        },
-        "AWSRegion": {
-            "type": "parameter",
-            "description": "Specifies the AWS Region",
-            "replaces": "AWSRegion",
-            "datatype": "string"
-        },
         "AWSDeployRecipesCDKCommonVersion": {
             "type": "parameter",
             "description": "The version number of AWS.Deploy.Recipes.CDK.Common to use",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Program.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Program.cs
@@ -21,8 +21,8 @@ namespace ConsoleAppEcsFargateService
             {
                 Env = new Environment
                 {
-                    Account = "AWSAccountId",
-                    Region = "AWSRegion"
+                    Account = recipeConfiguration.AWSAccountId,
+                    Region = recipeConfiguration.AWSRegion
                 }
             }), recipeConfiguration);
 


### PR DESCRIPTION
*Issue #, if available:*
`5137`

*Description of changes:*
This PR injects the account ID and region values in the generated CDK project using the RecipeConfiguration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
