### PR TITLE
fix: Replace default values for option setting items with stack name as prefix

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -25,6 +25,8 @@ namespace AWS.Deploy.CLI.Commands
 {
     public class DeployCommand
     {
+        public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";
+
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
         private readonly ICdkProjectHandler _cdkProjectHandler;
@@ -162,7 +164,7 @@ namespace AWS.Deploy.CLI.Commands
 
             // Get Cloudformation stack name.
             var cloudApplicationName = GetCloudApplicationName(stackName, userDeploymentSettings, compatibleApplications);
-
+            
             // Find existing application with the same CloudFormation stack name.
             var deployedApplication = allDeployedApplications.FirstOrDefault(x => string.Equals(x.Name, cloudApplicationName));
 
@@ -190,6 +192,9 @@ namespace AWS.Deploy.CLI.Commands
                     selectedRecommendation = GetSelectedRecommendation(userDeploymentSettings, recommendations);
                 }
             }
+
+            // Apply the user entered stack name to the recommendation so that any default settings based on stack name are applied.
+            selectedRecommendation.AddReplacementToken(REPLACE_TOKEN_STACK_NAME, cloudApplicationName);
 
             var cloudApplication = new CloudApplication(cloudApplicationName, selectedRecommendation.Recipe.Id);
 
@@ -222,9 +227,6 @@ namespace AWS.Deploy.CLI.Commands
         /// <param name="userDeploymentSettings"><see cref="UserDeploymentSettings"/></param>
         public async Task ConfigureDeployment(CloudApplication cloudApplication, Orchestrator orchestrator, Recommendation selectedRecommendation, UserDeploymentSettings? userDeploymentSettings)
         {
-            // Apply the user entered project name to the recommendation so that any default settings based on project name are applied.
-            selectedRecommendation.OverrideProjectName(cloudApplication.Name);
-
             var configurableOptionSettings = selectedRecommendation.GetConfigurableOptionSettingItems();
 
             if (userDeploymentSettings != null)

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -28,6 +28,7 @@ using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.LocalUserSettings;
+using AWS.Deploy.CLI.Commands;
 
 namespace AWS.Deploy.CLI.ServerMode.Controllers
 {
@@ -284,6 +285,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
                 state.ApplicationDetails.Name = input.NewDeploymentName;
                 state.ApplicationDetails.RecipeId = input.NewDeploymentRecipeId;
+                state.SelectedRecommendation.AddReplacementToken(DeployCommand.REPLACE_TOKEN_STACK_NAME, input.NewDeploymentName);
             }
             else if(!string.IsNullOrEmpty(input.ExistingDeploymentName))
             {
@@ -307,6 +309,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
                 state.ApplicationDetails.Name = input.ExistingDeploymentName;
                 state.ApplicationDetails.RecipeId = existingDeployment.RecipeId;
+                state.SelectedRecommendation.AddReplacementToken(DeployCommand.REPLACE_TOKEN_STACK_NAME, input.ExistingDeploymentName);
             }
 
             return Ok();

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -11,8 +11,6 @@ namespace AWS.Deploy.Common
 {
     public class Recommendation : IUserInputOption
     {
-        private const string REPLACE_TOKEN_PROJECT_NAME = "{ProjectName}";
-
         public string ProjectPath => ProjectDefinition.ProjectPath;
 
         public ProjectDefinition ProjectDefinition { get; }
@@ -46,22 +44,11 @@ namespace AWS.Deploy.Common
             DeploymentBundle = new DeploymentBundle();
             DeploymentBundleSettings = deploymentBundleSettings;
 
-            _replacementTokens[REPLACE_TOKEN_PROJECT_NAME] = Path.GetFileNameWithoutExtension(projectDefinition.ProjectPath);
-
             foreach (var replacement in additionalReplacements)
             {
                 if (!_replacementTokens.ContainsKey(replacement.Key))
                     _replacementTokens[replacement.Key] = replacement.Value;
             }
-        }
-
-        /// <summary>
-        /// Overrides the project name used as a replacement token in default setting values.
-        /// </summary>
-        /// <param name="name"></param>
-        public void OverrideProjectName(string name)
-        {
-            _replacementTokens[REPLACE_TOKEN_PROJECT_NAME] = name;
         }
 
         public Recommendation ApplyPreviousSettings(IDictionary<string, object> previousSettings)
@@ -71,6 +58,11 @@ namespace AWS.Deploy.Common
             ApplyPreviousSettings(recommendation, previousSettings);
 
             return recommendation;
+        }
+
+        public void AddReplacementToken(string key, string value)
+        {
+            _replacementTokens[key] = value;
         }
 
         private void ApplyPreviousSettings(Recommendation recommendation, IDictionary<string, object> previousSettings)

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -63,7 +63,7 @@
             "TypeHint": "AppRunnerService",
             "AdvancedSetting": false,
             "Updatable": false,
-            "DefaultValue": "{ProjectName}-service"
+            "DefaultValue": "{StackName}-service"
         },
         {
             "Id": "Port",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -116,7 +116,7 @@
                     "Name": "New Cluster Name",
                     "Description": "The name of the new cluster to create.",
                     "Type": "String",
-                    "DefaultValue": "{ProjectName}",
+                    "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -145,7 +145,7 @@
             "Description": "The name of the ECS service running in the cluster.",
             "Type": "String",
             "TypeHint": "ECSService",
-            "DefaultValue": "{ProjectName}-service",
+            "DefaultValue": "{StackName}-service",
             "AdvancedSetting": false,
             "Updatable": false,
             "Validators": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -100,7 +100,7 @@
                     "Name": "Application Name",
                     "Description": "The Elastic Beanstalk application name.",
                     "Type": "String",
-                    "DefaultValue": "{ProjectName}",
+                    "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -122,7 +122,7 @@
             "Description": "The Elastic Beanstalk environment name.",
             "Type": "String",
             "TypeHint": "BeanstalkEnvironment",
-            "DefaultValue": "{ProjectName}-dev",
+            "DefaultValue": "{StackName}-dev",
             "AdvancedSetting": false,
             "Updatable": false,
             "Validators": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -143,7 +143,7 @@
                     "Name": "New Cluster Name",
                     "Description": "The name of the new cluster to create.",
                     "Type": "String",
-                    "DefaultValue": "{ProjectName}",
+                    "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -143,7 +143,7 @@
                     "Name": "New Cluster Name",
                     "Description": "The name of the new cluster to create.",
                     "Type": "String",
-                    "DefaultValue": "{ProjectName}",
+                    "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -172,7 +172,7 @@
             "Description": "The name of the ECS service running in the cluster.",
             "Type": "String",
             "TypeHint": "ECSService",
-            "DefaultValue": "{ProjectName}-service",
+            "DefaultValue": "{StackName}-service",
             "AdvancedSetting": false,
             "Updatable": false,
             "Validators": [

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -169,6 +169,8 @@ namespace AWS.Deploy.CLI.UnitTests
             var recommendations = await engine.ComputeRecommendations();
 
             var fargateRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_ASPNET_CORE_FARGATE_RECIPE_ID);
+            fargateRecommendation.AddReplacementToken("{StackName}", "MyAppStack");
+
             var ecsServiceNameOptionSetting = fargateRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ECSServiceName"));
 
             var originalDefaultValue = fargateRecommendation.GetOptionSettingDefaultValue<string>(ecsServiceNameOptionSetting);
@@ -252,11 +254,14 @@ namespace AWS.Deploy.CLI.UnitTests
             var recommendations = await engine.ComputeRecommendations();
 
             var beanstalkRecommendation = recommendations.FirstOrDefault(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
-            var beanstalEnvNameSetting = beanstalkRecommendation.Recipe.OptionSettings.FirstOrDefault(x => string.Equals("EnvironmentName", x.Id));
-            Assert.Equal("WebAppNoDockerFile-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
 
-            beanstalkRecommendation.OverrideProjectName("CustomName");
-            Assert.Equal("CustomName-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
+            var beanstalEnvNameSetting = beanstalkRecommendation.Recipe.OptionSettings.FirstOrDefault(x => string.Equals("EnvironmentName", x.Id));
+
+            beanstalkRecommendation.AddReplacementToken("{StackName}", "MyAppStack");
+            Assert.Equal("MyAppStack-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
+
+            beanstalkRecommendation.AddReplacementToken("{StackName}", "CustomAppStack");
+            Assert.Equal("CustomAppStack-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
         }
 
         [Theory]


### PR DESCRIPTION
*Description of changes:*
Currently in the deploy tool we are prefixing the default values for certain parameter (ECS Service name, Elastic Beanstalk Environment etc..) with the `ProjectName`. However, the `ProjectName` is not unique because we use the same project for multiple integration tests. This is causing an issue while deletion of stacks because the Cloudformation resources are shared between multiple stacks. 

In order to avoid this issue, we are replacing the `ProjectName` prefix is replaced with the `StackName`, which is unique per test. As a result, all Cloudformation resources created by a test are exclusive to the stack that it created

The same is also extended to the server mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
