### PR TITLE
feat: detect CDK version by parsing deployment project csproj file

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
@@ -67,6 +68,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly IDeploymentManifestEngine _deploymentManifestEngine;
         private readonly ICustomRecipeLocator _customRecipeLocator;
         private readonly ILocalUserSettingsEngine _localUserSettingsEngine;
+        private readonly ICDKVersionDetector _cdkVersionDetector;
 
         public CommandFactory(
             IToolInteractiveService toolInteractiveService,
@@ -90,7 +92,8 @@ namespace AWS.Deploy.CLI.Commands
             IFileManager fileManager,
             IDeploymentManifestEngine deploymentManifestEngine,
             ICustomRecipeLocator customRecipeLocator,
-            ILocalUserSettingsEngine localUserSettingsEngine)
+            ILocalUserSettingsEngine localUserSettingsEngine,
+            ICDKVersionDetector cdkVersionDetector)
         {
             _toolInteractiveService = toolInteractiveService;
             _orchestratorInteractiveService = orchestratorInteractiveService;
@@ -114,6 +117,7 @@ namespace AWS.Deploy.CLI.Commands
             _deploymentManifestEngine = deploymentManifestEngine;
             _customRecipeLocator = customRecipeLocator;
             _localUserSettingsEngine = localUserSettingsEngine;
+            _cdkVersionDetector = cdkVersionDetector;
         }
 
         public Command BuildRootCommand()
@@ -193,6 +197,7 @@ namespace AWS.Deploy.CLI.Commands
                         _orchestratorInteractiveService,
                         _cdkProjectHandler,
                         _cdkManager,
+                        _cdkVersionDetector,
                         _deploymentBundleHandler,
                         dockerEngine,
                         _awsResourceQueryer,
@@ -205,7 +210,8 @@ namespace AWS.Deploy.CLI.Commands
                         _consoleUtilities,
                         _customRecipeLocator,
                         _systemCapabilityEvaluator,
-                        session);
+                        session,
+                        _directoryManager);
 
                     var deploymentProjectPath = input.DeploymentProject ?? string.Empty;
                     if (!string.IsNullOrEmpty(deploymentProjectPath))
@@ -338,7 +344,7 @@ namespace AWS.Deploy.CLI.Commands
                 listCommand.Add(_optionRegion);
                 listCommand.Add(_optionProjectPath);
                 listCommand.Add(_optionDiagnosticLogging);
-            } 
+            }
 
             listCommand.Handler = CommandHandler.Create(async (ListCommandHandlerInput input) =>
             {

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -42,12 +42,15 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ICustomRecipeLocator _customRecipeLocator;
         private readonly ISystemCapabilityEvaluator _systemCapabilityEvaluator;
         private readonly OrchestratorSession _session;
+        private readonly IDirectoryManager _directoryManager;
+        private ICDKVersionDetector _cdkVersionDetector;
 
         public DeployCommand(
             IToolInteractiveService toolInteractiveService,
             IOrchestratorInteractiveService orchestratorInteractiveService,
             ICdkProjectHandler cdkProjectHandler,
             ICDKManager cdkManager,
+            ICDKVersionDetector cdkVersionDetector,
             IDeploymentBundleHandler deploymentBundleHandler,
             IDockerEngine dockerEngine,
             IAWSResourceQueryer awsResourceQueryer,
@@ -60,7 +63,8 @@ namespace AWS.Deploy.CLI.Commands
             IConsoleUtilities consoleUtilities,
             ICustomRecipeLocator customRecipeLocator,
             ISystemCapabilityEvaluator systemCapabilityEvaluator,
-            OrchestratorSession session)
+            OrchestratorSession session,
+            IDirectoryManager directoryManager)
         {
             _toolInteractiveService = toolInteractiveService;
             _orchestratorInteractiveService = orchestratorInteractiveService;
@@ -76,6 +80,8 @@ namespace AWS.Deploy.CLI.Commands
             _localUserSettingsEngine = localUserSettingsEngine;
             _consoleUtilities = consoleUtilities;
             _session = session;
+            _directoryManager = directoryManager;
+            _cdkVersionDetector = cdkVersionDetector;
             _cdkManager = cdkManager;
             _customRecipeLocator = customRecipeLocator;
             _systemCapabilityEvaluator = systemCapabilityEvaluator;
@@ -136,12 +142,14 @@ namespace AWS.Deploy.CLI.Commands
                     _orchestratorInteractiveService,
                     _cdkProjectHandler,
                     _cdkManager,
+                    _cdkVersionDetector,
                     _awsResourceQueryer,
                     _deploymentBundleHandler,
                     _localUserSettingsEngine,
                     _dockerEngine,
                     _customRecipeLocator,
-                    new List<string> { RecipeLocator.FindRecipeDefinitionsPath() });
+                    new List<string> { RecipeLocator.FindRecipeDefinitionsPath() },
+                    _directoryManager);
 
             // Determine what recommendations are possible for the project.
             var recommendations = await GenerateDeploymentRecommendations(orchestrator, deploymentProjectPath);
