### PR TITLE
fix: use unique identifiers for stdin values

### DIFF
--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/IntegrationTestFiles/ECSFargateConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/IntegrationTestFiles/ECSFargateConfigFile.json
@@ -1,19 +1,19 @@
 {
-    "StackName": "EcsFargateAppStack",
+    "StackName": "EcsFargate{Suffix}",
     "RecipeId": "AspNetAppEcsFargate",
     "OptionSettingsConfig":{
-        "ECSCluster": 
+        "ECSCluster":
         {
             "CreateNew": true,
-            "NewClusterName": "MyNewCluster"
+            "NewClusterName": "MyNewCluster{Suffix}"
         },
-        "ECSServiceName": "MyNewService",
+        "ECSServiceName": "MyNewService{Suffix}",
         "DesiredCount": 3,
-        "ApplicationIAMRole": 
+        "ApplicationIAMRole":
         {
             "CreateNew": true
         },
-        "Vpc": 
+        "Vpc":
         {
             "IsDefault": true
         },

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/IntegrationTestFiles/ElasticBeanStalkConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/IntegrationTestFiles/ElasticBeanStalkConfigFile.json
@@ -1,14 +1,14 @@
 {
-    "StackName": "ElasticBeanStalkAppStack",
+    "StackName": "ElasticBeanStalk{Suffix}",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
     "OptionSettingsConfig":
     {
-        "BeanstalkApplication": 
+        "BeanstalkApplication":
         {
             "CreateNew": true,
-            "ApplicationName": "MyApplication"
+            "ApplicationName": "MyApplication{Suffix}"
         },
-        "EnvironmentName": "MyEnvironment",
+        "EnvironmentName": "MyEnvironment{Suffix}",
         "EnvironmentType": "LoadBalanced",
         "LoadBalancerType": "application",
         "ApplicationIAMRole":

--- a/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
@@ -93,7 +93,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _app.Run(deleteArgs);
 
             // Verify application is delete
-            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
         public void Dispose()

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
@@ -18,6 +18,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 {
+    [Collection("WebAppWithDockerFile")]
     public class ECSFargateDeploymentTest : IDisposable
     {
         private readonly HttpHelper _httpHelper;
@@ -48,6 +49,9 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             _configFilePath = Path.Combine("ConfigFileDeployment", "TestFiles", "IntegrationTestFiles", "ECSFargateConfigFile.json");
+
+            ConfigFileHelper.ReplacePlaceholders(_configFilePath);
+
             var userDeploymentSettings = UserDeploymentSettings.ReadSettings(_configFilePath);
 
             _stackName = userDeploymentSettings.StackName;
@@ -102,7 +106,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             await _app.Run(deleteArgs);
 
             // Verify application is delete
-            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
         public void Dispose()
@@ -132,8 +136,4 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             Dispose(false);
         }
     }
-
-
-
-
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
@@ -17,6 +17,7 @@ using Environment = System.Environment;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 {
+    [Collection("WebAppNoDockerFile")]
     public class ElasticBeanStalkDeploymentTest : IDisposable
     {
         private readonly HttpHelper _httpHelper;
@@ -42,6 +43,9 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             _configFilePath = Path.Combine("ConfigFileDeployment", "TestFiles", "IntegrationTestFiles", "ElasticBeanStalkConfigFile.json");
+
+            ConfigFileHelper.ReplacePlaceholders(_configFilePath);
+
             var userDeploymentSettings = UserDeploymentSettings.ReadSettings(_configFilePath);
 
             _stackName = userDeploymentSettings.StackName;
@@ -91,7 +95,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             await _app.Run(deleteArgs);
 
             // Verify application is delete
-            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
         public void Dispose()

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -96,7 +96,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _app.Run(deleteArgs);
 
             // Verify application is delete
-            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
         public void Dispose()

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ConfigFileHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ConfigFileHelper.cs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class ConfigFileHelper
+    {
+        public static void ReplacePlaceholders(string configFilePath)
+        {
+            var suffix = Guid.NewGuid().ToString().Split('-').Last();
+            var json = File.ReadAllText(configFilePath);
+            json = json.Replace("{Suffix}", suffix);
+            File.WriteAllText(configFilePath, json);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -27,6 +27,7 @@ using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
+    [Collection("WebAppWithDockerFile")]
     public class ServerModeTests : IDisposable
     {
         private bool _isDisposed;
@@ -150,7 +151,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
         [Fact]
         public async Task WebFargateDeploymentNoConfigChanges()
         {
-            _stackName = "ServerModeWebFargate-" + DateTime.UtcNow.Ticks;
+            _stackName = $"ServerModeWebFargate{Guid.NewGuid().ToString().Split('-').Last()}";
 
             var projectPath = Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj");
             var portNumber = 4001;

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -16,6 +16,7 @@ using Environment = System.Environment;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
+    [Collection("WebAppNoDockerFile")]
     public class WebAppNoDockerFileTests : IDisposable
     {
         private readonly HttpHelper _httpHelper;
@@ -91,7 +92,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _app.Run(deleteArgs);
 
             // Verify application is delete
-            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
         public void Dispose()

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
@@ -17,6 +17,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace AWS.Deploy.CLI.IntegrationTests
 {
+    [Collection("WebAppWithDockerFile")]
     public class WebAppWithDockerFileTests : IDisposable
     {
         private readonly HttpHelper _httpHelper;
@@ -99,7 +100,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _app.Run(deleteArgs);
 
             // Verify application is delete
-            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName));
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
         public void Dispose()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Option setting values which are stdin are now unique by nature.
- 3 integ test runs passed that ensures there are no transient failures when tests are running in parallel
- Serial execute test cases which depends on same testapp otherwise dotnet cli used for packaging will trigger race condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
