### PR TITLE
fix: For Blazor WASM recipe increase memory size for BucketDeployment

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/AppStack.cs
@@ -50,7 +50,8 @@ namespace BlazorWasm
             new BucketDeployment(this, "BlazorDeployment", new BucketDeploymentProps
             {
                 Sources = new ISource[] { Source.Asset(Path.Combine(recipeConfiguration.DotnetPublishOutputDirectory, "wwwroot")) },
-                DestinationBucket = bucket
+                DestinationBucket = bucket,
+                MemoryLimit = 4096
             });
 
             new CfnOutput(this, "EndpointURL", new CfnOutputProps


### PR DESCRIPTION
*Description of changes:*
The `BucketDeployment` CDK construct under the covers creates and invokes a Lambda function to copy the contents from the CDK bootstrap bucket to the target S3 bucket. By default the Lambda function memory size is `512` and if a user has a large application especially with a lot of individual web files the Lambda function can timeout. This PR increase the memory size to the max size `4096` to give the Lambda function more power to get all of the files upload in time.

Since this function is only called once during a deployment so I'm not worried about over allocating for the function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
