### PR TITLE
fix: Correctly resolve target project path

### DIFF
--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -33,10 +33,18 @@ namespace AWS.Deploy.Common
             _directoryManager = directoryManager;
         }
 
+        /// <summary>
+        /// This method parses the target application project and sets the
+        /// appropriate metadata as part of the <see cref="ProjectDefinition"/>
+        /// </summary>
+        /// <param name="projectPath">The project path can be an absolute or a relative path to the
+        /// target application project directory or the application project file.</param>
+        /// <returns><see cref="ProjectDefinition"/></returns>
         public async Task<ProjectDefinition> Parse(string projectPath)
         {
             if (_directoryManager.Exists(projectPath))
             {
+                projectPath = _directoryManager.GetDirectoryInfo(projectPath).FullName;
                 var files = _directoryManager.GetFiles(projectPath, "*.csproj");
                 if (files.Length == 1)
                 {

--- a/test/AWS.Deploy.CLI.UnitTests/ProjectDefinitionParserTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ProjectDefinitionParserTest.cs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using Xunit;
+using Should;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class ProjectDefinitionParserTest
+    {
+        [Theory]
+        [InlineData("WebAppWithDockerFile", "WebAppWithDockerFile.csproj")]
+        [InlineData("WebAppNoDockerFile", "WebAppNoDockerFile.csproj")]
+        [InlineData("ConsoleAppTask", "ConsoleAppTask.csproj")]
+        [InlineData("ConsoleAppService", "ConsoleAppService.csproj")]
+        [InlineData("MessageProcessingApp", "MessageProcessingApp.csproj")]
+        [InlineData("ContosoUniversityBackendService", "ContosoUniversityBackendService.csproj")]
+        [InlineData("ContosoUniversityWeb", "ContosoUniversity.csproj")]
+        [InlineData("BlazorWasm31", "BlazorWasm31.csproj")]
+        [InlineData("BlazorWasm50", "BlazorWasm50.csproj")]
+        public async Task ParseProjectDefinitionWithRelativeProjectPath(string projectName, string csprojName)
+        {
+            //Arrange
+            var currrentWorkingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location); 
+            var projectDirectoryPath = SystemIOUtilities.ResolvePath(projectName);
+            var absoluteProjectDirectoryPath = new DirectoryInfo(projectDirectoryPath).FullName;
+            var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
+            var relativeProjectDirectoryPath = Path.GetRelativePath(currrentWorkingDirectory, absoluteProjectDirectoryPath);
+
+            // Act
+            var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(relativeProjectDirectoryPath);
+
+            // Assert
+            projectDefinition.ShouldNotBeNull();
+            Assert.Equal(absoluteProjectPath, projectDefinition.ProjectPath);
+        }
+
+        [Theory]
+        [InlineData("WebAppWithDockerFile", "WebAppWithDockerFile.csproj")]
+        [InlineData("WebAppNoDockerFile", "WebAppNoDockerFile.csproj")]
+        [InlineData("ConsoleAppTask", "ConsoleAppTask.csproj")]
+        [InlineData("ConsoleAppService", "ConsoleAppService.csproj")]
+        [InlineData("MessageProcessingApp", "MessageProcessingApp.csproj")]
+        [InlineData("ContosoUniversityBackendService", "ContosoUniversityBackendService.csproj")]
+        [InlineData("ContosoUniversityWeb", "ContosoUniversity.csproj")]
+        [InlineData("BlazorWasm31", "BlazorWasm31.csproj")]
+        [InlineData("BlazorWasm50", "BlazorWasm50.csproj")]
+        public async Task ParseProjectDefinitionWithAbsoluteProjectPath(string projectName, string csprojName)
+        {
+            //Arrange
+            var projectDirectoryPath = SystemIOUtilities.ResolvePath(projectName);
+            var absoluteProjectDirectoryPath = new DirectoryInfo(projectDirectoryPath).FullName;
+            var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
+
+            // Act
+            var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(absoluteProjectDirectoryPath);
+
+            // Assert
+            projectDefinition.ShouldNotBeNull();
+            Assert.Equal(absoluteProjectPath, projectDefinition.ProjectPath);
+        }
+    }
+}
+


### PR DESCRIPTION
*Description of changes:*
Currently, in the deploy tool, if a **relative path** to the target application project directory is provided it results in a `ProjectFileNotFoundException`.

Example scenario:
* Current working directory - `C:\codebase\aws-dotnet-deploy`
* CLI command - `dotnet aws deploy --project-path ".\testapps\WebAppWithDockerFile"`
* Result - `ProjectFileNotFoundException`

This PR attempts to correct this behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
