### PR TITLE
feat: display created AWS resources as deployment outputs

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.65" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.2.27" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.45" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.3.12" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.35" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />

--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -17,6 +17,7 @@ using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.CLI.Commands.CommandHandlerInput;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.DeploymentManifest;
+using AWS.Deploy.Orchestration.DisplayedResources;
 
 namespace AWS.Deploy.CLI.Commands
 {
@@ -52,6 +53,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ITemplateMetadataReader _templateMetadataReader;
         private readonly IDeployedApplicationQueryer _deployedApplicationQueryer;
         private readonly ITypeHintCommandFactory _typeHintCommandFactory;
+        private readonly IDisplayedResourcesHandler _displayedResourceHandler;
         private readonly IConsoleUtilities _consoleUtilities;
         private readonly IDeploymentManifestEngine _deploymentManifestEngine;
 
@@ -71,6 +73,7 @@ namespace AWS.Deploy.CLI.Commands
             ITemplateMetadataReader templateMetadataReader,
             IDeployedApplicationQueryer deployedApplicationQueryer,
             ITypeHintCommandFactory typeHintCommandFactory,
+            IDisplayedResourcesHandler displayedResourceHandler,
             IConsoleUtilities consoleUtilities,
             IDeploymentManifestEngine deploymentManifestEngine)
         {
@@ -89,6 +92,7 @@ namespace AWS.Deploy.CLI.Commands
             _templateMetadataReader = templateMetadataReader;
             _deployedApplicationQueryer = deployedApplicationQueryer;
             _typeHintCommandFactory = typeHintCommandFactory;
+            _displayedResourceHandler = displayedResourceHandler;
             _consoleUtilities = consoleUtilities;
             _deploymentManifestEngine = deploymentManifestEngine;
         }
@@ -172,6 +176,7 @@ namespace AWS.Deploy.CLI.Commands
                         _templateMetadataReader,
                         _deployedApplicationQueryer,
                         _typeHintCommandFactory,
+                        _displayedResourceHandler,
                         _cloudApplicationNameGenerator,
                         _consoleUtilities,
                         session);

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -17,6 +17,7 @@ using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Recipes;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
+using AWS.Deploy.Orchestration.DisplayedResources;
 
 namespace AWS.Deploy.CLI.Commands
 {
@@ -32,6 +33,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ITemplateMetadataReader _templateMetadataReader;
         private readonly IDeployedApplicationQueryer _deployedApplicationQueryer;
         private readonly ITypeHintCommandFactory _typeHintCommandFactory;
+        private readonly IDisplayedResourcesHandler _displayedResourcesHandler;
         private readonly ICloudApplicationNameGenerator _cloudApplicationNameGenerator;
 
         private readonly IConsoleUtilities _consoleUtilities;
@@ -48,6 +50,7 @@ namespace AWS.Deploy.CLI.Commands
             ITemplateMetadataReader templateMetadataReader,
             IDeployedApplicationQueryer deployedApplicationQueryer,
             ITypeHintCommandFactory typeHintCommandFactory,
+            IDisplayedResourcesHandler displayedResourcesHandler,
             ICloudApplicationNameGenerator cloudApplicationNameGenerator,
             IConsoleUtilities consoleUtilities,
             OrchestratorSession session)
@@ -61,6 +64,7 @@ namespace AWS.Deploy.CLI.Commands
             _templateMetadataReader = templateMetadataReader;
             _deployedApplicationQueryer = deployedApplicationQueryer;
             _typeHintCommandFactory = typeHintCommandFactory;
+            _displayedResourcesHandler = displayedResourcesHandler;
             _cloudApplicationNameGenerator = cloudApplicationNameGenerator;
             _consoleUtilities = consoleUtilities;
             _session = session;
@@ -85,6 +89,23 @@ namespace AWS.Deploy.CLI.Commands
             await CreateDeploymentBundle(orchestrator, selectedRecommendation, cloudApplication);
 
             await orchestrator.DeployRecommendation(cloudApplication, selectedRecommendation);
