### PR TITLE
fix: Fix misleading language in user input prompt to deploy to a new or an existing Cloudformation stack

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -354,7 +354,8 @@ namespace AWS.Deploy.CLI.Commands
                         _consoleUtilities.AskUserForValue(
                             title,
                             defaultName,
-                            allowEmpty: false);
+                            allowEmpty: false,
+                            defaultAskValuePrompt: Constants.CLI.PROMPT_NEW_STACK_NAME);
                 }
                 else
                 {
@@ -366,7 +367,10 @@ namespace AWS.Deploy.CLI.Commands
                             existingApplications.Select(x => x.Name),
                             title,
                             askNewName: true,
-                            defaultNewName: defaultName);
+                            defaultNewName: defaultName,
+                            defaultChoosePrompt: Constants.CLI.PROMPT_CHOOSE_STACK_NAME,
+                            defaultCreateNewPrompt: Constants.CLI.PROMPT_NEW_STACK_NAME,
+                            defaultCreateNewLabel: Constants.CLI.CREATE_NEW_STACK_LABEL) ;
 
                     cloudApplicationName = userResponse.SelectedOption ?? userResponse.NewName;
                 }
@@ -382,8 +386,8 @@ namespace AWS.Deploy.CLI.Commands
         private void PrintInvalidStackNameMessage()
         {
             _toolInteractiveService.WriteLine();
-            _toolInteractiveService.WriteLine(
-                "Invalid stack name.  A stack name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
+            _toolInteractiveService.WriteErrorLine(
+                "Invalid stack name. A stack name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
                 "It must start with an alphabetic character and can't be longer than 128 characters");
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
@@ -25,8 +25,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     recommendation.GetOptionSettingValue<string>(optionSetting),
                     allowEmpty: true,
                     resetValue: recommendation.GetOptionSettingDefaultValue<string>(optionSetting) ?? "",
-                    // validators:
-                    buildArgs => ValidateBuildArgs(buildArgs))
+                    validators: buildArgs => ValidateBuildArgs(buildArgs))
                 .ToString()
                 .Replace("\"", "\"\"");
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
@@ -25,8 +25,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     recommendation.GetOptionSettingValue<string>(optionSetting),
                     allowEmpty: true,
                     resetValue: recommendation.GetOptionSettingDefaultValue<string>(optionSetting) ?? "",
-                    // validators:
-                    executionDirectory => ValidateExecutionDirectory(executionDirectory));
+                    validators: executionDirectory => ValidateExecutionDirectory(executionDirectory));
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = settingValue;
             return Task.FromResult<object>(settingValue);

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -25,8 +25,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     recommendation.GetOptionSettingValue<string>(optionSetting),
                     allowEmpty: true,
                     resetValue: recommendation.GetOptionSettingDefaultValue<string>(optionSetting) ?? "",
-                    // validators:
-                    publishArgs => ValidateDotnetPublishArgs(publishArgs))     
+                    validators: publishArgs => ValidateDotnetPublishArgs(publishArgs))     
                 .ToString()
                 .Replace("\"", "\"\"");
 

--- a/src/AWS.Deploy.Constants/CLI.cs
+++ b/src/AWS.Deploy.Constants/CLI.cs
@@ -9,5 +9,8 @@ namespace AWS.Deploy.Constants
         public const string CREATE_NEW_LABEL = "*** Create new ***";
         public const string DEFAULT_LABEL = "*** Default ***";
         public const string EMPTY_LABEL = "*** Empty ***";
+        public const string CREATE_NEW_STACK_LABEL = "*** Deploy to a new stack ***";
+        public const string PROMPT_NEW_STACK_NAME = "Enter the name of the new stack";
+        public const string PROMPT_CHOOSE_STACK_NAME = "Choose stack to deploy to";
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5193

*Description of changes:*
This PR fixes the misleading language in user input prompt to deploy to a new or an existing Cloudformation stack.

![image](https://user-images.githubusercontent.com/36622308/123856180-c55db180-d8ee-11eb-856e-6950a2f87fd5.png)
![image](https://user-images.githubusercontent.com/36622308/123856402-0e156a80-d8ef-11eb-8e67-2de60771d83f.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
