### PR TITLE
ci: add manual workflow to prepare release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,79 @@
+# This is a basic workflow that is manually triggered to prepare the release
+# It creates two PRs
+# 1. Pulls target branch to main
+# 2. Increment minor version of target branch
+
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pulling-into-main:
+    name: Pulling into main
+    runs-on: ubuntu-latest
+
+    outputs:
+      # set PR_URL as output of job to add in body of version bump PR
+      PR_URL: ${{ steps.pull-request.outputs.pr_url }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Read Current Version
+      id: read-current-version
+      run: |
+        version=$(jq -r ".version" version.json)
+        echo "::set-output name=VERSION::$version"
+
+    - name: Pull Request
+      id: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "main"
+        pr_title: 'chore: release ${{ steps.read-current-version.outputs.VERSION }}'
+        pr_body: "Pulling ${{ github.ref }} into main."
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_label: "auto-pr"
+
+  version-bump:
+    name: Version bump
+    runs-on: ubuntu-latest
+    needs: [pulling-into-main]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build Next Version
+      id: build-next-version
+      run: |
+        version=$(jq -r .version version.json)
+        major=$(echo $version | awk '{split($0, components, "."); print components[1]}')
+        minor=$(echo $version | awk '{split($0, components, "."); print components[2]+1}')
+        echo "::set-output name=VERSION::$major.$minor"
+
+    - name: Commit and Push next version
+      id: commit-push
+      run: |
+        git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+        git config --global user.name "aws-sdk-dotnet-automation"
+        content=$(jq '.version = "${{ steps.build-next-version.outputs.VERSION }}"' version.json)
+        echo $content | jq '.' > version.json
+        branch=build/version-bump-${{ steps.build-next-version.outputs.VERSION }}
+        git checkout -b $branch
+        git add version.json
+        git commit -m "build: version bump to ${{ steps.build-next-version.outputs.VERSION }}"
+        git push origin $branch
+        echo "::set-output name=BRANCH::$branch"
+
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: ${{ steps.commit-push.outputs.BRANCH }}
+        destination_branch: "dev"
+        pr_title: "build: version bump to ${{ steps.build-next-version.outputs.VERSION }}"
+        pr_body: "Merge after ${{ needs.pulling-into-main.outputs.PR_URL }} is merged."
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_label: "auto-pr"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prepare Release workflow allows to create release PRs from the target branch. Typically target branch will be `dev`.

Final state of workflow: https://github.com/ganeshnj/aws-dotnet-deploy/actions/workflows/prepare-release.yml
Release PR samples
- https://github.com/ganeshnj/aws-dotnet-deploy/pull/35
- https://github.com/ganeshnj/aws-dotnet-deploy/pull/34


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
