### PR TITLE
fix: Correctly resolve the Solution path on non-Windows targets

### DIFF
--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -126,7 +126,16 @@ namespace AWS.Deploy.Common
 
             var lines = await _fileManager.ReadAllLinesAsync(solutionFile);
             var projectLines = lines.Where(x => x.StartsWith("Project"));
-            var projectPaths = projectLines.Select(x => x.Split(',')[1].Replace('\"', ' ').Trim()).ToList();
+            var projectPaths =
+                projectLines
+                    .Select(x => x.Split(','))
+                    .Where(x => x.Length > 1)
+                    .Select(x =>
+                            x[1]
+                                .Replace('\"', ' ')
+                                .Trim())
+                    .Select(x => x.Replace('\\', Path.DirectorySeparatorChar))
+                    .ToList();
 
             //Validate project exists in solution
             return projectPaths.Select(x => Path.GetFileName(x)).Any(x => x.Equals(projectFileName));

--- a/test/AWS.Deploy.CLI.UnitTests/ProjectDefinitionParserTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ProjectDefinitionParserTest.cs
@@ -35,6 +35,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var absoluteProjectDirectoryPath = new DirectoryInfo(projectDirectoryPath).FullName;
             var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
             var relativeProjectDirectoryPath = Path.GetRelativePath(currrentWorkingDirectory, absoluteProjectDirectoryPath);
+            var projectSolutionPath = SystemIOUtilities.ResolvePathToSolution();
 
             // Act
             var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(relativeProjectDirectoryPath);
@@ -42,6 +43,7 @@ namespace AWS.Deploy.CLI.UnitTests
             // Assert
             projectDefinition.ShouldNotBeNull();
             Assert.Equal(absoluteProjectPath, projectDefinition.ProjectPath);
+            Assert.Equal(projectSolutionPath, projectDefinition.ProjectSolutionPath);
         }
 
         [Theory]
@@ -60,6 +62,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var projectDirectoryPath = SystemIOUtilities.ResolvePath(projectName);
             var absoluteProjectDirectoryPath = new DirectoryInfo(projectDirectoryPath).FullName;
             var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
+            var projectSolutionPath = SystemIOUtilities.ResolvePathToSolution();
 
             // Act
             var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(absoluteProjectDirectoryPath);
@@ -67,6 +70,7 @@ namespace AWS.Deploy.CLI.UnitTests
             // Assert
             projectDefinition.ShouldNotBeNull();
             Assert.Equal(absoluteProjectPath, projectDefinition.ProjectPath);
+            Assert.Equal(projectSolutionPath, projectDefinition.ProjectSolutionPath);
         }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/System.IO.Utilties.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/System.IO.Utilties.cs
@@ -20,5 +20,16 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             return Path.Combine(testsPath, "..", "testapps", projectName);
         }
 
+        public static string ResolvePathToSolution()
+        {
+            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            while (path != null && !string.Equals(new DirectoryInfo(path).Name, "aws-dotnet-deploy", StringComparison.OrdinalIgnoreCase))
+            {
+                path = Directory.GetParent(path).FullName;
+            }
+
+            return new DirectoryInfo(Path.Combine(path, "AWS.Deploy.sln")).FullName;
+        }
+
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR correctly resolves the Solution path while parsing the project definition on non-Windows targets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
