### PR TITLE
fix: disallow SMB shares from file paths

### DIFF
--- a/src/AWS.Deploy.CLI/AWSUtilities.cs
+++ b/src/AWS.Deploy.CLI/AWSUtilities.cs
@@ -9,6 +9,7 @@ using Amazon.Runtime.CredentialManagement;
 using Amazon.EC2.Model;
 using System.IO;
 using AWS.Deploy.CLI.Utilities;
+using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.CLI
 {
@@ -22,11 +23,13 @@ namespace AWS.Deploy.CLI
     {
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IDirectoryManager _directoryManager;
 
-        public AWSUtilities(IToolInteractiveService toolInteractiveService, IConsoleUtilities consoleUtilities)
+        public AWSUtilities(IToolInteractiveService toolInteractiveService, IConsoleUtilities consoleUtilities, IDirectoryManager directoryManager)
         {
             _toolInteractiveService = toolInteractiveService;
             _consoleUtilities = consoleUtilities;
+            _directoryManager = directoryManager;
         }
 
         public async Task<AWSCredentials> ResolveAWSCredentials(string? profileName, string? lastUsedProfileName = null)
@@ -89,7 +92,7 @@ namespace AWS.Deploy.CLI
             if (credentials is AssumeRoleAWSCredentials assumeRoleAWSCredentials)
             {
                 var assumeOptions = assumeRoleAWSCredentials.Options;
-                assumeOptions.MfaTokenCodeCallback = new AssumeRoleMfaTokenCodeCallback(_toolInteractiveService, assumeOptions).Execute;
+                assumeOptions.MfaTokenCodeCallback = new AssumeRoleMfaTokenCodeCallback(_toolInteractiveService, _directoryManager, assumeOptions).Execute;
             }
 
             return credentials;

--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -190,7 +190,7 @@ namespace AWS.Deploy.CLI.Commands
                         AWSProfileName = input.Profile ?? userDeploymentSettings?.AWSProfile ?? null
                     };
 
-                    var dockerEngine = new DockerEngine.DockerEngine(projectDefinition);
+                    var dockerEngine = new DockerEngine.DockerEngine(projectDefinition, _fileManager);
 
                     var deploy = new DeployCommand(
                         _toolInteractiveService,

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -390,7 +390,7 @@ namespace AWS.Deploy.CLI.Commands
             switch (optionSettingId)
             {
                 case "DockerExecutionDirectory":
-                    new DockerExecutionDirectoryCommand(_consoleUtilities).OverrideValue(recommendation, settingValue.ToString() ?? "");
+                    new DockerExecutionDirectoryCommand(_consoleUtilities, _directoryManager).OverrideValue(recommendation, settingValue.ToString() ?? "");
                     break;
                 case "DockerBuildArgs":
                     new DockerBuildArgsCommand(_consoleUtilities).OverrideValue(recommendation, settingValue.ToString() ?? "");
@@ -571,7 +571,7 @@ namespace AWS.Deploy.CLI.Commands
                             selectedRecommendation.DeploymentBundle.DockerExecutionDirectory,
                             allowEmpty: true);
 
-                        if (!Directory.Exists(dockerExecutionDirectory))
+                        if (!_directoryManager.Exists(dockerExecutionDirectory))
                             continue;
 
                         selectedRecommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -11,10 +12,12 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
     public class DockerExecutionDirectoryCommand : ITypeHintCommand
     {
         private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IDirectoryManager _directoryManager;
 
-        public DockerExecutionDirectoryCommand(IConsoleUtilities consoleUtilities)
+        public DockerExecutionDirectoryCommand(IConsoleUtilities consoleUtilities, IDirectoryManager directoryManager)
         {
             _consoleUtilities = consoleUtilities;
+            _directoryManager = directoryManager;
         }
 
         public Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
@@ -47,7 +50,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         private string ValidateExecutionDirectory(string executionDirectory)
         {
-            if (!string.IsNullOrEmpty(executionDirectory) && !Directory.Exists(executionDirectory))
+            if (!string.IsNullOrEmpty(executionDirectory) && !_directoryManager.Exists(executionDirectory))
                 return "The directory specified for Docker execution does not exist.";
             else
                 return "";

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Data;
 
@@ -29,7 +30,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
     {
         private readonly Dictionary<OptionSettingTypeHint, ITypeHintCommand> _commands;
 
-        public TypeHintCommandFactory(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        public TypeHintCommandFactory(IToolInteractiveService toolInteractiveService, IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities, IDirectoryManager directoryManager)
         {
             _commands = new Dictionary<OptionSettingTypeHint, ITypeHintCommand>
             {
@@ -42,7 +43,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.DotnetPublishAdditionalBuildArguments, new DotnetPublishArgsCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishSelfContainedBuild, new DotnetPublishSelfContainedBuildCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishBuildConfiguration, new DotnetPublishBuildConfigurationCommand(consoleUtilities) },
-                { OptionSettingTypeHint.DockerExecutionDirectory, new DockerExecutionDirectoryCommand(consoleUtilities) },
+                { OptionSettingTypeHint.DockerExecutionDirectory, new DockerExecutionDirectoryCommand(consoleUtilities, directoryManager) },
                 { OptionSettingTypeHint.DockerBuildArgs, new DockerBuildArgsCommand(consoleUtilities) },
                 { OptionSettingTypeHint.ECSCluster, new ECSClusterCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.ExistingApplicationLoadBalancer, new ExistingApplicationLoadBalancerCommand(awsResourceQueryer, consoleUtilities) },

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.CLI
 {
@@ -35,10 +36,12 @@ namespace AWS.Deploy.CLI
     public class ConsoleUtilities : IConsoleUtilities
     {
         private readonly IToolInteractiveService _interactiveService;
+        private readonly IDirectoryManager _directoryManager;
 
-        public ConsoleUtilities(IToolInteractiveService interactiveService)
+        public ConsoleUtilities(IToolInteractiveService interactiveService, IDirectoryManager directoryManager)
         {
             _interactiveService = interactiveService;
+            _directoryManager = directoryManager;
         }
 
         public Recommendation AskToChooseRecommendation(IList<Recommendation> recommendations)
@@ -311,7 +314,7 @@ namespace AWS.Deploy.CLI
             {
                 var keyPairDirectory = _interactiveService.ReadLine();
                 if (keyPairDirectory != null &&
-                    Directory.Exists(keyPairDirectory))
+                    _directoryManager.Exists(keyPairDirectory))
                 {
                     var projectFolder = new FileInfo(projectPath).Directory;
                     var keyPairDirectoryInfo = new DirectoryInfo(keyPairDirectory);

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -515,7 +515,9 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                                     serviceProvider.GetRequiredService<IAWSResourceQueryer>(),
                                     serviceProvider.GetRequiredService<IDeploymentBundleHandler>(),
                                     serviceProvider.GetRequiredService<ILocalUserSettingsEngine>(),
-                                    new DockerEngine.DockerEngine(session.ProjectDefinition),
+                                    new DockerEngine.DockerEngine(
+                                        session.ProjectDefinition,
+                                        serviceProvider.GetRequiredService<IFileManager>()),
                                     serviceProvider.GetRequiredService<ICustomRecipeLocator>(),
                                     new List<string> { RecipeLocator.FindRecipeDefinitionsPath() },
                                     serviceProvider.GetRequiredService<IDirectoryManager>()

--- a/src/AWS.Deploy.CLI/Utilities/AssumeRoleMfaTokenCodeCallback.cs
+++ b/src/AWS.Deploy.CLI/Utilities/AssumeRoleMfaTokenCodeCallback.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Amazon.Runtime;
+using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.CLI.Utilities
 {
@@ -15,18 +16,20 @@ namespace AWS.Deploy.CLI.Utilities
     {
         private readonly AssumeRoleAWSCredentialsOptions _options;
         private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IDirectoryManager _directoryManager;
 
-        internal AssumeRoleMfaTokenCodeCallback(IToolInteractiveService toolInteractiveService, AssumeRoleAWSCredentialsOptions options)
+        internal AssumeRoleMfaTokenCodeCallback(IToolInteractiveService toolInteractiveService, IDirectoryManager directoryManager, AssumeRoleAWSCredentialsOptions options)
         {
             _toolInteractiveService = toolInteractiveService;
             _options = options;
+            _directoryManager = directoryManager;
         }
 
         internal string Execute()
         {
             _toolInteractiveService.WriteLine();
             _toolInteractiveService.WriteLine($"Enter MFA code for {_options.MfaSerialNumber}: ");
-            var consoleUtilites = new ConsoleUtilities(_toolInteractiveService);
+            var consoleUtilites = new ConsoleUtilities(_toolInteractiveService, _directoryManager);
             var code = consoleUtilites.ReadSecretFromConsole();
             
             return code;

--- a/src/AWS.Deploy.Common/IO/DirectoryManager.cs
+++ b/src/AWS.Deploy.Common/IO/DirectoryManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using AWS.Deploy.Common.Utilities;
 
 namespace AWS.Deploy.Common.IO
 {
@@ -35,7 +36,7 @@ namespace AWS.Deploy.Common.IO
 
         public DirectoryInfo GetDirectoryInfo(string path) => new DirectoryInfo(path);
 
-        public bool Exists(string path) => Directory.Exists(path);
+        public bool Exists(string path) => IsDirectoryValid(path);
 
         public string[] GetFiles(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
             => Directory.GetFiles(path, searchPattern ?? "*", searchOption);
@@ -60,6 +61,17 @@ namespace AWS.Deploy.Common.IO
         public string[] GetProjFiles(string path)
         {
             return Directory.GetFiles(path).Where(filePath => _projFileExtensions.Contains(Path.GetExtension(filePath).ToLower())).ToArray();
+        }
+
+        private bool IsDirectoryValid(string directoryPath)
+        {
+            if (!PathUtilities.IsPathValid(directoryPath))
+                return false;
+
+            if (!Directory.Exists(directoryPath))
+                return false;
+
+            return true;
         }
     }
 }

--- a/src/AWS.Deploy.Common/IO/FileManager.cs
+++ b/src/AWS.Deploy.Common/IO/FileManager.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Utilities;
 
 namespace AWS.Deploy.Common.IO
 {
@@ -20,7 +22,7 @@ namespace AWS.Deploy.Common.IO
     /// </summary>
     public class FileManager : IFileManager
     {
-        public bool Exists(string path) => File.Exists(path);
+        public bool Exists(string path) => IsFileValid(path);
 
         public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
 
@@ -28,5 +30,16 @@ namespace AWS.Deploy.Common.IO
 
         public Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken) =>
             File.WriteAllTextAsync(filePath, contents, cancellationToken);
+
+        private bool IsFileValid(string filePath)
+        {
+            if (!PathUtilities.IsPathValid(filePath))
+                return false;
+
+            if (!File.Exists(filePath))
+                return false;
+
+            return true;
+        }
     }
 }

--- a/src/AWS.Deploy.Common/Utilities/PathUtilities.cs
+++ b/src/AWS.Deploy.Common/Utilities/PathUtilities.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using System.Linq;
+
+namespace AWS.Deploy.Common.Utilities
+{
+    public class PathUtilities
+    {
+        public static bool IsPathValid(string path)
+        {
+            path = path.Trim();
+
+            if (string.IsNullOrEmpty(path))
+                return false;
+
+            if (path.StartsWith(@"\\"))
+                return false;
+
+            if (path.Contains("&"))
+                return false;
+
+            if (Path.GetInvalidPathChars().Any(x => path.Contains(x)))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
 using Newtonsoft.Json;
 
 namespace AWS.Deploy.DockerEngine
@@ -31,9 +32,10 @@ namespace AWS.Deploy.DockerEngine
     public class DockerEngine : IDockerEngine
     {
         private readonly ProjectDefinition _project;
+        private readonly IFileManager _fileManager;
         private readonly string _projectPath;
 
-        public DockerEngine(ProjectDefinition project)
+        public DockerEngine(ProjectDefinition project, IFileManager fileManager)
         {
             if (project == null)
             {
@@ -42,6 +44,7 @@ namespace AWS.Deploy.DockerEngine
 
             _project = project;
             _projectPath = project.ProjectPath;
+            _fileManager = fileManager;
         }
 
         /// <summary>
@@ -146,7 +149,7 @@ namespace AWS.Deploy.DockerEngine
             {
                 var projectFilename = Path.GetFileName(recommendation.ProjectPath);
                 var dockerFilePath = Path.Combine(Path.GetDirectoryName(recommendation.ProjectPath) ?? "", "Dockerfile");
-                if (File.Exists(dockerFilePath))
+                if (_fileManager.Exists(dockerFilePath))
                 {
                     using (var stream = File.OpenRead(dockerFilePath))
                     using (var reader = new StreamReader(stream))

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -106,7 +106,9 @@ namespace AWS.Deploy.Orchestration
         {
             if (_session == null)
                 throw new InvalidOperationException($"{nameof(_session)} is null as part of the orchestartor object");
-            if (!Directory.Exists(deploymentProjectPath))
+            if (_directoryManager == null)
+                throw new InvalidOperationException($"{nameof(_directoryManager)} is null as part of the orchestartor object");
+            if (!_directoryManager.Exists(deploymentProjectPath))
                 throw new InvalidCliArgumentException($"The path '{deploymentProjectPath}' does not exists on the file system. Please provide a valid deployment project path and try again.");
 
             var engine = new RecommendationEngine.RecommendationEngine(new List<string> { deploymentProjectPath }, _session);

--- a/src/AWS.Deploy.Orchestration/Utilities/ZipFileManager.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/ZipFileManager.cs
@@ -8,6 +8,7 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.Orchestration.Utilities
 {
@@ -19,10 +20,12 @@ namespace AWS.Deploy.Orchestration.Utilities
     public class ZipFileManager : IZipFileManager
     {
         private readonly ICommandLineWrapper _commandLineWrapper;
+        private readonly IFileManager _fileManager;
 
-        public ZipFileManager(ICommandLineWrapper commandLineWrapper)
+        public ZipFileManager(ICommandLineWrapper commandLineWrapper, IFileManager fileManager)
         {
             _commandLineWrapper = commandLineWrapper;
+            _fileManager = fileManager;
         }
 
         public async Task CreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName)
@@ -94,7 +97,7 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// <returns>The full path to the command if found otherwise it will return null</returns>
         private string? FindExecutableInPath(string command)
         {
-            if (File.Exists(command))
+            if (_fileManager.Exists(command))
                 return Path.GetFullPath(command);
 
             Func<string, string> quoteRemover = x =>
@@ -112,7 +115,7 @@ namespace AWS.Deploy.Orchestration.Utilities
                 try
                 {
                     var fullPath = Path.Combine(quoteRemover(path), command);
-                    if (File.Exists(fullPath))
+                    if (_fileManager.Exists(fullPath))
                         return fullPath;
                 }
                 catch (Exception)
@@ -121,7 +124,7 @@ namespace AWS.Deploy.Orchestration.Utilities
                 }
             }
 
-            if (KNOWN_LOCATIONS.ContainsKey(command) && File.Exists(KNOWN_LOCATIONS[command]))
+            if (KNOWN_LOCATIONS.ContainsKey(command) && _fileManager.Exists(KNOWN_LOCATIONS[command]))
                 return KNOWN_LOCATIONS[command];
 
             return null;

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -9,11 +9,20 @@ using Xunit;
 using Amazon.Runtime;
 using AWS.Deploy.CLI.Utilities;
 using System;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
     public class ConsoleUtilitiesTests
     {
+        private readonly IDirectoryManager _directoryManager;
+
+        public ConsoleUtilitiesTests()
+        {
+            _directoryManager = new TestDirectoryManager();
+        }
+
         private readonly List<OptionItem> _options = new List<OptionItem>
         {
             new()
@@ -36,7 +45,7 @@ namespace AWS.Deploy.CLI.UnitTests
                 "3",
                 "CustomNewIdentifier"
             });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var userInputConfiguration = new UserInputConfiguration<OptionItem>(
                 option => option.DisplayName,
                 option => option.Identifier.Equals("Identifier2"),
@@ -67,7 +76,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 "1"
             });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var userInputConfiguration = new UserInputConfiguration<OptionItem>(
                 option => option.DisplayName,
                 option => option.Identifier.Equals("Identifier2"),
@@ -94,7 +103,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskUserToChooseStringsPickDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskUserToChoose(new List<string> { "Option1", "Option2" }, "Title", "Option2");
             Assert.Equal("Option2", selectedValue);
 
@@ -111,7 +120,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskUserToChooseStringsPicksNoDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "1" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskUserToChoose(new List<string> { "Option1", "Option2" }, "Title", "Option2");
             Assert.Equal("Option1", selectedValue);
         }
@@ -120,7 +129,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskUserToChooseStringsFirstSelectInvalid()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "a", "10", "1" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskUserToChoose(new List<string> { "Option1", "Option2" }, "Title", "Option2");
             Assert.Equal("Option1", selectedValue);
         }
@@ -129,7 +138,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskUserToChooseStringsNoTitle()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "a", "10", "1" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskUserToChoose(new List<string> { "Option1", "Option2" }, null, "Option2");
             Assert.Equal("Option1", selectedValue);
 
@@ -140,7 +149,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskUserForValueCanBeSetToEmptyString()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "<reset>" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
 
             var selectedValue =
                 consoleUtilities.AskUserForValue(
@@ -155,7 +164,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskUserForValueCanBeSetToEmptyStringNoDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "<reset>" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
 
             var selectedValue =
                 consoleUtilities.AskUserForValue(
@@ -170,7 +179,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskYesNoPickDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { string.Empty });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskYesNoQuestion("Do you want to deploy", YesNo.Yes);
             Assert.Equal(YesNo.Yes, selectedValue);
 
@@ -181,7 +190,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskYesNoPickNonDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "n" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskYesNoQuestion("Do you want to deploy", YesNo.Yes);
             Assert.Equal(YesNo.No, selectedValue);
         }
@@ -190,7 +199,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskYesNoPickNoDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "n" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskYesNoQuestion("Do you want to deploy");
             Assert.Equal(YesNo.No, selectedValue);
 
@@ -201,7 +210,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void AskYesNoPickInvalidChoice()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "q", "n" });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             var selectedValue = consoleUtilities.AskYesNoQuestion("Do you want to deploy", YesNo.Yes);
             Assert.Equal(YesNo.No, selectedValue);
 
@@ -212,7 +221,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public void DisplayRow()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl();
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
             consoleUtilities.DisplayRow(new[] { ("Hello", 10), ("World", 20) });
 
             Assert.Equal("Hello      | World               ", interactiveServices.OutputMessages[0]);
@@ -230,7 +239,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var interactiveServices = new TestToolInteractiveServiceImpl();
             interactiveServices.QueueConsoleInfos(ConsoleKey.A, ConsoleKey.B, ConsoleKey.C, ConsoleKey.Enter);
 
-            var callback = new AssumeRoleMfaTokenCodeCallback(interactiveServices, options);
+            var callback = new AssumeRoleMfaTokenCodeCallback(interactiveServices, _directoryManager, options);
             var code = callback.Execute();
 
             Assert.Equal("ABC", code);
@@ -254,7 +263,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var interactiveServices = new TestToolInteractiveServiceImpl();
             interactiveServices.QueueConsoleInfos(ConsoleKey.A, ConsoleKey.B, ConsoleKey.C, ConsoleKey.Backspace, ConsoleKey.D, ConsoleKey.Enter);
 
-            var callback = new AssumeRoleMfaTokenCodeCallback(interactiveServices, options);
+            var callback = new AssumeRoleMfaTokenCodeCallback(interactiveServices, _directoryManager, options);
             var code = callback.Execute();
 
             Assert.Equal("ABD", code);

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -27,9 +27,11 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = ResolvePath(Path.Combine(topLevelFolder, projectName));
 
-            var project = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(projectPath);
+            var fileManager = new FileManager();
 
-            var engine = new DockerEngine.DockerEngine(project);
+            var project = await new ProjectDefinitionParser(fileManager, new DirectoryManager()).Parse(projectPath);
+
+            var engine = new DockerEngine.DockerEngine(project, fileManager);
 
             engine.GenerateDockerFile();
 

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.Runtime;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common;
@@ -22,6 +23,13 @@ namespace AWS.Deploy.CLI.UnitTests
     public class RecommendationTests
     {
         private OrchestratorSession _session;
+        private readonly IDirectoryManager _directoryManager;
+
+        public RecommendationTests()
+        {
+            _directoryManager = new TestDirectoryManager();
+        }
+
         private async Task<RecommendationEngine> BuildRecommendationEngine(string testProjectName)
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
@@ -128,7 +136,7 @@ namespace AWS.Deploy.CLI.UnitTests
                 "<reset>"
             });
 
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
 
             var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
 
@@ -155,7 +163,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 "<reset>"
             });
-            var consoleUtilities = new ConsoleUtilities(interactiveServices);
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
 
             var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
 


### PR DESCRIPTION
*Issue #, if available:*
IDE-5678

*Description of changes:*
Pentest recommendation:

Disallow SMB shares from being considered valid file paths by default.
If SMB shares are required, consider allowing specific servers to be explicitly allowed in a configuration file, and deny all other file paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
