### PR TITLE
feat: Create command to save the CDK deployment project

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -15,6 +15,7 @@ using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.CLI.Commands.CommandHandlerInput;
+using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.CLI.Commands
 {
@@ -32,6 +33,8 @@ namespace AWS.Deploy.CLI.Commands
         private static readonly Option<bool> _optionDiagnosticLogging = new(new []{"-d", "--diagnostics"}, "Enable diagnostic output.");
         private static readonly Option<string> _optionApply = new("--apply", "Path to the deployment settings file to be applied.");
         private static readonly Option<bool> _optionDisableInteractive = new(new []{"-s", "--silent" }, "Disable interactivity to deploy without any prompts for user input.");
+        private static readonly Option<string> _optionOutputDirectory = new(new[]{"-o", "--output"}, "Directory path in which the CDK deployment project will be saved.");
+        private static readonly Option<string> _optionProjectDisplayName = new(new[] { "--project-display-name" }, "The name of the deployment project that will be displayed in the list of available deployment options.");
 
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
@@ -98,6 +101,7 @@ namespace AWS.Deploy.CLI.Commands
             rootCommand.Add(BuildDeployCommand());
             rootCommand.Add(BuildListCommand());
             rootCommand.Add(BuildDeleteCommand());
+            rootCommand.Add(BuildDeploymentProjectCommand());
             rootCommand.Add(BuildServerModeCommand());
 
             return rootCommand;
@@ -305,6 +309,81 @@ namespace AWS.Deploy.CLI.Commands
                 }
             });
             return listCommand;
+        }
+
+        /// <summary>
+        /// Builds the top level command called "deployment-project" which supports the creation and saving of the
+        /// CDK deployment project.
+        /// </summary>
+        /// <returns>An instance of the <see cref="Command"/> class</returns>
+        private Command BuildDeploymentProjectCommand()
+        {
+            var deploymentProjectCommand = new Command("deployment-project",
+                "Save the deployment project inside a user provided directory path.");
+
+            var generateDeploymentProjectCommand = new Command("generate",
+                "Save the deployment project inside a user provided directory path without proceeding with a deployment")
+            {
+                _optionOutputDirectory,
+                _optionDiagnosticLogging,
+                _optionProjectPath,
+                _optionProjectDisplayName
+            };
+
+            generateDeploymentProjectCommand.Handler = CommandHandler.Create(async (GenerateDeploymentProjectCommandHandlerInput input) =>
+            {
+                try
+                {
+                    _toolInteractiveService.Diagnostics = input.Diagnostics;
+                    var projectDefinition = await _projectParserUtility.Parse(input.ProjectPath ?? "");
+
+                    var saveDirectory = input.Output ?? "";
+                    var projectDisplayName = input.ProjectDisplayName ?? "";
+
+                    OrchestratorSession session = new OrchestratorSession(projectDefinition);
+
+                    var targetApplicationFullPath = new DirectoryManager().GetDirectoryInfo(projectDefinition.ProjectPath).FullName;
+
+                    var generateDeploymentProject = new GenerateDeploymentProjectCommand(
+                        _toolInteractiveService,
+                        _consoleUtilities,
+                        _cdkProjectHandler,
+                        _commandLineWrapper,
+                        new DirectoryManager(),
+                        new FileManager(),
+                        session,
+                        targetApplicationFullPath);
+
+                    await generateDeploymentProject.ExecuteAsync(saveDirectory, projectDisplayName);
+
+                    return CommandReturnCodes.SUCCESS;
+                }
+                catch (Exception e) when (e.IsAWSDeploymentExpectedException())
+                {
+                    _toolInteractiveService.WriteErrorLine("Failed to generate deployment project.");
+                    if (input.Diagnostics)
+                        _toolInteractiveService.WriteErrorLine(e.PrettyPrint());
+                    else
+                    {
+                        _toolInteractiveService.WriteErrorLine(string.Empty);
+                        _toolInteractiveService.WriteErrorLine(e.Message);
+                    }
+                    // bail out with an non-zero return code.
+                    return CommandReturnCodes.USER_ERROR;
+                }
+                catch (Exception e)
+                {
+                    // This is a bug
+                    _toolInteractiveService.WriteErrorLine(
+                        "Unhandled exception.  This is a bug.  Please copy the stack trace below and file a bug at https://github.com/aws/aws-dotnet-deploy. " +
+                        e.PrettyPrint());
+
+                    return CommandReturnCodes.UNHANDLED_EXCEPTION;
+                }
+            });
+
+            deploymentProjectCommand.Add(generateDeploymentProjectCommand);
+            return deploymentProjectCommand;
         }
 
         private Command BuildServerModeCommand()

