### PR TITLE
feat: add SetConfigSettings API to set configuration settings

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Models/ApplyConfigSettingsInput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/ApplyConfigSettingsInput.cs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class ApplyConfigSettingsInput
+    {
+        public Dictionary<string, string> UpdatedSettings { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Models/ApplyConfigSettingsOutput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/ApplyConfigSettingsOutput.cs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class ApplyConfigSettingsOutput
+    {
+        public IDictionary<string, string> FailedConfigUpdates { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -73,6 +73,21 @@ namespace AWS.Deploy.ServerMode.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<GetOptionSettingsOutput> GetConfigSettingsAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
+        /// <summary>Applies a value for a list of option setting items on the selected recommendation.
+        /// Option setting updates are provided as Key Value pairs with the Key being the JSON path to the leaf node.
+        /// Only primitive data types are supported for Value updates. The Value is a string value which will be parsed as its corresponding data type.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<ApplyConfigSettingsOutput> ApplyConfigSettingsAsync(string sessionId, ApplyConfigSettingsInput body);
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Applies a value for a list of option setting items on the selected recommendation.
+        /// Option setting updates are provided as Key Value pairs with the Key being the JSON path to the leaf node.
+        /// Only primitive data types are supported for Value updates. The Value is a string value which will be parsed as its corresponding data type.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<ApplyConfigSettingsOutput> ApplyConfigSettingsAsync(string sessionId, ApplyConfigSettingsInput body, System.Threading.CancellationToken cancellationToken);
+    
         /// <summary>Gets the list of existing deployments that are compatible with the session's project.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -548,6 +563,94 @@ namespace AWS.Deploy.ServerMode.Client
             }
         }
     
+        /// <summary>Applies a value for a list of option setting items on the selected recommendation.
+        /// Option setting updates are provided as Key Value pairs with the Key being the JSON path to the leaf node.
+        /// Only primitive data types are supported for Value updates. The Value is a string value which will be parsed as its corresponding data type.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<ApplyConfigSettingsOutput> ApplyConfigSettingsAsync(string sessionId, ApplyConfigSettingsInput body)
+        {
+            return ApplyConfigSettingsAsync(sessionId, body, System.Threading.CancellationToken.None);
+        }
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Applies a value for a list of option setting items on the selected recommendation.
+        /// Option setting updates are provided as Key Value pairs with the Key being the JSON path to the leaf node.
+        /// Only primitive data types are supported for Value updates. The Value is a string value which will be parsed as its corresponding data type.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<ApplyConfigSettingsOutput> ApplyConfigSettingsAsync(string sessionId, ApplyConfigSettingsInput body, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/v1/Deployment/session/<sessionId>/settings?");
+            if (sessionId != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("sessionId") + "=").Append(System.Uri.EscapeDataString(ConvertToString(sessionId, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+    
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(body, _settings.Value));
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+    
+                    PrepareRequest(client_, request_, urlBuilder_);
+    
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+    
+                    PrepareRequest(client_, request_, url_);
+    
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+    
+                        ProcessResponse(client_, response_);
+    
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApplyConfigSettingsOutput>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+    
         /// <summary>Gets the list of existing deployments that are compatible with the session's project.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -965,6 +1068,24 @@ namespace AWS.Deploy.ServerMode.Client
         }
     }
 
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class ApplyConfigSettingsInput 
+    {
+        [Newtonsoft.Json.JsonProperty("updatedSettings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.IDictionary<string, string> UpdatedSettings { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class ApplyConfigSettingsOutput 
+    {
+        [Newtonsoft.Json.JsonProperty("failedConfigUpdates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.IDictionary<string, string> FailedConfigUpdates { get; set; }
+    
+    
+    }
+    
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
     public enum DeploymentStatus
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added SetConfigSettings that takes a list of updated settings and applies them. If there is an error setting any of them, a list of errors is returned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