@@ -170,7 +178,7 @@ namespace AWS.Deploy.CLI.Commands
 
                 // preset settings for deployment based on last deployment.
                 selectedRecommendation = await GetSelectedRecommendationFromPreviousDeployment(recommendations, deployedApplication, userDeploymentSettings);
-            } 
+            }
             else
             {
                 if (!string.IsNullOrEmpty(deploymentProjectPath))
@@ -182,7 +190,7 @@ namespace AWS.Deploy.CLI.Commands
                     selectedRecommendation = GetSelectedRecommendation(userDeploymentSettings, recommendations);
                 }
             }
-                
+
             var cloudApplication = new CloudApplication(cloudApplicationName, selectedRecommendation.Recipe.Id);
 
             return (orchestrator, selectedRecommendation, cloudApplication);
@@ -275,7 +283,7 @@ namespace AWS.Deploy.CLI.Commands
                 }
                 throw new InvalidUserDeploymentSettingsException(errorMessage.Trim());
             }
-                
+
             selectedRecommendation = selectedRecommendation.ApplyPreviousSettings(existingCloudApplicationMetadata.Settings);
 
             var header = $"Loading {deployedApplication.Name} settings:";
@@ -440,7 +448,7 @@ namespace AWS.Deploy.CLI.Commands
         private Recommendation GetSelectedRecommendation(UserDeploymentSettings? userDeploymentSettings, List<Recommendation> recommendations)
         {
             var deploymentSettingsRecipeId = userDeploymentSettings?.RecipeId;
-            
+
             if (string.IsNullOrEmpty(deploymentSettingsRecipeId))
             {
                 if (_toolInteractiveService.DisableInteractive)
@@ -453,13 +461,13 @@ namespace AWS.Deploy.CLI.Commands
                 }
                 return _consoleUtilities.AskToChooseRecommendation(recommendations);
             }
-            
+
             var selectedRecommendation = recommendations.FirstOrDefault(x => x.Recipe.Id.Equals(deploymentSettingsRecipeId, StringComparison.Ordinal));
             if (selectedRecommendation == null)
             {
                 throw new InvalidUserDeploymentSettingsException($"The user deployment settings provided contains an invalid value for the property '{nameof(userDeploymentSettings.RecipeId)}'.");
             }
-                
+
             _toolInteractiveService.WriteLine();
             _toolInteractiveService.WriteLine($"Configuring Recommendation with: '{selectedRecommendation.Name}'.");
             return selectedRecommendation;

--- a/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
@@ -102,7 +102,7 @@ namespace AWS.Deploy.CLI.Commands
                 }
             }
 
