### PR TITLE
fix: Server-mode GetRecipe API supports finding recipes for custom deployment project recipe ids.

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/RecipeController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/RecipeController.cs
@@ -1,9 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Linq;
+using System.Threading.Tasks;
 using AWS.Deploy.CLI.ServerMode.Models;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.DeploymentManifest;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -14,20 +20,34 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
     [Route("api/v1/[controller]")]
     public class RecipeController : ControllerBase
     {
+        private readonly ICustomRecipeLocator _customRecipeLocator;
+        private readonly IProjectDefinitionParser _projectDefinitionParser;
+
+        public RecipeController(ICustomRecipeLocator customRecipeLocator, IProjectDefinitionParser projectDefinitionParser)
+        {
+            _customRecipeLocator = customRecipeLocator;
+            _projectDefinitionParser = projectDefinitionParser;
+        }
+
         /// <summary>
         /// Gets a summary of the specified Recipe.
         /// </summary>
         [HttpGet("{recipeId}")]
         [SwaggerOperation(OperationId = "GetRecipe")]
         [SwaggerResponse(200, type: typeof(RecipeSummary))]
-        public IActionResult GetRecipe(string recipeId, [FromQuery] string? projectPath = null)
+        public async Task<IActionResult> GetRecipe(string recipeId, [FromQuery] string? projectPath = null)
         {
             if (string.IsNullOrEmpty(recipeId))
             {
                 return BadRequest($"A Recipe ID was not provided.");
             }
 
-            var recipeDefinitions = RecipeHandler.GetRecipeDefinitions();
+            ProjectDefinition? projectDefinition = null;
+            if(!string.IsNullOrEmpty(projectPath))
+            {
+                projectDefinition = await _projectDefinitionParser.Parse(projectPath);
+            }
+            var recipeDefinitions = await RecipeHandler.GetRecipeDefinitions(_customRecipeLocator, projectDefinition);
             var selectedRecipeDefinition = recipeDefinitions.FirstOrDefault(x => x.Id.Equals(recipeId));
 
             if (selectedRecipeDefinition == null)


### PR DESCRIPTION
*Description of changes:*
Fix issue with the GetRecipe REST API from server mode that was not using custom recipe location paths to search for recipes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
