### PR TITLE
Fix issue with TypeHintData not being serialized correctly when saving CDK project

### DIFF
--- a/src/AWS.Deploy.Common/SerializeModelContractResolver.cs
+++ b/src/AWS.Deploy.Common/SerializeModelContractResolver.cs
@@ -20,8 +20,23 @@ namespace AWS.Deploy.Common
             if (property != null && property.PropertyType != null && property.PropertyName != null && property.PropertyType != typeof(string))
             {
                 if (property.PropertyType.GetInterface(nameof(IEnumerable)) != null)
-                    property.ShouldSerialize =
-                        instance => (instance?.GetType()?.GetProperty(property.PropertyName)?.GetValue(instance) as IEnumerable<object>)?.Any() ?? false;
+                {
+                    property.ShouldSerialize = instance =>
+                    {
+                        var instanceValue = instance?.GetType()?.GetProperty(property.PropertyName)?.GetValue(instance);
+                        if (instanceValue is IEnumerable<object> list)
+                        {
+                            return list.Any();
+                        }
+                        else if(instanceValue is System.Collections.IDictionary map)
+                        {
+                            return map.Count > 0;
+                        }
+                            
+
+                        return false;
+                    };
+                }
             }
             return property ?? throw new ArgumentException();
         }


### PR DESCRIPTION
*Description of changes:*
Fix issue with TypeHintData not being serialized correctly when saving CDK project

Also reformatted the `SerializeModelContractResolver` to make it easier to debug. The issue was TypeHintData is an IDictionary so you can't simply cast it to IEnumerable<object>.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
