### PR TITLE
fix: Change execution timeout for server mode tests

### DIFF
--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -224,7 +224,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             {
                 DeploymentStatus status = (await restApiClient.GetDeploymentStatusAsync(sessionId)).Status; ;
                 return status != DeploymentStatus.Executing;
-            }, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(10));
+            }, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(15));
 
             return (await restApiClient.GetDeploymentStatusAsync(sessionId)).Status;
         }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5299

*Description of changes:*
Currently, the server mode tests have a 10 minute execution timeout, within which it is expected that the Cloudformation stack creation will be complete. However, depending on Cloudformation throttling, this process may be delayed and the tests can fail. 

This PR mitigates this problem by change the execution timeout to 15 minutes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
