### PR TITLE
feat: Add logging messages to show what docker build command and from what directory the build will happen

### DIFF
--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -56,6 +56,9 @@ namespace AWS.Deploy.Orchestration
             var buildArgs = GetDockerBuildArgs(recommendation);
 
             var dockerBuildCommand = $"docker build -t {imageTag} -f \"{dockerFile}\"{buildArgs} .";
+            _interactiveService.LogMessageLine($"Docker Execution Directory: {Path.GetFullPath(dockerExecutionDirectory)}");
+            _interactiveService.LogMessageLine($"Docker Build Command: {dockerBuildCommand}");
+
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;
 


### PR DESCRIPTION
*Description of changes:*
While recently setting up a CodeBuild jobs I was running into a lot of Docker build issues. It would have greatly helped my debugging effort if I knew for sure what exactly was the Docker execution directory was in CodeBuild. Added logging messages to better help debugging efforts in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
