### PR TITLE
fix: replace ErrorCode with Throttling

### DIFF
--- a/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
+++ b/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
@@ -23,7 +23,7 @@ namespace AWS.Deploy.CLI.CloudFormation
         private const int RESOURCE_STATUS_WIDTH = 20;
         private const int RESOURCE_TYPE_WIDTH = 40;
         private const int LOGICAL_RESOURCE_WIDTH = 40;
-        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(5);
 
         private readonly string _stackName;
         private bool _isActive;

--- a/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
@@ -19,7 +19,7 @@ namespace AWS.Deploy.CLI.Commands
     /// </summary>
     public class DeleteDeploymentCommand
     {
-        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan s_pollingPeriod = TimeSpan.FromSeconds(5);
 
         private readonly IAWSClientFactory _awsClientFactory;
         private readonly IToolInteractiveService _interactiveService;
@@ -173,7 +173,7 @@ namespace AWS.Deploy.CLI.Commands
                 {
                     shouldRetry = false;
                 }
-                catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ThrottlingException"))
+                catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("Throttling"))
                 {
                     _interactiveService.WriteDebugLine(exception.PrettyPrint());
                     shouldRetry = true;

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
@@ -68,6 +68,28 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
         }
 
         [Fact]
+        public void WriteDebugLine()
+        {
+            var service = new InMemoryInteractiveService();
+
+            service.WriteDebugLine("Debug Line 1");
+            service.WriteDebugLine("Debug Line 2");
+            service.WriteDebugLine("Debug Line 3");
+
+            Assert.Equal("Debug Line 1", service.StdDebugReader.ReadLine());
+            Assert.Equal("Debug Line 2", service.StdDebugReader.ReadLine());
+            Assert.Equal("Debug Line 3", service.StdDebugReader.ReadLine());
+
+            service.WriteDebugLine("Debug Line 4");
+            service.WriteDebugLine("Debug Line 5");
+            service.WriteDebugLine("Debug Line 6");
+
+            Assert.Equal("Debug Line 4", service.StdDebugReader.ReadLine());
+            Assert.Equal("Debug Line 5", service.StdDebugReader.ReadLine());
+            Assert.Equal("Debug Line 6", service.StdDebugReader.ReadLine());
+        }
+
+        [Fact]
         public void ReadLine()
         {
             var service = new InMemoryInteractiveService();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change also change polling period to 5 seconds for both DeleteDeploymentCommand and StackEventMonitor


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
