### PR TITLE
fix: cdk deploy failure does not throw an exception

### DIFF
--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -60,10 +60,14 @@ namespace AWS.Deploy.Orchestration
 
             // Handover to CDK command line tool
             // Use a CDK Context parameter to specify the settings file that has been serialized.
-            await _commandLineWrapper.Run( $"npx cdk deploy --require-approval never -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
+            var cdkDeploy = await _commandLineWrapper.TryRunWithResult( $"npx cdk deploy --require-approval never -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
                 workingDirectory: cdkProjectPath,
                 environmentVariables: environmentVariables,
-                needAwsCredentials: true);
+                needAwsCredentials: true,
+                streamOutputToInteractiveService: true);
+
+            if (cdkDeploy.ExitCode != 0)
+                throw new FailedToDeployCDKAppException("We had an issue deploying your application to AWS. Check the deployment output for more details.");
         }
 
         public async Task<string> CreateCdkProjectForDeployment(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -147,4 +147,13 @@ namespace AWS.Deploy.Orchestration
     {
         public InvalidAWSDeployRecipesCDKCommonVersionException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Exception thrown if the 'cdk deploy' command failed.
+    /// </summary>
+    [AWSDeploymentExpectedException]
+    public class FailedToDeployCDKAppException : Exception
+    {
+        public FailedToDeployCDKAppException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
IDE-5426

*Description of changes:*
fix: cdk deploy failure does not throw an exception

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