+
+            var displayedResources = await _displayedResourcesHandler.GetDeploymentOutputs(cloudApplication, selectedRecommendation);
+            DisplayOutputResources(displayedResources);
+        }
+
+        private void DisplayOutputResources(List<DisplayedResourceItem> displayedResourceItems)
+        {
+            _toolInteractiveService.WriteLine("Created AWS Resources");
+            _toolInteractiveService.WriteLine("---------------------");
+            foreach (var resource in displayedResourceItems)
+            {
+                _toolInteractiveService.WriteLine($"{resource.Description}:");
+                foreach (var resourceKey in resource.Data.Keys)
+                {
+                    _toolInteractiveService.WriteLine($"\t{resourceKey}: {resource.Data[resourceKey]}");
+                }
+            }
         }
 
         /// <summary>

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -11,6 +11,7 @@ using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
+using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Orchestration.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -48,6 +49,8 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ITemplateMetadataReader), typeof(TemplateMetadataReader), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IToolInteractiveService), typeof(ConsoleInteractiveServiceImpl), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ITypeHintCommandFactory), typeof(TypeHintCommandFactory), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IDisplayedResourcesFactory), typeof(DisplayedResourcesFactory), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IDisplayedResourcesHandler), typeof(DisplayedResourcesHandler), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IZipFileManager), typeof(ZipFileManager), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IDeploymentManifestEngine), typeof(DeploymentManifestEngine), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICommandFactory), typeof(CommandFactory), lifetime));

