### PR TITLE
test: enable parallel integ tests

### DIFF
--- a/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
+++ b/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
@@ -23,7 +23,7 @@ namespace AWS.Deploy.CLI.CloudFormation
         private const int RESOURCE_STATUS_WIDTH = 20;
         private const int RESOURCE_TYPE_WIDTH = 40;
         private const int LOGICAL_RESOURCE_WIDTH = 40;
-        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(2);
 
         private readonly string _stackName;
         private bool _isActive;

--- a/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
@@ -16,7 +16,6 @@ using static System.Net.WebRequestMethods;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
-    [Collection("Serial")]
     public class BlazorWasmTests : IDisposable
     {
         private readonly HttpHelper _httpHelper;

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
@@ -18,7 +18,6 @@ using Task = System.Threading.Tasks.Task;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 {
-    [Collection("Serial")]
     public class ECSFargateDeploymentTest : IDisposable
     {
         private readonly HttpHelper _httpHelper;

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
@@ -17,7 +17,6 @@ using Environment = System.Environment;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 {
-    [Collection("Serial")]
     public class ElasticBeanStalkDeploymentTest : IDisposable
     {
         private readonly HttpHelper _httpHelper;

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
-    [Collection("Serial")]
     public class ConsoleAppTests : IDisposable
     {
         private readonly CloudFormationHelper _cloudFormationHelper;

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -27,7 +27,6 @@ using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
-    [Collection("Serial")]
     public class ServerModeTests : IDisposable
     {
         private bool _isDisposed;
@@ -165,7 +164,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             {
                 var baseUrl = $"http://localhost:{portNumber}/";
                 var restClient = new RestAPIClient(baseUrl, httpClient);
-                
+
                 await WaitTillServerModeReady(restClient);
 
                 var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -16,7 +16,6 @@ using Environment = System.Environment;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
-    [Collection("Serial")]
     public class WebAppNoDockerFileTests : IDisposable
     {
         private readonly HttpHelper _httpHelper;

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
@@ -17,7 +17,6 @@ using Task = System.Threading.Tasks.Task;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
-    [Collection("Serial")]
     public class WebAppWithDockerFileTests : IDisposable
     {
         private readonly HttpHelper _httpHelper;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enabled parallel tests
- Changed the polling frequency to 2 seconds, 1 second easily throttles GetStack operation call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