-            _cdkProjectHandler.CreateCdkProjectForDeployment(selectedRecommendation, _session, saveCdkDirectoryPath);
+            _cdkProjectHandler.CreateCdkProject(selectedRecommendation, _session, saveCdkDirectoryPath);
             await GenerateDeploymentRecipeSnapShot(selectedRecommendation, saveCdkDirectoryPath, projectDisplayName);
 
             var saveCdkDirectoryFullPath = _directoryManager.GetDirectoryInfo(saveCdkDirectoryPath).FullName;

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -57,6 +57,7 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICustomRecipeLocator), typeof(CustomRecipeLocator), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ILocalUserSettingsEngine), typeof(LocalUserSettingsEngine), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICommandFactory), typeof(CommandFactory), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICDKVersionDetector), typeof(CDKVersionDetector), lifetime));
 
             var packageJsonTemplate = typeof(PackageJsonGenerator).Assembly.ReadEmbeddedFile(PackageJsonGenerator.TemplateIdentifier);
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IPackageJsonGenerator), (serviceProvider) => new PackageJsonGenerator(packageJsonTemplate), lifetime));

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -464,7 +464,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             var serviceProvider = services.BuildServiceProvider();
 
             var awsClientFactory = serviceProvider.GetRequiredService<IAWSClientFactory>();
-            
+
             awsClientFactory.ConfigureAWSOptions(awsOptions =>
             {
                 awsOptions.Credentials = awsCredentials;
@@ -498,12 +498,14 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                                     serviceProvider.GetRequiredService<IOrchestratorInteractiveService>(),
                                     serviceProvider.GetRequiredService<ICdkProjectHandler>(),
                                     serviceProvider.GetRequiredService<ICDKManager>(),
+                                    serviceProvider.GetRequiredService<ICDKVersionDetector>(),
                                     serviceProvider.GetRequiredService<IAWSResourceQueryer>(),
                                     serviceProvider.GetRequiredService<IDeploymentBundleHandler>(),
                                     serviceProvider.GetRequiredService<ILocalUserSettingsEngine>(),
                                     new DockerEngine.DockerEngine(session.ProjectDefinition),
                                     serviceProvider.GetRequiredService<ICustomRecipeLocator>(),
-                                    new List<string> { RecipeLocator.FindRecipeDefinitionsPath() }
+                                    new List<string> { RecipeLocator.FindRecipeDefinitionsPath() },
+                                    serviceProvider.GetRequiredService<IDirectoryManager>()
                                 );
         }
     }

--- a/src/AWS.Deploy.Common/IO/DirectoryManager.cs
+++ b/src/AWS.Deploy.Common/IO/DirectoryManager.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace AWS.Deploy.Common.IO
 {
@@ -18,19 +20,26 @@ namespace AWS.Deploy.Common.IO
         void Delete(string path, bool recursive = false);
         string GetRelativePath(string referenceFullPath, string targetFullPath);
         string GetAbsolutePath(string referenceFullPath, string targetRelativePath);
+        public string[] GetProjFiles(string path);
     }
 
     public class DirectoryManager : IDirectoryManager
     {
+        private readonly HashSet<string> _projFileExtensions = new()
+        {
+            "csproj",
+            "fsproj"
+        };
+
         public DirectoryInfo CreateDirectory(string path) => Directory.CreateDirectory(path);
-            
+
         public DirectoryInfo GetDirectoryInfo(string path) => new DirectoryInfo(path);
 
         public bool Exists(string path) => Directory.Exists(path);
 
         public string[] GetFiles(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
             => Directory.GetFiles(path, searchPattern ?? "*", searchOption);
-        
+
         public string[] GetDirectories(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
             => Directory.GetDirectories(path, searchPattern ?? "*", searchOption);
 
@@ -47,5 +56,10 @@ namespace AWS.Deploy.Common.IO
 
         public string GetRelativePath(string referenceFullPath, string targetFullPath) => Path.GetRelativePath(referenceFullPath, targetFullPath);
         public string GetAbsolutePath(string referenceFullPath, string targetRelativePath) => Path.GetFullPath(targetRelativePath, referenceFullPath);
+
+        public string[] GetProjFiles(string path)
+        {
+            return Directory.GetFiles(path).Where(filePath => _projFileExtensions.Contains(Path.GetExtension(filePath).ToLower())).ToArray();
+        }
     }
 }

--- a/src/AWS.Deploy.Constants/CDK.cs
+++ b/src/AWS.Deploy.Constants/CDK.cs
@@ -19,12 +19,8 @@ namespace AWS.Deploy.Constants
         public static string ProjectsDirectory => Path.Combine(DeployToolWorkspaceDirectoryRoot, "Projects");
 
         /// <summary>
-        /// Minimum version of CDK CLI to check before starting the deployment
+        /// Default version of CDK CLI
         /// </summary>
-        /// <remarks>
-        /// Currently the version is hardcoded by design.
-        /// In coming iterations, this will be dynamically calculated based on the package references used in the CDK App csproj files.
-        /// </remarks>
-        public static readonly Version MinimumCDKVersion = Version.Parse("1.107.0");
+        public static readonly Version DefaultCDKVersion = Version.Parse("1.107.0");
     }
 }