--- a/src/AWS.Deploy.CLI/ServerMode/Models/DisplayedResourceSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/DisplayedResourceSummary.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class DisplayedResourceSummary
+    {
+        /// <summary>
+        /// The Physical ID that represents a CloudFormation resource
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The description of the resource that is defined in the recipe definition
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The CloudFormation resource type
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The Key Value pair of additional data unique to this resource type
+        /// </summary>
+        public Dictionary<string, string> Data { get; set; }
+
+        public DisplayedResourceSummary(string id, string description, string type, Dictionary<string, string> data)
+        {
+            Id = id;
+            Description = description;
+            Type = type;
+            Data = data;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Models/GetDeploymentDetailsOutput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/GetDeploymentDetailsOutput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class GetDeploymentDetailsOutput
+    {
+        /// <summary>
+        /// The CloudFormation Stack ID
+        /// </summary>
+        public string StackId { get; set; }
+
+        /// <summary>
+        /// The list of displayed resources based on the recipe definition
+        /// </summary>
+        public List<DisplayedResourceSummary> DisplayedResources { get; set; }
+
+        public GetDeploymentDetailsOutput(string stackId, List<DisplayedResourceSummary> displayedResources)
+        {
+            StackId = stackId;
+            DisplayedResources = displayedResources;
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.2.4" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.45" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.1.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.35" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.Common/Recipes/DisplayedResource.cs
+++ b/src/AWS.Deploy.Common/Recipes/DisplayedResource.cs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes
+{
+    public class DisplayedResource
+    {
+        /// <summary>
+        /// The CloudFormation ID that represents a resource.
+        /// </summary>
+        public string LogicalId { get; set; }
+
+        /// <summary>
+        /// The Description gives context to the metadata of the CloudFormation resource.
+        /// </summary>
+        public string Description { get; set; }
+
+        public DisplayedResource(string logicalId, string description)
+        {
+            LogicalId = logicalId;
+            Description = description;
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -44,6 +44,11 @@ namespace AWS.Deploy.Common.Recipes
         public string TargetService { get; set; }
 
         /// <summary>
+        /// The list of DisplayedResources that lists logical CloudFormation IDs with a description.
+        /// </summary>
+        public List<DisplayedResource>? DisplayedResources { get; set; }
+
+        /// <summary>
         /// Confirmation messages to display to the user before performing deployment.
         /// </summary>
         public DeploymentConfirmationType? DeploymentConfirmation { get; set; }

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -8,12 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.EC2" Version="3.5.29.4" />
-    <PackageReference Include="AWSSDK.ECR" Version="3.5.1.5" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.5.2.18" />
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.2.23" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.65" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.2.27" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.7.19.1" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.7.0.45" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.7.2.20" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.45" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" Version="3.7.0.48" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.3.12" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.1.17" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="5.0.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="5.0.1" />

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourceItem.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourceItem.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    public class DisplayedResourceItem
+    {
+        /// <summary>
+        /// The Physical ID that represents a CloudFormation resource
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The description of the resource that is defined in the recipe definition
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The CloudFormation resource type
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The Key Value pair of additional data unique to this resource type
+        /// </summary>
+        public Dictionary<string, string> Data { get; set; }
+
+        public DisplayedResourceItem(string id, string description, string type, Dictionary<string, string> data)
+        {
+            Id = id;
+            Description = description;
+            Type = type;
+            Data = data;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourcesFactory.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourcesFactory.cs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    /// <summary>
+    /// Interface for displayed resources such as <see cref="ElasticBeanstalkEnvironmentResource"/>
+    /// </summary>
+    public interface IDisplayedResource
+    {
+        Task<Dictionary<string, string>> Execute(string resourceId);
+    }
+
+    public interface IDisplayedResourcesFactory
+    {
+        IDisplayedResource? GetResource(string resourceType);
+    }
+
+    /// <summary>
+    /// Factory class responsible to build and get the displayed resources.
+    /// </summary>
+    public class DisplayedResourcesFactory : IDisplayedResourcesFactory
+    {
+        private readonly Dictionary<string, IDisplayedResource> _resources;
+
+        public DisplayedResourcesFactory(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _resources = new Dictionary<string, IDisplayedResource>
+            {
+                { "AWS::ElasticBeanstalk::Environment", new ElasticBeanstalkEnvironmentResource(awsResourceQueryer) },
+                { "AWS::ElasticLoadBalancingV2::LoadBalancer", new ElasticLoadBalancerResource(awsResourceQueryer) },
+                { "AWS::S3::Bucket", new S3BucketResource(awsResourceQueryer) }
+            };
+        }
+
+        public IDisplayedResource? GetResource(string resourceType)
+        {
+            if (!_resources.ContainsKey(resourceType))
+            {
+                return null;
+            }
+
+            return _resources[resourceType];
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourcesHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourcesHandler.cs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AWS.Deploy.Common;
+using System.Threading.Tasks;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    public interface IDisplayedResourcesHandler
+    {
+        Task<List<DisplayedResourceItem>> GetDeploymentOutputs(CloudApplication cloudApplication, Recommendation recommendation);
+    }
+
+    public class DisplayedResourcesHandler : IDisplayedResourcesHandler
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IDisplayedResourcesFactory _displayedResourcesFactory;
+
+        public DisplayedResourcesHandler(IAWSResourceQueryer awsResourceQueryer, IDisplayedResourcesFactory displayedResourcesFactory)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _displayedResourcesFactory = displayedResourcesFactory;
+        }
+
+        /// <summary>
+        /// Retrieves the displayed resource data for known resource types by executing specific resource commands.
+        /// For unknown resource types, this returns the physical resource ID and type.
+        /// </summary>
+        public async Task<List<DisplayedResourceItem>> GetDeploymentOutputs(CloudApplication cloudApplication, Recommendation recommendation)
+        {
+            var displayedResources = new List<DisplayedResourceItem>();
+
+            if (recommendation.Recipe.DisplayedResources == null)
+                return displayedResources;
+
+            foreach (var displayedResource in recommendation.Recipe.DisplayedResources)
+            {
+                var resource = await _awsResourceQueryer.DescribeCloudFormationResource(cloudApplication.StackName, displayedResource.LogicalId);
+                Dictionary<string, string> data;
+                if (!string.IsNullOrEmpty(resource.ResourceType) && _displayedResourcesFactory.GetResource(resource.ResourceType) is var displayedResourceCommand && displayedResourceCommand != null)
+                {
+                    data = await displayedResourceCommand.Execute(resource.PhysicalResourceId);
+                }
+                else
+                {
+                    data = new Dictionary<string, string>() {
+                        { "ID", resource.PhysicalResourceId },
+                        { "Type", resource.ResourceType }
+                    };
+                }
+                displayedResources.Add(new DisplayedResourceItem(resource.PhysicalResourceId, displayedResource.Description, resource.ResourceType, data));
+            }
+
+            return displayedResources;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticBeanstalkEnvironmentResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticBeanstalkEnvironmentResource.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    public class ElasticBeanstalkEnvironmentResource : IDisplayedResource
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public ElasticBeanstalkEnvironmentResource(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<Dictionary<string, string>> Execute(string resourceId)
+        {
+            var environment = await _awsResourceQueryer.DescribeElasticBeanstalkEnvironment(resourceId);
+            return new Dictionary<string, string>() {
+                { "Endpoint", $"http://{environment.CNAME}/" }
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticLoadBalancerResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticLoadBalancerResource.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    public class ElasticLoadBalancerResource : IDisplayedResource
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public ElasticLoadBalancerResource(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<Dictionary<string, string>> Execute(string resourceId)
+        {
+            var loadBalancer = await _awsResourceQueryer.DescribeElasticLoadBalancer(resourceId);
+            return new Dictionary<string, string>() {
+                { "Endpoint", $"http://{loadBalancer.DNSName}/" }
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/S3BucketResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/S3BucketResource.cs
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    public class S3BucketResource : IDisplayedResource
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public S3BucketResource(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<Dictionary<string, string>> Execute(string resourceId)
+        {
+            string region = await _awsResourceQueryer.GetS3BucketLocation(resourceId);
+            string regionSeparator = ".";
+            if (string.Equals("us-east-1", region) ||
+                string.Equals("us-west-1", region) ||
+                string.Equals("us-west-2", region) ||
+                string.Equals("ap-southeast-1", region) ||
+                string.Equals("ap-southeast-2", region) ||
+                string.Equals("ap-northeast-1", region) ||
+                string.Equals("eu-west-1", region) ||
+                string.Equals("sa-east-1", region))
+            {
+                regionSeparator = "-";
+            }
+
+            var endpoint = $"http://{resourceId}.s3-website{regionSeparator}{region}.amazonaws.com/";
+
+            return new Dictionary<string, string>() {
+                { "Endpoint", endpoint },
+                { "Bucket Name", resourceId }
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -147,4 +147,13 @@ namespace AWS.Deploy.Orchestration
     {
         public InvalidAWSDeployRecipesCDKCommonVersionException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Exception thrown if an AWS Resource is not found or does not exist.
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class AWSResourceNotFoundException : Exception
+    {
+        public AWSResourceNotFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AppStack.cs
@@ -179,11 +179,6 @@ namespace AspNetAppElasticBeanstalkLinux
                 // This line is critical - reference the label created in this same stack
                 VersionLabel = applicationVersion.Ref,
             });
-
-            var output = new CfnOutput(this, "EndpointURL", new CfnOutputProps
-            {
-                Value = $"http://{environment.AttrEndpointUrl}/"
-            });
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -10,6 +10,13 @@
     "Description": "ASP.NET Core applications built as a container and deployed to Amazon Elastic Container Service (Amazon ECS) with compute power managed by AWS Fargate compute engine. Recommended for applications that can be deployed as a container image. If your project does not contain a Dockerfile, one will be generated for the project.",
     "TargetService": "Amazon Elastic Container Service",
 
+    "DisplayedResources": [
+        {
+            "LogicalId": "FargateServiceLBB353E155",
+            "Description": "Fargate Service"
+        }
+    ],
+
     "RecipePriority": 110,
     "RecommendationRules": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -10,6 +10,13 @@
     "Description": "Deploy an ASP.NET Core application to AWS Elastic Beanstalk. Recommended for applications that are not set up to be deployed as containers.",
     "TargetService": "AWS Elastic Beanstalk",
 
+    "DisplayedResources": [
+        {
+            "LogicalId": "Environment",
+            "Description": "Application Server"
+        }
+    ],
+
     "RecipePriority": 100,
     "RecommendationRules": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
@@ -9,6 +9,14 @@
     "CdkProjectTemplateId": "netdeploy.BlazorWasm",
     "Description": "Deploy a Blazor WebAssembly application to an Amazon S3 bucket. The Amazon S3 bucket created during deployment will be configured for web hosting and its contents will be open to the public with read access.",
     "TargetService": "Amazon S3",
+
+    "DisplayedResources": [
+        {
+            "LogicalId": "BlazorHostC7106839",
+            "Description": "Blazor Host"
+        }
+    ],
+
     "DeploymentConfirmation": {
         "DefaultMessage": "The Blazor WebAssembly application will be hosted in an Amazon S3 bucket with public read access. It is important that your application not contain any sensitive information like AWS credentials since the contents will be public. Do you wish to continue?"
     },

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -10,6 +10,17 @@
     "Description": "Deploy a console application as a scheduled task to Amazon Elastic Container Service (Amazon ECS). Recommended for applications that can be deployed as a container image. If your project does not contain a Dockerfile, one will be generated for the project.",
     "TargetService": "Amazon Elastic Container Service",
 
+    "DisplayedResources": [
+        {
+            "LogicalId": "ClusterEB0386A7",
+            "Description": "ECS Cluster"
+        },
+        {
+            "LogicalId": "TaskDefinitionB36D86D9",
+            "Description": "ECS Task Definition"
+        }
+    ],
+
     "RecipePriority": 100,
     "RecommendationRules": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -10,6 +10,21 @@
     "Description": "Deploy a console application as a service to Amazon Elastic Container Service (Amazon ECS). Recommended for applications that can be deployed as a container image. If your project does not contain a Dockerfile, one will be generated for the project.",
     "TargetService": "Amazon Elastic Container Service",
 
+    "DisplayedResources": [
+        {
+            "LogicalId": "ClusterEB0386A7",
+            "Description": "ECS Cluster"
+        },
+        {
+            "LogicalId": "FargateServiceAC2B3B85",
+            "Description": "ECS Service"
+        },
+        {
+            "LogicalId": "TaskDefinitionB36D86D9",
+            "Description": "ECS Task Definition"
+        }
+    ],
+
     "RecipePriority": 110,
     "RecommendationRules": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -68,6 +68,9 @@
             "description": "The description of the recipe",
             "minLength": 1
         },
+        "DisplayedResources": {
+            "$ref": "#/definitions/DisplayedResources"
+        },
         "TargetService": {
             "type": "string",
             "title": "AWS Target Service",
@@ -93,6 +96,30 @@
         }
     },
     "definitions": {
+
+        "DisplayedResources": {
+            "type": "array",
+            "description": "The list of DisplayedResources that lists logical CloudFormation IDs with a description.",
+            "items": { "$ref": "#/definitions/DisplayedResource" }
+        },
+
+        "DisplayedResource": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "The logical CloudFormation IDs with a description for CloudFormation resources.",
+            "properties": {
+                "LogicalId": {
+                    "type": "string",
+                    "title": "Logical Id",
+                    "description": "The CloudFormation ID that represents a resource."
+                },
+                "Description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The Description gives context to the metadata of the CloudFormation resource."
+                }
+            }
+        },
 
         "DeploymentConfirmation": {
             "type": "object",

--- a/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
+++ b/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.2.4" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -121,6 +121,17 @@ namespace AWS.Deploy.ServerMode.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<GetDeploymentStatusOutput> GetDeploymentStatusAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
+        /// <summary>Gets information about the displayed resources defined in the recipe definition.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<GetDeploymentDetailsOutput> GetDeploymentDetailsAsync(string sessionId);
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Gets information about the displayed resources defined in the recipe definition.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<GetDeploymentDetailsOutput> GetDeploymentDetailsAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
+    
         /// <summary>Gets the health of the deployment tool. Use this API after starting the command line to see if the tool is ready to handle requests.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -900,6 +911,87 @@ namespace AWS.Deploy.ServerMode.Client
             }
         }
     
+        /// <summary>Gets information about the displayed resources defined in the recipe definition.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<GetDeploymentDetailsOutput> GetDeploymentDetailsAsync(string sessionId)
+        {
+            return GetDeploymentDetailsAsync(sessionId, System.Threading.CancellationToken.None);
+        }
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Gets information about the displayed resources defined in the recipe definition.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<GetDeploymentDetailsOutput> GetDeploymentDetailsAsync(string sessionId, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/v1/Deployment/session/<sessionId>/details?");
+            if (sessionId != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("sessionId") + "=").Append(System.Uri.EscapeDataString(ConvertToString(sessionId, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+    
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+    
+                    PrepareRequest(client_, request_, urlBuilder_);
+    
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+    
+                    PrepareRequest(client_, request_, url_);
+    
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+    
+                        ProcessResponse(client_, response_);
+    
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<GetDeploymentDetailsOutput>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+    
         /// <summary>Gets the health of the deployment tool. Use this API after starting the command line to see if the tool is ready to handle requests.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -1200,6 +1292,28 @@ namespace AWS.Deploy.ServerMode.Client
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class DisplayedResourceSummary 
+    {
+        /// <summary>The Physical ID that represents a CloudFormation resource</summary>
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+    
+        /// <summary>The description of the resource that is defined in the recipe definition</summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+    
+        /// <summary>The CloudFormation resource type</summary>
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Type { get; set; }
+    
+        /// <summary>The Key Value pair of additional data unique to this resource type</summary>
+        [Newtonsoft.Json.JsonProperty("data", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.IDictionary<string, string> Data { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
     public partial class ExistingDeploymentSummary 
     {
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -1207,6 +1321,18 @@ namespace AWS.Deploy.ServerMode.Client
     
         [Newtonsoft.Json.JsonProperty("recipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RecipeId { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class GetDeploymentDetailsOutput 
+    {
+        [Newtonsoft.Json.JsonProperty("stackId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string StackId { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("displayedResources", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<DisplayedResourceSummary> DisplayedResources { get; set; }
     
     
     }

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.79" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.1.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -9,6 +9,7 @@ using Amazon.EC2.Model;
 using Amazon.ECR.Model;
 using Amazon.ElasticBeanstalk.Model;
 using Amazon.IdentityManagement.Model;
+using Amazon.S3;
 using Amazon.SecurityToken.Model;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
@@ -54,5 +55,9 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications() => throw new NotImplementedException();
         public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName) => throw new NotImplementedException();
         public Task<List<Role>> ListOfIAMRoles(string servicePrincipal) => throw new NotImplementedException();
+        public Task<StackResourceDetail> DescribeCloudFormationResource(string stackName, string logicalId) => throw new NotImplementedException();
+        public Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentId) => throw new NotImplementedException();
+        public Task<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn) => throw new NotImplementedException();
+        public Task<S3Region> GetS3BucketLocation(string bucketName) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5268

*Description of changes:*
Console App as ECS Service:
![image](https://user-images.githubusercontent.com/53088140/127556495-4c1e9254-17df-4be6-8024-200db67b757e.png)

Console App as Scheduled Task:
![image](https://user-images.githubusercontent.com/53088140/127556573-281d0030-49e2-484f-b068-ef0eb7faf427.png)

Web App using Fargate:
![image](https://user-images.githubusercontent.com/53088140/127556626-b8086e21-bddd-4fe2-8bce-9abda2925659.png)

Web App using Beanstalk:
![image](https://user-images.githubusercontent.com/53088140/127556659-828b1e58-24b6-4f02-a6b3-2bf7cb6244f7.png)

Blazor App using S3:
![image](https://user-images.githubusercontent.com/53088140/127556694-7bc7bc98-81d1-412b-b5e9-fbac3d9bd7e3.png)


I will put out another PR to add tests. However, I want to create interfaces for some of our classes to facilitate mocking and testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
