### PR TITLE
feat: Enable re-deployment using a compatible CDK deployment project.

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -211,7 +211,8 @@ namespace AWS.Deploy.CLI.Commands
                         _customRecipeLocator,
                         _systemCapabilityEvaluator,
                         session,
-                        _directoryManager);
+                        _directoryManager,
+                        _fileManager);
 
                     var deploymentProjectPath = input.DeploymentProject ?? string.Empty;
                     if (!string.IsNullOrEmpty(deploymentProjectPath))

--- a/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
@@ -234,6 +234,7 @@ namespace AWS.Deploy.CLI.Commands
             recipe.CdkProjectTemplate = null;
             recipe.PersistedDeploymentProject = true;
             recipe.RecipePriority = DEFAULT_PERSISTED_RECIPE_PRIORITY;
+            recipe.BaseRecipeId = recommendation.Recipe.Id;
 
             var recipeSnapshotBody = JsonConvert.SerializeObject(recipe, new JsonSerializerSettings
             {

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -79,4 +79,9 @@ namespace AWS.Deploy.CLI
     {
         public InvalidSaveDirectoryForCdkProject(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    public class FailedToFindDeploymentProjectRecipeIdException : Exception
+    {
+        public FailedToFindDeploymentProjectRecipeIdException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -108,6 +108,11 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         public bool PersistedDeploymentProject { get; set; }
 
+        /// <summary>
+        /// The recipe ID of the parent recipe which was used to create the CDK deployment project. 
+        /// </summary>
+        public string? BaseRecipeId { get; set; }
+
         public RecipeDefinition(
             string id,
             string version,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -100,6 +100,16 @@
         },
         "Validators": {
             "$ref": "#/definitions/Validators"
+        },
+        "PersistedDeploymentProject": {
+            "type": "boolean",
+            "title": "Persisted Deployment Project",
+            "description": "A boolean value that indicates if this recipe is generated from a saved CDK deployment project."
+        },
+        "BaseRecipeId": {
+            "type": "string",
+            "title": "Base Recipe Id",
+            "description": "The parent recipe Id which was used to create the saved CDK deployment project."
         }
     },
     "definitions": {

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RedeploymentTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RedeploymentTests.cs
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using Amazon.CloudFormation;
+using Amazon.ECS;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
+{
+    public class RedeploymentTests : IDisposable
+    {
+        private readonly HttpHelper _httpHelper;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly ECSHelper _ecsHelper;
+        private readonly App _app;
+        private readonly InMemoryInteractiveService _interactiveService;
+        private bool _isDisposed;
+        private string _stackName;
+
+        public RedeploymentTests()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _app = serviceProvider.GetService<App>();
+            Assert.NotNull(_app);
+
+            _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
+            Assert.NotNull(_interactiveService);
+
+            _httpHelper = new HttpHelper(_interactiveService);
+
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            var ecsClient = new AmazonECSClient();
+            _ecsHelper = new ECSHelper(ecsClient);
+        }
+
+        [Fact]
+        public async Task AttemptWorkFlow()
+        {
+            _stackName = $"WebAppWithDockerFile{Guid.NewGuid().ToString().Split('-').Last()}";
+            var tempDirectoryPath = new TestAppManager().GetProjectPath(string.Empty);
+            var projectPath = Path.Combine(tempDirectoryPath, "testapps", "WebAppWithDockerFile");
+            var compatibleDeploymentProjectPath = Path.Combine(tempDirectoryPath, "DeploymentProjects", "CompatibleCdkApp");
+            var incompatibleDeploymentProjectPath = Path.Combine(tempDirectoryPath, "DeploymentProjects", "IncompatibleCdkApp");
+
+            // perform inital deployment using ECS Fargate recipe
+            await PerformInitialDeployment(projectPath);
+
+            // Create a compatible CDK deployment project using the ECS recipe
+            await Utilities.CreateCDKDeploymentProjectWithRecipeName(projectPath, "Custom ECS Fargate Recipe", "1", compatibleDeploymentProjectPath, underSourceControl: false);
+
+            // Create an incompatible CDK deployment project using the App runner recipe
+            await Utilities.CreateCDKDeploymentProjectWithRecipeName(projectPath, "Custom App Runner Recipe", "2", incompatibleDeploymentProjectPath, underSourceControl: false);
+
+            // attempt re-deployment using incompatible CDK project
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--deployment-project", incompatibleDeploymentProjectPath, "--stack-name", _stackName, "--diagnostics" };
+            var returnCode = await _app.Run(deployArgs);
+            Assert.Equal(CommandReturnCodes.USER_ERROR, returnCode);
+
+            // attempt re-deployment using compatible CDK project
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default option settings
+            await _interactiveService.StdInWriter.FlushAsync();
+            deployArgs = new[] { "deploy", "--project-path", projectPath, "--deployment-project", compatibleDeploymentProjectPath, "--stack-name", _stackName, "--diagnostics" };
+            returnCode = await _app.Run(deployArgs);
+            Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
+            Assert.Equal(StackStatus.UPDATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+            var cluster = await _ecsHelper.GetCluster(_stackName);
+            Assert.Equal(TaskDefinitionStatus.ACTIVE, cluster.Status);
+
+            // Delete stack
+            await DeleteStack();
+        }
+
+        private async Task PerformInitialDeployment(string projectPath)
+        {
+            // Arrange input for deploy
+            await _interactiveService.StdInWriter.WriteLineAsync("1"); // Select ECS Fargate recommendation
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default option settings
+            await _interactiveService.StdInWriter.FlushAsync();
+
+            // Deploy
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
+            var returnCode = await _app.Run(deployArgs);
+            Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
+
+            // Verify application is deployed and running
+            Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+            var cluster = await _ecsHelper.GetCluster(_stackName);
+            Assert.Equal(TaskDefinitionStatus.ACTIVE, cluster.Status);
+
+            var deployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+
+            var applicationUrl = deployStdOut.First(line => line.Trim().StartsWith("Endpoint:"))
+                .Split(" ")[1]
+                .Trim();
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _httpHelper.WaitUntilSuccessStatusCode(applicationUrl, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            // list
+            var listArgs = new[] { "list-deployments", "--diagnostics" };
+            returnCode = await _app.Run(listArgs);
+            Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
+
+            // Verify stack exists in list of deployments
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
+        }
+
+        private async Task DeleteStack()
+        {
+            // Arrange input for delete
+            await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
+            await _interactiveService.StdInWriter.FlushAsync();
+            var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics" };
+
+            // Delete
+            var returnCode = await _app.Run(deleteArgs);
+            Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
+
+            // Verify application is deleted
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                if (!isStackDeleted)
+                {
+                    _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                }
+
+                _interactiveService.ReadStdOutStartToEnd();
+            }
+
+            _isDisposed = true;
+        }
+
+        ~RedeploymentTests()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/Utilities.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/Utilities.cs
@@ -33,11 +33,11 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             if (string.IsNullOrEmpty(saveDirectoryPath))
             {
                 saveDirectoryPath = targetApplicationPath + "CDK";
-                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath };
+                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--diagnostics" };
             }  
             else
             {
-                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--output", saveDirectoryPath };
+                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--output", saveDirectoryPath, "--diagnostics" };
             }
                 
 
@@ -59,14 +59,18 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             VerifyCreatedArtifacts(targetApplicationPath, saveDirectoryPath);
         }
 
-        public static async Task CreateCDKDeploymentProjectWithRecipeName(string targetApplicationPath, string recipeName, string option, string saveDirectoryPath = null, bool isValid = true)
+        public static async Task CreateCDKDeploymentProjectWithRecipeName(string targetApplicationPath, string recipeName, string option, string saveDirectoryPath = null, bool isValid = true, bool underSourceControl = true)
         {
             var (app, interactiveService) = GetAppServiceProvider();
             Assert.NotNull(app);
             Assert.NotNull(interactiveService);
 
             // Arrange input for saving the CDK deployment project
-            await interactiveService.StdInWriter.WriteAsync(option); // select recipe to save the CDK deployment project
+            await interactiveService.StdInWriter.WriteLineAsync(option); // select recipe to save the CDK deployment project
+            if (!underSourceControl)
+            {
+                await interactiveService.StdInWriter.WriteAsync("y"); // proceed to save without source control.
+            }
             await interactiveService.StdInWriter.FlushAsync();
 
 
@@ -75,11 +79,11 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             if (string.IsNullOrEmpty(saveDirectoryPath))
             {
                 saveDirectoryPath = targetApplicationPath + "CDK";
-                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--project-display-name", recipeName};
+                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--project-display-name", recipeName, "--diagnostics"};
             }
             else
             {
-                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--output", saveDirectoryPath, "--project-display-name", recipeName };
+                deployArgs = new[] { "deployment-project", "generate", "--project-path", targetApplicationPath, "--output", saveDirectoryPath, "--project-display-name", recipeName, "--diagnostics" };
             }
 
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5328

*Description of changes:*
This PR enables re-deployments to an existing Cloudformation stack using a compatible CDK project

A sample workflow of this feature is as follows:
1. Perform an initial deployment using the **ECS Fargate recipe**.
1.1 `dotnet aws deploy --project-path [path-to-project] --stack-name [stack-name]`.
2. Create a persisted CDK deployment project using the **ECS Fargate recipe**.
2.1 `dotnet aws deployment-project generate --project-path [path-to-project] --output [path-to-save-cdk-project]`
3. Perform a re-deployment to the **same stack** using the persisted CDK project.
3.1 `dotnet aws deploy --project-path [path-to-project] --stack-name [stack-name] --deployment-project [path-to-saved-cdk-project]`

To enable this feature, a new property called `BaseRecipeId` is added as part of the `RecipeDefinition`. This property is set while generating the recipe snapshot when saving a custom CDK project to customer's source control. 

A re-deployment using the custom CDK project is only permitted when the `BaseRecipeId` is equal to the RecipeId used during the initial deployment. 




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