--- a/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/GenerateDeploymentProjectCommandHandlerInput.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/GenerateDeploymentProjectCommandHandlerInput.cs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.CLI.Commands.CommandHandlerInput
+{
+    /// <summary>
+    /// This class maps the command line options for the "deployment-project generate" command to the appropriate C# properties.
+    /// </summary>
+    public class GenerateDeploymentProjectCommandHandlerInput
+    {
+        public string? ProjectPath { get; set; }
+        public bool Diagnostics { get; set; }
+        public string? Output { get; set; }
+        public string? ProjectDisplayName { get; set; }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
@@ -1,0 +1,231 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.Utilities;
+using AWS.Deploy.Recipes;
+using Newtonsoft.Json;
+
+namespace AWS.Deploy.CLI.Commands
+{
+    /// <summary>
+    /// The class supports the functionality to create a new CDK project and save it at a customer
+    /// specified directory location.
+    /// </summary>
+    public class GenerateDeploymentProjectCommand
+    {
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly ICdkProjectHandler _cdkProjectHandler;
+        private readonly ICommandLineWrapper _commandLineWrapper;
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IFileManager _fileManager;
+        private readonly OrchestratorSession _session;
+        private readonly string _targetApplicationFullPath;
+        
+        public GenerateDeploymentProjectCommand(
+            IToolInteractiveService toolInteractiveService,
+            IConsoleUtilities consoleUtilities,
+            ICdkProjectHandler cdkProjectHandler,
+            ICommandLineWrapper commandLineWrapper,
+            IDirectoryManager directoryManager,
+            IFileManager fileManager,
+            OrchestratorSession session,
+            string targetApplicationFullPath)
+        {
+            _toolInteractiveService = toolInteractiveService;
+            _consoleUtilities = consoleUtilities;
+            _cdkProjectHandler = cdkProjectHandler;
+            _commandLineWrapper = commandLineWrapper;
+            _directoryManager = directoryManager;
+            _fileManager = fileManager;
+            _session = session;
+            _targetApplicationFullPath = targetApplicationFullPath;
+        }
+
+        /// <summary>
+        /// This method takes a user specified directory path and generates the CDK deployment project at this location.
+        /// If the provided directory path is an empty string, then a default directory is created to save the CDK deployment project.
+        /// </summary>
+        /// <param name="saveCdkDirectoryPath">An absolute or a relative path provided by the user.</param>
+        /// <param name="projectDisplayName">The name of the deployment project that will be displayed in the list of available deployment options.</param>
+        /// <returns></returns>
+        public async Task ExecuteAsync(string saveCdkDirectoryPath, string projectDisplayName)
+        {
+            var orchestrator = new Orchestrator(_session, new[] { RecipeLocator.FindRecipeDefinitionsPath() });
+            var recommendations = await GenerateDeploymentRecommendations(orchestrator);
+            var selectedRecommendation = _consoleUtilities.AskToChooseRecommendation(recommendations);
+
+            if (string.IsNullOrEmpty(saveCdkDirectoryPath))
+                saveCdkDirectoryPath = GenerateDefaultSaveDirectoryPath();
+
+            var newDirectoryCreated = CreateSaveCdkDirectory(saveCdkDirectoryPath);
+
+            var (isValid, errorMessage) = ValidateSaveCdkDirectory(saveCdkDirectoryPath);
+            if (!isValid)
+            {
+                if (newDirectoryCreated)
+                    _directoryManager.Delete(saveCdkDirectoryPath);
+                throw new InvalidSaveDirectoryForCdkProject(errorMessage);
+            }
+            
+            var directoryUnderSourceControl = await IsDirectoryUnderSourceControl(saveCdkDirectoryPath);
+            if (!directoryUnderSourceControl)
+            {
+                var userPrompt = "Warning: The target directory is not being tracked by source control. If the saved deployment " +
+                    "project is used for deployment it is important that the deployment project is retained to allow " +
+                    "future redeployments to previously deployed applications. " + Environment.NewLine + Environment.NewLine +
+                    "Do you still want to continue?";
+
+                _toolInteractiveService.WriteLine();
+                var yesNoResult = _consoleUtilities.AskYesNoQuestion(userPrompt, YesNo.Yes);
+
+                if (yesNoResult == YesNo.No)
+                {
+                    if (newDirectoryCreated)
+                        _directoryManager.Delete(saveCdkDirectoryPath);
+                    return;
+                }
+            }
+
+            await _cdkProjectHandler.CreateCdkProjectForDeployment(selectedRecommendation, _session, saveCdkDirectoryPath);
+            await GenerateDeploymentRecipeSnapShot(selectedRecommendation, saveCdkDirectoryPath, projectDisplayName);
+
+            var saveCdkDirectoryInfo = _directoryManager.GetDirectoryInfo(saveCdkDirectoryPath);
+            _toolInteractiveService.WriteLine();
+            _toolInteractiveService.WriteLine($"The CDK deployment project is saved at: {saveCdkDirectoryInfo.FullName}");
+        }
+
+        /// <summary>
+        /// This method generates the appropriate recommendations for the target deployment project.
+        /// </summary>
+        /// <param name="orchestrator"><see cref="Orchestrator"/></param>
+        /// <returns>A list of <see cref="Recommendation"/></returns>
+        private async Task<List<Recommendation>> GenerateDeploymentRecommendations(Orchestrator orchestrator)
+        {
+            var recommendations = await orchestrator.GenerateDeploymentRecommendations(forDeployment: false);
+            if (recommendations.Count == 0)
+            {
+                throw new FailedToGenerateAnyRecommendations("The project you are trying to deploy is currently not supported.");
+            }
+            return recommendations;
+        }
+
+        /// <summary>
+        /// This method takes the path to the target deployment project and creates
+        /// a default save directory inside the parent folder of the current directory.
+        /// For example:
+        /// Target project directory - C:\Codebase\MyWebApp
+        /// Generated default save directory - C:\Codebase\MyWebAppCDK If the save directory already exists, then a suffix number is attached.
+        /// </summary>
+        /// <returns>The defaukt save directory path.</returns>
+        private string GenerateDefaultSaveDirectoryPath()
+        {
+            var applicatonDirectoryFullPath = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath).Parent.FullName;
+            var saveCdkDirectoryFullPath = applicatonDirectoryFullPath + "CDK";
+
+            var suffixNumber = 0;
+            while (_directoryManager.Exists(saveCdkDirectoryFullPath))
+                saveCdkDirectoryFullPath = applicatonDirectoryFullPath + $"CDK{++suffixNumber}";
+            
+            return saveCdkDirectoryFullPath;
+        }
+
+        /// <summary>
+        /// This method takes a path and creates a new directory at this path if one does not already exist.
+        /// </summary>
+        /// <param name="saveCdkDirectoryPath">Relative or absolute path of the directory at which the CDK deployment project will be saved.</param>
+        /// <returns>A boolean to indicate if a new directory was created.</returns>
+        private bool CreateSaveCdkDirectory(string saveCdkDirectoryPath)
+        {
+            var newDirectoryCreated = false;
+            if (!_directoryManager.Exists(saveCdkDirectoryPath))
+            {
+                _directoryManager.CreateDirectory(saveCdkDirectoryPath);
+                newDirectoryCreated = true;
+            }
+            return newDirectoryCreated;   
+        }
+
+        /// <summary>
+        /// This method takes the path to the intended location of the CDK deployment project and performs validations on it.
+        /// </summary>
+        /// <param name="saveCdkDirectoryPath">Relative or absolute path of the directory at which the CDK deployment project will be saved.</param>
+        /// <returns>A tuple containaing a boolean that indicates if the directory is valid and a corresponding string error message.</returns>
+        private Tuple<bool, string> ValidateSaveCdkDirectory(string saveCdkDirectoryPath)
+        {
+            var errorMessage = string.Empty;
+            var isValid = true;
+            var targetApplicationDirectoryFullPath = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath).Parent.FullName;
+           
+            if (!_directoryManager.IsEmpty(saveCdkDirectoryPath))
+            {
+                errorMessage += "The directory specified for saving the CDK project is non-empty. " +
+                    "Please provide an empty directory path and try again." + Environment.NewLine;
+
+                isValid = false;
+            }
+            if (_directoryManager.ExistsInsideDirectory(targetApplicationDirectoryFullPath, saveCdkDirectoryPath))
+            {
+                errorMessage += "The directory used to save the CDK deployment project is contained inside of " +
+                    "the target application project directory. Please specify a different directory and try again.";
+
+                isValid = false;
+            }
+
+            return new Tuple<bool, string>(isValid, errorMessage.Trim());
+        }
+
+        /// <summary>
+        /// Checks if the location of the saved CDK deployment project is monitored by a source control system.
+        /// </summary>
+        /// <param name="saveCdkDirectoryPath">Relative or absolute path of the directory at which the CDK deployment project will be saved.</param>
+        /// <returns></returns>
+        private async Task<bool> IsDirectoryUnderSourceControl(string saveCdkDirectoryPath)
+        {
+            var gitStatusResult = await _commandLineWrapper.TryRunWithResult("git status", saveCdkDirectoryPath);
+            var svnStatusResult = await _commandLineWrapper.TryRunWithResult("svn status", saveCdkDirectoryPath);
+            return gitStatusResult.Success || svnStatusResult.Success;
+        }
+
+        /// <summary>
+        /// Generates a snapshot of the deployment recipe inside the location at which the CDK deployment project is saved.
+        /// </summary>
+        /// <param name="recommendation"><see cref="Recommendation"/></param>
+        /// <param name="saveCdkDirectoryPath">Relative or absolute path of the directory at which the CDK deployment project will be saved.</param>
+        /// <param name="projectDisplayName">The name of the deployment project that will be displayed in the list of available deployment options.</param>
+        private async Task GenerateDeploymentRecipeSnapShot(Recommendation recommendation, string saveCdkDirectoryPath, string projectDisplayName)
+        {
+            var targetApplicationDirectoryName = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath).Parent.Name;
+            var recipeSnapshotFileName = _directoryManager.GetDirectoryInfo(saveCdkDirectoryPath).Name + ".recipe";
+            var recipeSnapshotFilePath = Path.Combine(saveCdkDirectoryPath, recipeSnapshotFileName);
+            var recipePath = recommendation.Recipe.RecipePath;
+
+            if (string.IsNullOrEmpty(recipePath))
+                throw new InvalidOperationException("The recipe path cannot be null or empty as part " +
+                    $"of the {nameof(recommendation.Recipe)} object");
+
+            var recipeBody = await _fileManager.ReadAllTextAsync(recipePath);
+            var recipe = JsonConvert.DeserializeObject<RecipeDefinition>(recipeBody);
+            
+            var recipeName = string.IsNullOrEmpty(projectDisplayName) ?
+                $"Deployment project for {targetApplicationDirectoryName} to {recommendation.Recipe.TargetService}"
+                : projectDisplayName;
+
+            recipe.Id = Guid.NewGuid().ToString();
+            recipe.Name = recipeName;
+            recipe.CdkProjectTemplateId = null;
+            recipe.CdkProjectTemplate = null;
+
+            var recipeSnapshotBody = JsonConvert.SerializeObject(recipe, Formatting.Indented);
+            await _fileManager.WriteAllTextAsync(recipeSnapshotFilePath, recipeSnapshotBody);
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -79,4 +79,13 @@ namespace AWS.Deploy.CLI
     {
         public FailedToFindCompatibleRecipeException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if the directory specified to save the CDK deployment project is invalid.
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class InvalidSaveDirectoryForCdkProject : Exception
+    {
+        public InvalidSaveDirectoryForCdkProject(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Common/IO/DirectoryManager.cs
+++ b/src/AWS.Deploy.Common/IO/DirectoryManager.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
 
 namespace AWS.Deploy.Common.IO
@@ -8,16 +9,38 @@ namespace AWS.Deploy.Common.IO
     public interface IDirectoryManager
     {
         DirectoryInfo CreateDirectory(string path);
+        DirectoryInfo GetDirectoryInfo(string path);
         bool Exists(string path);
-        string[] GetFiles(string projectPath, string? searchPattern = null);
+        string[] GetFiles(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly);
+        string[] GetDirectories(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly);
+        bool IsEmpty(string path);
+        bool ExistsInsideDirectory(string parentDirectoryPath, string childPath);
+        void Delete(string path, bool recursive = false);
     }
 
     public class DirectoryManager : IDirectoryManager
     {
         public DirectoryInfo CreateDirectory(string path) => Directory.CreateDirectory(path);
+            
+        public DirectoryInfo GetDirectoryInfo(string path) => new DirectoryInfo(path);
 
         public bool Exists(string path) => Directory.Exists(path);
 
-        public string[] GetFiles(string path, string? searchPattern = null) => Directory.GetFiles(path, searchPattern ?? "*");
+        public string[] GetFiles(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            => Directory.GetFiles(path, searchPattern ?? "*", searchOption);
+        
+        public string[] GetDirectories(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            => Directory.GetDirectories(path, searchPattern ?? "*", searchOption);
+
+        public bool IsEmpty(string path) => GetFiles(path).Length == 0 && GetDirectories(path).Length == 0;
+
+        public bool ExistsInsideDirectory(string parentDirectoryPath, string childPath)
+        {
+            var parentDirectoryFullPath = GetDirectoryInfo(parentDirectoryPath).FullName;
+            var childFullPath = GetDirectoryInfo(childPath).FullName;
+            return childFullPath.Contains(parentDirectoryFullPath + Path.DirectorySeparatorChar, StringComparison.InvariantCulture);
+        }
+
+        public void Delete(string path, bool recursive = false) => Directory.Delete(path, recursive);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -62,12 +62,12 @@ namespace AWS.Deploy.Common.Recipes
         /// <summary>
         /// The location of the CDK project template relative from the recipe definition file.
         /// </summary>
-        public string CdkProjectTemplate { get; set; }
+        public string? CdkProjectTemplate { get; set; }
 
         /// <summary>
         /// The ID of the CDK project template for the template generator.
         /// </summary>
-        public string CdkProjectTemplateId { get; set; }
+        public string? CdkProjectTemplateId { get; set; }
 
         /// <summary>
         /// The rules used by the recommendation engine to determine if the recipe definition is compatible with the project.

--- a/src/AWS.Deploy.Common/Recipes/Validation/IDeployToolValidationContext.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IDeployToolValidationContext.cs
@@ -16,6 +16,6 @@ namespace AWS.Deploy.Common.Recipes.Validation
     public interface IDeployToolValidationContext
     {
         ProjectDefinition ProjectDefinition { get; }
-        string AWSRegion { get; }
+        string? AWSRegion { get; }
     }
 }

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -1,3 +1,4 @@
+
 using System;
 using AWS.Deploy.Common;
 

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -24,15 +24,15 @@ namespace AWS.Deploy.Orchestration
     {
         private const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
 
-        private readonly ICdkProjectHandler _cdkProjectHandler;
-        private readonly ICDKManager _cdkManager;
-        private readonly IOrchestratorInteractiveService _interactiveService;
-        private readonly IAWSResourceQueryer _awsResourceQueryer;
-        private readonly IDeploymentBundleHandler _deploymentBundleHandler;
-        private readonly IDockerEngine _dockerEngine;
-        private readonly IList<string> _recipeDefinitionPaths;
+        private readonly ICdkProjectHandler? _cdkProjectHandler;
+        private readonly ICDKManager? _cdkManager;
+        private readonly IOrchestratorInteractiveService? _interactiveService;
+        private readonly IAWSResourceQueryer? _awsResourceQueryer;
+        private readonly IDeploymentBundleHandler? _deploymentBundleHandler;
+        private readonly IDockerEngine? _dockerEngine;
+        private readonly IList<string>? _recipeDefinitionPaths;
 
-        private readonly OrchestratorSession _session;
+        private readonly OrchestratorSession? _session;
 
         public Orchestrator(
             OrchestratorSession session,
@@ -54,9 +54,24 @@ namespace AWS.Deploy.Orchestration
             _recipeDefinitionPaths = recipeDefinitionPaths;
         }
 
-        public async Task<List<Recommendation>> GenerateDeploymentRecommendations()
+        public Orchestrator(OrchestratorSession session, IList<string> recipeDefinitionPaths)
         {
+            _session = session;
+            _recipeDefinitionPaths = recipeDefinitionPaths;
+        }
+
+        public async Task<List<Recommendation>> GenerateDeploymentRecommendations(bool forDeployment = true)
+        {
+            if (_recipeDefinitionPaths == null)
+                throw new InvalidOperationException($"{nameof(_recipeDefinitionPaths)} is null as part of the orchestartor object");
+            if (_session == null)
+                throw new InvalidOperationException($"{nameof(_session)} is null as part of the orchestartor object");
+
             var engine = new RecommendationEngine.RecommendationEngine(_recipeDefinitionPaths, _session);
+
+            if (!forDeployment)
+                return await engine.ComputeRecommendations();
+
             var additionalReplacements = await GetReplacements();
             return await engine.ComputeRecommendations(additionalReplacements);
         }
@@ -64,6 +79,9 @@ namespace AWS.Deploy.Orchestration
         public async Task<Dictionary<string, string>> GetReplacements()
         {
             var replacements = new Dictionary<string, string>();
+
+            if (_awsResourceQueryer == null)
+                throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
 
             var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn();
             replacements[REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN] = latestPlatform.PlatformArn;
@@ -73,6 +91,15 @@ namespace AWS.Deploy.Orchestration
 
         public async Task DeployRecommendation(CloudApplication cloudApplication, Recommendation recommendation)
         {
+            if (_interactiveService == null)
+                throw new InvalidOperationException($"{nameof(_interactiveService)} is null as part of the orchestartor object");
+            if (_cdkManager == null)
+                throw new InvalidOperationException($"{nameof(_cdkManager)} is null as part of the orchestartor object");
+            if (_cdkProjectHandler == null)
+                throw new InvalidOperationException($"{nameof(_cdkProjectHandler)} is null as part of the orchestartor object");
+            if (_session == null)
+                throw new InvalidOperationException($"{nameof(_session)} is null as part of the orchestartor object");
+
             _interactiveService.LogMessageLine(string.Empty);
             _interactiveService.LogMessageLine($"Initiating deployment: {recommendation.Name}");
 
@@ -124,6 +151,13 @@ namespace AWS.Deploy.Orchestration
 
         public async Task<bool> CreateContainerDeploymentBundle(CloudApplication cloudApplication, Recommendation recommendation)
         {
+            if (_interactiveService == null)
+                throw new InvalidOperationException($"{nameof(_recipeDefinitionPaths)} is null as part of the orchestartor object");
+            if (_dockerEngine == null)
+                throw new InvalidOperationException($"{nameof(_dockerEngine)} is null as part of the orchestartor object");
+            if (_deploymentBundleHandler == null)
+                throw new InvalidOperationException($"{nameof(_deploymentBundleHandler)} is null as part of the orchestartor object");
+
             if (!recommendation.ProjectDefinition.HasDockerFile)
             {
                 _interactiveService.LogMessageLine("Generating Dockerfile...");
@@ -159,6 +193,11 @@ namespace AWS.Deploy.Orchestration
 
         public async Task<bool> CreateDotnetPublishDeploymentBundle(Recommendation recommendation)
         {
+            if (_deploymentBundleHandler == null)
+                throw new InvalidOperationException($"{nameof(_deploymentBundleHandler)} is null as part of the orchestartor object");
+            if (_interactiveService == null)
+                throw new InvalidOperationException($"{nameof(_interactiveService)} is null as part of the orchestartor object");
+
             try
             {
                 await _deploymentBundleHandler.CreateDotnetPublishZip(recommendation);

--- a/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
+++ b/src/AWS.Deploy.Orchestration/OrchestratorSession.cs
@@ -16,8 +16,8 @@ namespace AWS.Deploy.Orchestration
     {
         public ProjectDefinition ProjectDefinition { get; set; }
         public string? AWSProfileName { get; set; }
-        public AWSCredentials AWSCredentials { get; set; }
-        public string AWSRegion { get; set; }
+        public AWSCredentials? AWSCredentials { get; set; }
+        public string? AWSRegion { get; set; }
         /// <remarks>
         /// Calculating the current <see cref="SystemCapabilities"/> can take several seconds
         /// and is not needed immediately so it is run as a background Task.
@@ -25,7 +25,7 @@ namespace AWS.Deploy.Orchestration
         /// It's safe to repeatedly await this property; evaluation will only be done once.
         /// </remarks>
         public Task<SystemCapabilities>? SystemCapabilities { get; set; }
-        public string AWSAccountId { get; set; }
+        public string? AWSAccountId { get; set; }
 
         public OrchestratorSession(
             ProjectDefinition projectDefinition,
@@ -37,6 +37,11 @@ namespace AWS.Deploy.Orchestration
             AWSCredentials = awsCredentials;
             AWSRegion = awsRegion;
             AWSAccountId = awsAccountId;
+        }
+
+        public OrchestratorSession(ProjectDefinition projectDefinition)
+        {
+            ProjectDefinition = projectDefinition;
         }
     }
 }

--- a/src/AWS.Deploy.Recipes.CDK.Common/RecipeConfiguration.cs
+++ b/src/AWS.Deploy.Recipes.CDK.Common/RecipeConfiguration.cs
@@ -59,12 +59,12 @@ namespace AWS.Deploy.Recipes.CDK.Common
         /// <summary>
         /// The Region used during deployment. 
         /// </summary>
-        public string AWSRegion { get; set; }
+        public string? AWSRegion { get; set; }
 
         /// <summary>
         /// The account ID used during deployment.
         /// </summary>
-        public string AWSAccountId { get; set; }
+        public string? AWSAccountId { get; set; }
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
@@ -77,7 +77,7 @@ namespace AWS.Deploy.Recipes.CDK.Common
 #nullable restore warnings
 
         public RecipeConfiguration(string stackName, string projectPath, string recipeId, string recipeVersion,
-             string awsAccountId, string awsRegion,  T settings)
+             string? awsAccountId, string? awsRegion,  T settings)
         {
             StackName = stackName;
             ProjectPath = projectPath;

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
@@ -18,12 +18,27 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
             return new DirectoryInfo(path);
         }
 
+        public void Delete(string path, bool recursive = false) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
+        public bool ExistsInsideDirectory(string parentDirectoryPath, string childPath) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
         public bool Exists(string path)
         {
             return CreatedDirectories.Contains(path);
         }
 
-        public string[] GetFiles(string projectPath, string searchPattern = null) =>
+        public string[] GetDirectories(string path, string searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
+        public DirectoryInfo GetDirectoryInfo(string path) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
+        public string[] GetFiles(string path, string searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
+        public bool IsEmpty(string path) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/SaveCdkDeploymentProjectTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/SaveCdkDeploymentProjectTests.cs
@@ -1,0 +1,167 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
+{
+    public class SaveCdkDeploymentProjectTests : IDisposable
+    {
+        private readonly App _app;
+        private readonly InMemoryInteractiveService _interactiveService;
+        private readonly string _targetApplicationProjectPath;
+
+        private bool _isDisposed;
+        private string _saveDirectoryPath;
+
+        public SaveCdkDeploymentProjectTests()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _app = serviceProvider.GetService<App>();
+            Assert.NotNull(_app);
+
+            _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
+            Assert.NotNull(_interactiveService);
+
+            _targetApplicationProjectPath = Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj");
+        }
+
+        [Fact]
+        public async Task DefaultSaveDirectory()
+        {
+            // Arrange input for saving the CDK deployment project
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
+
+            // Generate and save the CDK deployment project
+            var deployArgs = new[] { "deployment-project", "generate", "--project-path", _targetApplicationProjectPath};
+            await _app.Run(deployArgs);
+
+            // Verify project is saved
+            _saveDirectoryPath = Path.Combine("testapps", "WebAppWithDockerFileCDK");
+            var directoryInfo = new DirectoryInfo(_saveDirectoryPath);
+            var stdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var successMessage = $"The CDK deployment project is saved at: {directoryInfo.FullName}";
+
+            Assert.Contains(stdOut, (line) => successMessage.Equals(line));
+            Assert.True(Directory.Exists(_saveDirectoryPath));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "WebAppWithDockerFileCDK.csproj")));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "AppStack.cs")));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "Program.cs")));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "cdk.json")));
+            Assert.True(Directory.EnumerateFiles(_saveDirectoryPath, "*.recipe").Any());
+
+            // Delete save directory
+            Directory.Delete(_saveDirectoryPath, true);
+
+            // Verify directory is deleted
+            Assert.False(Directory.Exists(_saveDirectoryPath));
+        }
+
+        [Fact]
+        public async Task CustomSaveDirectory()
+        {
+            // Arrange input for saving the CDK deployment project
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
+
+            // Generate and save the CDK deployment project
+            _saveDirectoryPath = Path.Combine("DeploymentProjects", "MyCdkApp");
+            var deployArgs = new[] { "deployment-project", "generate", "--project-path", _targetApplicationProjectPath, "--output", _saveDirectoryPath };
+            var returnCode = await _app.Run(deployArgs);
+
+            // Verify project is saved
+            var directoryInfo = new DirectoryInfo(_saveDirectoryPath);
+            var stdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var successMessage = $"The CDK deployment project is saved at: {directoryInfo.FullName}";
+
+            Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
+            Assert.Contains(stdOut, (line) => successMessage.Equals(line));
+            Assert.True(Directory.Exists(_saveDirectoryPath));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "MyCdkApp.csproj")));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "AppStack.cs")));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "Program.cs")));
+            Assert.True(File.Exists(Path.Combine(_saveDirectoryPath, "cdk.json")));
+            Assert.True(Directory.EnumerateFiles(_saveDirectoryPath, "*.recipe").Any());
+
+            // Delete save directory
+            Directory.Delete(_saveDirectoryPath, true);
+
+            // Verify directory is deleted
+            Assert.False(Directory.Exists(_saveDirectoryPath));
+        }
+
+        [Fact]
+        public async Task InvalidSaveCdkDirectoryInsideProjectDirectory()
+        {
+            // Arrange input for saving the CDK deployment project
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
+
+            // Generate and save the CDK deployment project
+            _saveDirectoryPath = Path.Combine("testapps", "WebAppWithDockerFile", "MyCdkApp");
+            var deployArgs = new[] { "deployment-project", "generate", "--project-path", _targetApplicationProjectPath, "--output", _saveDirectoryPath };
+            var returnCode = await _app.Run(deployArgs);
+
+            Assert.Equal(CommandReturnCodes.USER_ERROR, returnCode);
+            Assert.False(Directory.Exists(_saveDirectoryPath));
+        }
+
+        [Fact]
+        public async Task InvalidNonEmptySaveCdkDirectory()
+        {
+            // Arrange input for saving the CDK deployment project
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
+
+            // create a non-empty directory inside which we intend to save the CDK deployment project.
+            Directory.CreateDirectory(Path.Combine("DeploymentProjects", "MyCdkApp"));
+
+            // Generate and save the CDK deployment project
+            _saveDirectoryPath = "DeploymentProjects";
+            var deployArgs = new[] { "deployment-project", "generate", "--project-path", _targetApplicationProjectPath, "--output", _saveDirectoryPath };
+            var returnCode = await _app.Run(deployArgs);
+
+            Assert.Equal(CommandReturnCodes.USER_ERROR, returnCode);
+
+            Directory.Delete("DeploymentProjects", true);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                var directoryExists = Directory.Exists(_saveDirectoryPath);
+                if (directoryExists)
+                {
+                    Directory.Delete(_saveDirectoryPath, true);
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~SaveCdkDeploymentProjectTests()
+        {
+            Dispose(false);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
1. `DOTNET-5245`
2. `DOTNET-5246`

*Description of changes:*
1. Add a new command that generate the CDK deployment project and saves it at a user-specified directory. 
2. Generate a deployment recipe snapshot that is taken at the time of the CDK deployment project generation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
