### PR TITLE
fix: deployment bundle settings are not handled in server mode

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -150,9 +150,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             var orchestrator = CreateOrchestrator(state);
 
-            var deploymentBundleDefinition = orchestrator.GetDeploymentBundleDefinition(state.SelectedRecommendation);
-
-            var configurableOptionSettings = state.SelectedRecommendation.Recipe.OptionSettings.Union(deploymentBundleDefinition.Parameters);
+            var configurableOptionSettings = state.SelectedRecommendation.GetConfigurableOptionSettingItems();
 
             var output = new GetOptionSettingsOutput();
             output.OptionSettings = ListOptionSettingSummary(state.SelectedRecommendation, configurableOptionSettings);
@@ -220,7 +218,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             return Ok(output);
         }
-        
+
         /// <summary>
         /// Gets the list of existing deployments that are compatible with the session's project.
         /// </summary>

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -150,13 +150,22 @@ namespace AWS.Deploy.Common
     {
         public InvalidProjectPathException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
-    
+
     /// Throw if an invalid <see cref="UserDeploymentSettings"/> is used.
     /// </summary>
     [AWSDeploymentExpectedException]
     public class InvalidUserDeploymentSettingsException : Exception
     {
         public InvalidUserDeploymentSettingsException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
+
+    /// <summary>
+    /// Exception is thrown if we cannot retrieve deployment bundle definitions
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class NoDeploymentBundleDefinitionsFoundException : Exception
+    {
+        public NoDeploymentBundleDefinitionsFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
 
     /// <summary>

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -28,9 +28,11 @@ namespace AWS.Deploy.Common
 
         public DeploymentBundle DeploymentBundle { get; }
 
+        private readonly List<OptionSettingItem> DeploymentBundleSettings = new ();
+
         private readonly Dictionary<string, string> _replacementTokens = new();
 
-        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, int computedPriority, Dictionary<string, string> additionalReplacements)
+        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, List<OptionSettingItem> deploymentBundleSettings, int computedPriority, Dictionary<string, string> additionalReplacements)
         {
             Recipe = recipe;
 
@@ -38,6 +40,7 @@ namespace AWS.Deploy.Common
 
             ProjectDefinition = projectDefinition;
             DeploymentBundle = new DeploymentBundle();
+            DeploymentBundleSettings = deploymentBundleSettings;
 
             _replacementTokens[REPLACE_TOKEN_PROJECT_NAME] = Path.GetFileNameWithoutExtension(projectDefinition.ProjectPath);
 
@@ -78,6 +81,11 @@ namespace AWS.Deploy.Common
             }
         }
 
+        public IEnumerable<OptionSettingItem> GetConfigurableOptionSettingItems()
+        {
+            return Recipe.OptionSettings.Union(DeploymentBundleSettings);
+        }
+
         /// <summary>
         /// Interactively traverses given json path and returns target option setting.
         /// Throws exception if there is no <see cref="OptionSettingItem" /> that matches <paramref name="jsonPath"/> />
@@ -98,7 +106,7 @@ namespace AWS.Deploy.Common
 
             foreach (var id in ids)
             {
-                var optionSettings = optionSetting?.ChildOptionSettings ?? Recipe.OptionSettings;
+                var optionSettings = optionSetting?.ChildOptionSettings ?? GetConfigurableOptionSettingItems();
                 optionSetting = optionSettings.FirstOrDefault(os => os.Id.Equals(id));
                 if (optionSetting == null)
                 {

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -86,15 +86,6 @@ namespace AWS.Deploy.Orchestration
     }
 
     /// <summary>
-    /// Exception is thrown if we cannot retrieve deployment bundle definitions
-    /// </summary>
-    [AWSDeploymentExpectedException]
-    public class NoDeploymentBundleDefinitionsFoundException : Exception
-    {
-        public NoDeploymentBundleDefinitionsFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
-    }
-
-    /// <summary>
     /// Exception is thrown if we cannot retrieve recipe definitions
     /// </summary>
     [AWSDeploymentExpectedException]

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -120,35 +120,6 @@ namespace AWS.Deploy.Orchestration
             }
         }
 
-        public DeploymentBundleDefinition GetDeploymentBundleDefinition(Recommendation recommendation)
-        {
-            var deploymentBundleDefinitionsPath = DeploymentBundleDefinitionLocator.FindDeploymentBundleDefinitionPath();
-
-            try
-            {
-                foreach (var deploymentBundleFile in Directory.GetFiles(deploymentBundleDefinitionsPath, "*.deploymentbundle", SearchOption.TopDirectoryOnly))
-                {
-                    try
-                    {
-                        var content = File.ReadAllText(deploymentBundleFile);
-                        var definition = JsonConvert.DeserializeObject<DeploymentBundleDefinition>(content);
-                        if (definition.Type.Equals(recommendation.Recipe.DeploymentBundle))
-                            return definition;
-                    }
-                    catch (Exception e)
-                    {
-                        throw new Exception($"Failed to Deserialize Deployment Bundle [{deploymentBundleFile}]: {e.Message}", e);
-                    }
-                }
-            }
-            catch(IOException)
-            {
-                throw new NoDeploymentBundleDefinitionsFoundException("Failed to find a deployment bundle definition");
-            }
-
-            throw new NoDeploymentBundleDefinitionsFoundException("Failed to find a deployment bundle definition");
-        }
-
         public async Task<bool> CreateContainerDeploymentBundle(CloudApplication cloudApplication, Recommendation recommendation)
         {
             if (_interactiveService == null)

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -58,7 +58,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
 
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
             var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty);
             var result = await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation);
@@ -77,7 +77,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = projectPath;
 
@@ -97,7 +97,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
             var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty);
             await _deploymentBundleHandler.PushDockerImageToECR(cloudApplication, recommendation, "ConsoleAppTask:latest");
@@ -110,7 +110,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
             recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = false;
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = "Release";
@@ -133,7 +133,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
             recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = "Release";


### PR DESCRIPTION
*Issue #, if available:*
IDE-5368

*Description of changes:*
Reworked Recommendation to treat Deployment Bundle similar to OptionItemSettings and centralize access to them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
