### PR TITLE
fix: reusing AES IV could cause potential security risks

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
@@ -100,10 +100,6 @@ namespace AWS.Deploy.CLI.Commands
                         {
                             aes.Key = Convert.FromBase64String(keyInfo.Key);
                         }
-                        if (keyInfo.IV != null)
-                        {
-                            aes.IV = Convert.FromBase64String(keyInfo.IV);
-                        }
 
                         encryptionProvider = new AesEncryptionProvider(aes);
                         break;

--- a/src/AWS.Deploy.CLI/ServerMode/Services/AesEncryptionProvider.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/AesEncryptionProvider.cs
@@ -19,9 +19,9 @@ namespace AWS.Deploy.CLI.ServerMode.Services
             _aes = aes;
         }
 
-        public byte[] Decrypt(byte[] encryptedData)
-        {            
-            var decryptor = _aes.CreateDecryptor(_aes.Key, _aes.IV);
+        public byte[] Decrypt(byte[] encryptedData, byte[]? generatedIV)
+        {
+            var decryptor = _aes.CreateDecryptor(_aes.Key, generatedIV);
 
             using var inputStream = new MemoryStream(encryptedData);
             using var decryptStream = new CryptoStream(inputStream, decryptor, CryptoStreamMode.Read);

--- a/src/AWS.Deploy.CLI/ServerMode/Services/IEncryptionProvider.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/IEncryptionProvider.cs
@@ -10,6 +10,6 @@ namespace AWS.Deploy.CLI.ServerMode.Services
 {
     public interface IEncryptionProvider
     {
-        byte[] Decrypt(byte[] encryptedData);
+        byte[] Decrypt(byte[] encryptedData, byte[]? generatedIV);
     }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Services/NoEncryptionProvider.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/NoEncryptionProvider.cs
@@ -10,6 +10,6 @@ namespace AWS.Deploy.CLI.ServerMode.Services
 {
     public class NoEncryptionProvider : IEncryptionProvider
     {
-        public byte[] Decrypt(byte[] encryptedData) => encryptedData;
+        public byte[] Decrypt(byte[] encryptedData, byte[]? generatedIV) => encryptedData;
     }
 }

--- a/src/AWS.Deploy.ServerMode.Client/ServerModeHttpClient.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeHttpClient.cs
@@ -73,6 +73,7 @@ namespace AWS.Deploy.ServerMode.Client
             string base64;
             if(aes != null)
             {
+                aes.GenerateIV();
                 var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
 
                 using var inputStream = new MemoryStream(Encoding.UTF8.GetBytes(json));
@@ -82,7 +83,7 @@ namespace AWS.Deploy.ServerMode.Client
                     inputStream.CopyTo(encryptStream);
                 }
 
-                base64 = Convert.ToBase64String(outputStream.ToArray());
+                base64 = $"{Convert.ToBase64String(aes.IV)} {Convert.ToBase64String(outputStream.ToArray())}";
             }
             else
             {

--- a/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
@@ -128,12 +128,10 @@ namespace AWS.Deploy.ServerMode.Client
             {
                 _aes = Aes.Create();
                 _aes.GenerateKey();
-                _aes.GenerateIV();
 
                 var keyInfo = new EncryptionKeyInfo(
                     EncryptionKeyInfo.VERSION_1_0,
-                    Convert.ToBase64String(_aes.Key),
-                    Convert.ToBase64String(_aes.IV));
+                    Convert.ToBase64String(_aes.Key));
 
                 var keyInfoStdin = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(keyInfo)));
 
@@ -245,9 +243,9 @@ namespace AWS.Deploy.ServerMode.Client
 
             public string Version { get; set; }
             public string Key { get; set; }
-            public string IV { get; set; }
+            public string? IV { get; set; }
 
-            public EncryptionKeyInfo(string version, string key, string iv)
+            public EncryptionKeyInfo(string version, string key, string? iv = null)
             {
                 Version = version;
                 Key = key;


### PR DESCRIPTION
*Issue #, if available:*
IDE-5677

*Description of changes:*
Pentest recommendations:

* Remove the IV from being specified when the server is first created.
* Generate a new IV for each request, every time a new encryption operation is being performed.
   * This value does not need to be secret, but it does need to be unpredictable and unique.
* Include the IV alongside the ciphertext in each request, so it can be used to decrypt the message when used with the correct key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