--- a/src/AWS.Deploy.Orchestration/CDK/CDKVersionDetector.cs
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKVersionDetector.cs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace AWS.Deploy.Orchestration.CDK
+{
+    /// <summary>
+    /// Detects the CDK version by parsing the csproj files
+    /// </summary>
+    public interface ICDKVersionDetector
+    {
+        /// <summary>
+        /// Parses the given csproj file and returns the highest version among Amazon.CDK.* dependencies.
+        /// </summary>
+        /// <param name="csprojPath">C# project file path.</param>
+        /// <returns>Highest version among Amazon.CDK.* dependencies.</returns>
+        Version Detect(string csprojPath);
+
+        /// <summary>
+        /// This is convenience method that uses <see cref="Detect(string)"/> method to detect highest version among Amazon.CDK.* dependencies
+        /// in all the csproj files
+        /// </summary>
+        /// <param name="csprojPaths">C# project file paths.</param>
+        /// <returns>Highest version among Amazon.CDK.* dependencies in all <param name="csprojPaths"></param>.</returns>
+        Version Detect(IEnumerable<string> csprojPaths);
+    }
+
+    public class CDKVersionDetector : ICDKVersionDetector
+    {
+        private const string AMAZON_CDK_PACKAGE_REFERENCE_PREFIX = "Amazon.CDK";
+
+        public Version Detect(string csprojPath)
+        {
+            var content = File.ReadAllText(csprojPath);
+            var document = XDocument.Parse(content);
+            var cdkVersion = Constants.CDK.DefaultCDKVersion;
+
+            foreach (var node in document.DescendantNodes())
+            {
+                if (node is not XElement element || element.Name.ToString() != "PackageReference")
+                {
+                    continue;
+                }
+
+                var includeAttribute = element.Attribute("Include");
+                if (includeAttribute == null)
+                {
+                    continue;
+                }
+
+                if (!includeAttribute.Value.Equals(AMAZON_CDK_PACKAGE_REFERENCE_PREFIX) && !includeAttribute.Value.StartsWith($"{AMAZON_CDK_PACKAGE_REFERENCE_PREFIX}."))
+                {
+                    continue;
+                }
+
+                var versionAttribute = element.Attribute("Version");
+                if (versionAttribute == null)
+                {
+                    continue;
+                }
+
+                var version = new Version(versionAttribute.Value);
+                if (version > cdkVersion)
+                {
+                    cdkVersion = version;
+                }
+            }
+
+            return cdkVersion;
+        }
+
+        public Version Detect(IEnumerable<string> csprojPaths)
+        {
+            var cdkVersion = Constants.CDK.DefaultCDKVersion;
+
+            foreach (var csprojPath in csprojPaths)
+            {
+                var version = Detect(csprojPath);
+                if (version > cdkVersion)
+                {
+                    cdkVersion = version;
+                }
+            }
+
+            return cdkVersion;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -13,8 +13,9 @@ namespace AWS.Deploy.Orchestration
 {
     public interface ICdkProjectHandler
     {
-        Task CreateCdkDeployment(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
-        string CreateCdkProjectForDeployment(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
+        Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
+        string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
+        Task DeployCdkProject(OrchestratorSession session, string cdkProjectPath, Recommendation recommendation);
     }
 
     public class CdkProjectHandler : ICdkProjectHandler
@@ -32,14 +33,8 @@ namespace AWS.Deploy.Orchestration
             _directoryManager = new DirectoryManager();
         }
 
-        public async Task CreateCdkDeployment(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation)
+        public async Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation)
         {
-            var recipeInfo = $"{recommendation.Recipe.Id}_{recommendation.Recipe.Version}";
-            var environmentVariables = new Dictionary<string, string>
-            {
-                { EnvironmentVariableKeys.AWS_EXECUTION_ENV, recipeInfo }
-            };
-
             string? cdkProjectPath;
             if (recommendation.Recipe.PersistedDeploymentProject)
             {
@@ -53,22 +48,33 @@ namespace AWS.Deploy.Orchestration
             {
                 // Create a new temporary CDK project for a new deployment
                 _interactiveService.LogMessageLine($"Generating a {recommendation.Recipe.Name} CDK Project");
-                cdkProjectPath = CreateCdkProjectForDeployment(recommendation, session);
+                cdkProjectPath = CreateCdkProject(recommendation, session);
             }
-            
+
             // Write required configuration in appsettings.json
             var appSettingsBody = _appSettingsBuilder.Build(cloudApplication, recommendation, session);
             var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
-            using (var appSettingsFile = new StreamWriter(appSettingsFilePath))
+            await using var appSettingsFile = new StreamWriter(appSettingsFilePath);
+            await appSettingsFile.WriteAsync(appSettingsBody);
+
+            return cdkProjectPath;
+        }
+
+        public async Task DeployCdkProject(OrchestratorSession session, string cdkProjectPath, Recommendation recommendation)
+        {
+            var recipeInfo = $"{recommendation.Recipe.Id}_{recommendation.Recipe.Version}";
+            var environmentVariables = new Dictionary<string, string>
             {
-                await appSettingsFile.WriteAsync(appSettingsBody);
-            }
+                { EnvironmentVariableKeys.AWS_EXECUTION_ENV, recipeInfo }
+            };
 
             _interactiveService.LogMessageLine("Starting deployment of CDK Project");
 
             // Ensure region is bootstrapped
             await _commandLineWrapper.Run($"npx cdk bootstrap aws://{session.AWSAccountId}/{session.AWSRegion}",
                 needAwsCredentials: true);
+
+            var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
 
             // Handover to CDK command line tool
             // Use a CDK Context parameter to specify the settings file that has been serialized.
@@ -82,7 +88,7 @@ namespace AWS.Deploy.Orchestration
                 throw new FailedToDeployCDKAppException("We had an issue deploying your application to AWS. Check the deployment output for more details.");
         }
 
-        public string CreateCdkProjectForDeployment(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)
+        public string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)
         {
             string? assemblyName;
             if (string.IsNullOrEmpty(saveCdkDirectoryPath))
@@ -101,7 +107,7 @@ namespace AWS.Deploy.Orchestration
 
             if (string.IsNullOrEmpty(assemblyName))
                 throw new ArgumentNullException("The assembly name for the CDK deployment project cannot be null");
-           
+
             _directoryManager.CreateDirectory(saveCdkDirectoryPath);
 
             var templateEngine = new TemplateEngine();

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
@@ -23,6 +23,8 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
         public string GetRelativePath(string referenceFullPath, string targetFullPath) => Path.GetRelativePath(referenceFullPath, targetFullPath);
 
         public string GetAbsolutePath(string referenceFullPath, string targetRelativePath) => Path.GetFullPath(targetRelativePath, referenceFullPath);
+        public string[] GetProjFiles(string path) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
 
         public void Delete(string path, bool recursive = false) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -25,7 +25,7 @@ using AWS.Deploy.Orchestration.LocalUserSettings;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 {
-    public class RecommendationTests 
+    public class RecommendationTests
     {
         private readonly CommandLineWrapper _commandLineWrapper;
 
@@ -168,7 +168,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             // ACT
             var recommendations = await orchestrator.GenerateRecommendationsFromSavedDeploymentProject(saveDirectoryPathEcsProject);
 
-            // ASSERT 
+            // ASSERT
             recommendations.Count.ShouldEqual(1);
             recommendations[0].Name.ShouldEqual("Custom ECS Fargate Recipe");
             recommendations[0].Recipe.Id.ShouldEqual(customEcsRecipeId);
@@ -191,7 +191,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             // ACT
             var recommendations = await orchestrator.GenerateRecommendationsFromSavedDeploymentProject(saveDirectoryPathEcsProject);
 
-            // ASSERT 
+            // ASSERT
             recommendations.ShouldBeEmpty();
         }
 
@@ -213,12 +213,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
                 consoleOrchestratorLogger,
                 new Mock<ICdkProjectHandler>().Object,
                 new Mock<ICDKManager>().Object,
+                new Mock<ICDKVersionDetector>().Object,
                 new TestToolAWSResourceQueryer(),
                 new Mock<IDeploymentBundleHandler>().Object,
                 localUserSettingsEngine,
                 new Mock<IDockerEngine>().Object,
                 customRecipeLocator,
-                new List<string> { RecipeLocator.FindRecipeDefinitionsPath() });
+                new List<string> { RecipeLocator.FindRecipeDefinitionsPath() },
+                directoryManager);
         }
 
         private async Task<string> GetCustomRecipeId(string recipeFilePath)

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
@@ -20,6 +20,12 @@
       <ProjectReference Include="..\AWS.Deploy.CLI.Common.UnitTests\AWS.Deploy.CLI.Common.UnitTests.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Include="CDK\CSProjFiles\*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
     <Import Project="..\..\src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems" Label="Shared" />
 
 </Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKVersionDetectorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKVersionDetectorTests.cs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using System.Linq;
+using AWS.Deploy.Orchestration.CDK;
+using Xunit;
+
+namespace AWS.Deploy.Orchestration.UnitTests.CDK
+{
+    public class CDKVersionDetectorTests
+    {
+        private readonly ICDKVersionDetector _cdkVersionDetector;
+
+        public CDKVersionDetectorTests()
+        {
+            _cdkVersionDetector = new CDKVersionDetector();
+        }
+
+        [Theory]
+        [InlineData("MixedReferences.csproj", "1.109.0")]
+        [InlineData("SameReferences.csproj", "1.108.0")]
+        [InlineData("NoReferences.csproj", "1.107.0")]
+        public void Detect_CSProjPath(string fileName, string expectedVersion)
+        {
+            var csprojPath = Path.Combine("CDK", "CSProjFiles", fileName);
+            var version = _cdkVersionDetector.Detect(csprojPath);
+            Assert.Equal(expectedVersion, version.ToString());
+        }
+
+        [Fact]
+        public void Detect_CSProjPaths()
+        {
+            var csprojPaths = new []
+            {
+                "MixedReferences.csproj",
+                "SameReferences.csproj",
+                "NoReferences.csproj"
+            }.Select(fileName => Path.Combine("CDK", "CSProjFiles", fileName));
+            var version = _cdkVersionDetector.Detect(csprojPaths);
+            Assert.Equal("1.109.0", version.ToString());
+        }
+    }
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/MixedReferences.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/MixedReferences.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.CDK" Version="1.109.0" />
+    <PackageReference Include="Amazon.CDK3P" Version="1.110.0" />
+    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="1.108.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.107.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/NoReferences.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/NoReferences.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/SameReferences.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/SameReferences.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.CDK" Version="1.108.0" />
+    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="1.108.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.108.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestDirectoryManager.cs
@@ -24,6 +24,9 @@ namespace AWS.Deploy.Orchestration.UnitTests
 
         public string GetAbsolutePath(string referenceFullPath, string targetRelativePath) => Path.GetFullPath(targetRelativePath, referenceFullPath);
 
+        public string[] GetProjFiles(string path) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
         public void Delete(string path, bool recursive = false) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, Deployment Tool uses static CDK version which needs to be changed as Amazon.CDK.* package references are updated. This change allows Deployment Tool to detect the minimum compatible version of Amazon.CDK.* dependency which must be installed or will be installed by the tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
