### PR TITLE
fix: Startup freezing when started from a project that has a large "git status" response.

### DIFF
--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -83,14 +83,27 @@ namespace AWS.Deploy.CLI.Utilities
             if (null == process)
                 throw new Exception("Process.Start failed to return a non-null process");
 
-            if (redirectIO && streamOutputToInteractiveService)
+            if (redirectIO)
             {
-                process.OutputDataReceived += (sender, e) => {
-                    _interactiveService.LogMessageLine(e.Data);
-                    strOutput.Append(e.Data); };
-                process.ErrorDataReceived += (sender, e) => {
-                    _interactiveService.LogMessageLine(e.Data);
-                    strError.Append(e.Data); };
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if(streamOutputToInteractiveService)
+                    {
+                        _interactiveService.LogMessageLine(e.Data);
+                    }
+
+                    strOutput.Append(e.Data);
+                };
+
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if(streamOutputToInteractiveService)
+                    {
+                        _interactiveService.LogMessageLine(e.Data);
+                    }
+
+                    strError.Append(e.Data);
+                };
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
             }
@@ -115,8 +128,8 @@ namespace AWS.Deploy.CLI.Utilities
 
                 if (redirectIO)
                 {
-                    result.StandardError = streamOutputToInteractiveService ? strError.ToString() : await process.StandardError.ReadToEndAsync();
-                    result.StandardOut = streamOutputToInteractiveService ? strOutput.ToString() : await process.StandardOutput.ReadToEndAsync();
+                    result.StandardError = strError.ToString();
+                    result.StandardOut = strOutput.ToString();
                 }
 
                 onComplete(result);

--- a/src/AWS.Deploy.Orchestration/CustomRecipeLocator.cs
+++ b/src/AWS.Deploy.Orchestration/CustomRecipeLocator.cs
@@ -23,7 +23,7 @@ namespace AWS.Deploy.Orchestration
     /// </summary>
     public class CustomRecipeLocator : ICustomRecipeLocator
     {
-        private const string GIT_STATUS_COMMAND = "git status";
+        private const string GIT_STATUS_COMMAND = "git worktree list";
         private const string SVN_STATUS_COMMAND = "svn status";
 
         private readonly string _ignorePathSubstring = Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar;


### PR DESCRIPTION
*Description of changes:*
During startup the tool looks to see if current directory is inside a git repo. It does this by shelling out the command `git status`. Because we just care about the exit code we redirect the IO to hide the console window but ignore the stdout. If the the `git status` command returns a lot of data it can fill up the std out buffer used by the process freezing the program.

The fix was to make sure we always read stdout and stderror so we don't fill up the buffer but only write back to the console if the `streamOutputToInteractiveService` flag was set.

Also calling `git status` is heavy weight for just checking if in a git repo because it forces git to check the status of the repo which could be slow for large repos. I changed the command to `git worktree list`. It will only work if run inside a git repo but doesn't have to inspect anything with the files. I didn't use `git log` because that command fails if there hasn't been a commit yet.

I test this by creating a project and then did a `git init` in the project. I then added a lot of javascript files to the wwwroot folder, in this case the source of bootstrap. Then did a git add for all of the untracked files but did not commit them. I reproduce the freeze first by running the tool and then running the tool with this fix to confirm it work as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
