### PR TITLE
Integration test improvements

### DIFF
--- a/src/AWS.Deploy.CLI/AWSUtilities.cs
+++ b/src/AWS.Deploy.CLI/AWSUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,7 +9,9 @@ using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
 using Amazon.EC2.Model;
 using System.IO;
+using AWS.Deploy.CLI.Commands.CommandHandlerInput;
 using AWS.Deploy.CLI.Utilities;
+using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.CLI
@@ -25,7 +28,10 @@ namespace AWS.Deploy.CLI
         private readonly IConsoleUtilities _consoleUtilities;
         private readonly IDirectoryManager _directoryManager;
 
-        public AWSUtilities(IToolInteractiveService toolInteractiveService, IConsoleUtilities consoleUtilities, IDirectoryManager directoryManager)
+        public AWSUtilities(
+            IToolInteractiveService toolInteractiveService,
+            IConsoleUtilities consoleUtilities,
+            IDirectoryManager directoryManager)
         {
             _toolInteractiveService = toolInteractiveService;
             _consoleUtilities = consoleUtilities;
@@ -36,51 +42,52 @@ namespace AWS.Deploy.CLI
         {
             async Task<AWSCredentials> Resolve()
             {
-            var chain = new CredentialProfileStoreChain();
+                var chain = new CredentialProfileStoreChain();
 
                 if (!string.IsNullOrEmpty(profileName) && chain.TryGetAWSCredentials(profileName, out var profileCredentials) &&
                     // Skip checking CanLoadCredentials for AssumeRoleAWSCredentials because it might require an MFA token and the callback hasn't been setup yet.
                     (profileCredentials is AssumeRoleAWSCredentials || await CanLoadCredentials(profileCredentials)))
-            {
+                {
                     _toolInteractiveService.WriteLine($"Configuring AWS Credentials from Profile {profileName}.");
                     return profileCredentials;
                 }
 
-            if (!string.IsNullOrEmpty(lastUsedProfileName) &&
+                if (!string.IsNullOrEmpty(lastUsedProfileName) &&
                     chain.TryGetAWSCredentials(lastUsedProfileName, out var lastUsedCredentials) &&
                     await CanLoadCredentials(lastUsedCredentials))
-            {
-                _toolInteractiveService.WriteLine($"Configuring AWS Credentials with previous configured profile value {lastUsedProfileName}.");
+                {
+                    _toolInteractiveService.WriteLine($"Configuring AWS Credentials with previous configured profile value {lastUsedProfileName}.");
                     return lastUsedCredentials;
-            }
+                }
 
-            try
-            {
+                try
+                {
                     var fallbackCredentials = FallbackCredentialsFactory.GetCredentials();
 
                     if (await CanLoadCredentials(fallbackCredentials))
-                {
-                    _toolInteractiveService.WriteLine("Configuring AWS Credentials using AWS SDK credential search.");
+                    {
+                        _toolInteractiveService.WriteLine("Configuring AWS Credentials using AWS SDK credential search.");
                         return fallbackCredentials;
+                    }
                 }
-            }
-            catch (AmazonServiceException)
-            {
-                // FallbackCredentialsFactory throws an exception if no credentials are found. Burying exception because if no credentials are found
-                // we want to continue and ask the user to select a profile.
-            }
+                catch (AmazonServiceException ex)
+                {
+                    // FallbackCredentialsFactory throws an exception if no credentials are found. Burying exception because if no credentials are found
+                    // we want to continue and ask the user to select a profile.
+                    _toolInteractiveService.WriteDebugLine(ex.PrettyPrint());
+                }
 
-            var sharedCredentials = new SharedCredentialsFile();
-            if (sharedCredentials.ListProfileNames().Count == 0)
-            {
-                throw new NoAWSCredentialsFoundException("Unable to resolve AWS credentials to access AWS.");
-            }
+                var sharedCredentials = new SharedCredentialsFile();
+                if (sharedCredentials.ListProfileNames().Count == 0)
+                {
+                    throw new NoAWSCredentialsFoundException("Unable to resolve AWS credentials to access AWS.");
+                }
 
-            var selectedProfileName = _consoleUtilities.AskUserToChoose(sharedCredentials.ListProfileNames(), "Select AWS Credentials Profile", null);
+                var selectedProfileName = _consoleUtilities.AskUserToChoose(sharedCredentials.ListProfileNames(), "Select AWS Credentials Profile", null);
 
                 if (chain.TryGetAWSCredentials(selectedProfileName, out var selectedProfileCredentials) &&
                     (await CanLoadCredentials(selectedProfileCredentials)))
-            {
+                {
                     return selectedProfileCredentials;
                 }
 
@@ -100,16 +107,14 @@ namespace AWS.Deploy.CLI
 
         private async Task<bool> CanLoadCredentials(AWSCredentials credentials)
         {
-            if (null == credentials)
-                return false;
-
             try
             {
                 await credentials.GetCredentialsAsync();
                 return true;
             }
-            catch
+            catch (Exception ex)
             {
+                _toolInteractiveService.WriteDebugLine(ex.PrettyPrint());
                 return false;
             }
         }

--- a/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
+++ b/src/AWS.Deploy.CLI/CloudFormation/StackEventMonitor.cs
@@ -31,11 +31,13 @@ namespace AWS.Deploy.CLI.CloudFormation
         private readonly IAmazonCloudFormation _cloudFormationClient;
         private readonly HashSet<string> _processedEventIds = new HashSet<string>();
         private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IToolInteractiveService _interactiveService;
 
-        public StackEventMonitor(string stackName, IAWSClientFactory awsClientFactory, IConsoleUtilities consoleUtilities)
+        public StackEventMonitor(string stackName, IAWSClientFactory awsClientFactory, IConsoleUtilities consoleUtilities, IToolInteractiveService interactiveService)
         {
             _stackName = stackName;
             _consoleUtilities = consoleUtilities;
+            _interactiveService = interactiveService;
 
             _cloudFormationClient = awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
         }
@@ -112,10 +114,12 @@ namespace AWS.Deploy.CLI.CloudFormation
             catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ValidationError") && exception.Message.Equals($"Stack [{_stackName}] does not exist"))
             {
                 // Stack is deleted, there could be some missed events between the last poll timestamp and DELETE_COMPLETE
+                _interactiveService.WriteDebugLine(exception.PrettyPrint());
             }
-            catch (AmazonCloudFormationException)
+            catch (AmazonCloudFormationException exception)
             {
                 // Other AmazonCloudFormationException
+                _interactiveService.WriteDebugLine(exception.PrettyPrint());
             }
 
             foreach (var stackEvent in stackEvents.OrderBy(e => e.Timestamp))

--- a/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
@@ -64,7 +64,7 @@ namespace AWS.Deploy.CLI.Commands
             }
 
             _interactiveService.WriteLine($"{stackName}: deleting...");
-            var monitor = new StackEventMonitor(stackName, _awsClientFactory, _consoleUtilities);
+            var monitor = new StackEventMonitor(stackName, _awsClientFactory, _consoleUtilities, _interactiveService);
 
             try
             {
@@ -171,6 +171,7 @@ namespace AWS.Deploy.CLI.Commands
                 }
                 catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ValidationError") && exception.Message.Equals($"Stack with id {stackName} does not exist"))
                 {
+                    _interactiveService.WriteDebugLine(exception.PrettyPrint());
                     shouldRetry = false;
                 }
                 catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("Throttling"))

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -164,7 +164,7 @@ namespace AWS.Deploy.CLI.Commands
 
             // Get Cloudformation stack name.
             var cloudApplicationName = GetCloudApplicationName(stackName, userDeploymentSettings, compatibleApplications);
-            
+
             // Find existing application with the same CloudFormation stack name.
             var deployedApplication = allDeployedApplications.FirstOrDefault(x => string.Equals(x.Name, cloudApplicationName));
 
@@ -354,8 +354,9 @@ namespace AWS.Deploy.CLI.Commands
                                 throw new InvalidOverrideValueException($"Invalid value {optionSettingValue} for option setting item {optionSettingJsonPath}");
                         }
                     }
-                    catch (Exception)
+                    catch (Exception exception)
                     {
+                        _toolInteractiveService.WriteDebugLine(exception.PrettyPrint());
                         throw new InvalidOverrideValueException($"Invalid value {optionSettingValue} for option setting item {optionSettingJsonPath}");
                     }
 
@@ -483,7 +484,10 @@ namespace AWS.Deploy.CLI.Commands
             {
                 defaultName = _cloudApplicationNameGenerator.GenerateValidName(project, existingApplications);
             }
-            catch { }
+            catch (Exception exception)
+            {
+                _toolInteractiveService.WriteDebugLine(exception.PrettyPrint());
+            }
 
             var cloudApplicationName = "";
 

--- a/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AWS.Deploy.CLI.ServerMode;
 using AWS.Deploy.CLI.ServerMode.Services;
+using AWS.Deploy.Common;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -65,8 +66,9 @@ namespace AWS.Deploy.CLI.Commands
                     process.EnableRaisingEvents = true;
                     process.Exited += async (sender, args) => { await ShutDownHost(host, cancellationToken); };
                 }
-                catch (Exception)
+                catch (Exception exception)
                 {
+                    _interactiveService.WriteDebugLine(exception.PrettyPrint());
                     return;
                 }
 

--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -114,7 +114,12 @@ namespace AWS.Deploy.CLI.Utilities
             while (true)
             {
                 if (process.HasExited)
+                {
+                    // In some cases, process might have exited but OutputDataReceived or ErrorDataReceived could still be writing
+                    // asynchronously, adding a delay should cover most of the cases.
+                    await Task.Delay(TimeSpan.FromSeconds(1), cancelToken);
                     break;
+                }
 
                 await Task.Delay(TimeSpan.FromMilliseconds(50), cancelToken);
             }

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -16,7 +16,7 @@ namespace AWS.Deploy.Orchestration
         Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
         string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
         Task DeployCdkProject(OrchestratorSession session, string cdkProjectPath, Recommendation recommendation);
-        void DeleteTemporaryCdkProject(string cdkProjectPath);
+        void DeleteTemporaryCdkProject(OrchestratorSession session, string cdkProjectPath);
     }
 
     public class CdkProjectHandler : ICdkProjectHandler
@@ -83,6 +83,7 @@ namespace AWS.Deploy.Orchestration
                 workingDirectory: cdkProjectPath,
                 environmentVariables: environmentVariables,
                 needAwsCredentials: true,
+                redirectIO: true,
                 streamOutputToInteractiveService: true);
 
             if (cdkDeploy.ExitCode != 0)
@@ -118,7 +119,7 @@ namespace AWS.Deploy.Orchestration
             return saveCdkDirectoryPath;
         }
 
-        public void DeleteTemporaryCdkProject(string cdkProjectPath)
+        public void DeleteTemporaryCdkProject(OrchestratorSession session, string cdkProjectPath)
         {
             var parentPath = Path.GetFullPath(Constants.CDK.ProjectsDirectory);
             cdkProjectPath = Path.GetFullPath(cdkProjectPath);
@@ -130,8 +131,9 @@ namespace AWS.Deploy.Orchestration
             {
                 _directoryManager.Delete(cdkProjectPath, true);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                _interactiveService.LogDebugLine(exception.PrettyPrint());
                 _interactiveService.LogErrorMessageLine($"We were unable to delete the temporary project that was created for this deployment. Please manually delete it at this location: {cdkProjectPath}");
             }
         }

--- a/src/AWS.Deploy.Orchestration/CustomRecipeLocator.cs
+++ b/src/AWS.Deploy.Orchestration/CustomRecipeLocator.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.Orchestration
         private readonly ICommandLineWrapper _commandLineWrapper;
         private readonly IDeploymentManifestEngine _deploymentManifestEngine;
         private readonly IDirectoryManager _directoryManager;
-        
+
         public CustomRecipeLocator(IDeploymentManifestEngine deploymentManifestEngine, IOrchestratorInteractiveService orchestratorInteractiveService,
             ICommandLineWrapper commandLineWrapper, IDirectoryManager directoryManager)
         {
@@ -109,7 +109,7 @@ namespace AWS.Deploy.Orchestration
                 rootDirectoryPath = solutionDirectoryPath;
             }
 
-            return GetRecipePathsFromRootDirectory(rootDirectoryPath); 
+            return GetRecipePathsFromRootDirectory(rootDirectoryPath);
         }
 
         /// <summary>
@@ -141,10 +141,15 @@ namespace AWS.Deploy.Orchestration
         private async Task<string?> GetSourceControlRootDirectory(string currentDirectoryPath)
         {
             var possibleRootDirectoryPath = currentDirectoryPath;
-            while (currentDirectoryPath != null && await IsDirectoryUnderSourceControl(currentDirectoryPath))
+            while (await IsDirectoryUnderSourceControl(currentDirectoryPath))
             {
                 possibleRootDirectoryPath = currentDirectoryPath;
-                currentDirectoryPath = _directoryManager.GetDirectoryInfo(currentDirectoryPath).Parent.FullName;
+                var currentDirectoryInfo = _directoryManager.GetDirectoryInfo(currentDirectoryPath);
+                if (currentDirectoryInfo.Parent == null)
+                {
+                    break;
+                }
+                currentDirectoryPath = currentDirectoryInfo.Parent.FullName;
             }
             return possibleRootDirectoryPath;
         }

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -62,7 +62,7 @@ namespace AWS.Deploy.Orchestration
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;
 
-            var result = await _commandLineWrapper.TryRunWithResult(dockerBuildCommand, dockerExecutionDirectory, redirectIO: false);
+            var result = await _commandLineWrapper.TryRunWithResult(dockerBuildCommand, dockerExecutionDirectory, streamOutputToInteractiveService: true);
             if (result.ExitCode != 0)
             {
                 throw new DockerBuildFailedException(result.StandardError ?? "");
@@ -117,7 +117,7 @@ namespace AWS.Deploy.Orchestration
                 publishCommand += " --self-contained true";
             }
 
-            var result = await _commandLineWrapper.TryRunWithResult(publishCommand, redirectIO: false);
+            var result = await _commandLineWrapper.TryRunWithResult(publishCommand, streamOutputToInteractiveService: true);
             if (result.ExitCode != 0)
             {
                 throw new DotnetPublishFailedException(result.StandardError ?? "");
@@ -202,7 +202,7 @@ namespace AWS.Deploy.Orchestration
             var decodedTokens = authToken.Split(':');
 
             var dockerLoginCommand = $"docker login --username {decodedTokens[0]} --password {decodedTokens[1]} {authorizationTokens[0].ProxyEndpoint}";
-            var result = await _commandLineWrapper.TryRunWithResult(dockerLoginCommand);
+            var result = await _commandLineWrapper.TryRunWithResult(dockerLoginCommand, streamOutputToInteractiveService: true);
 
             if (result.ExitCode != 0)
                 throw new DockerLoginFailedException("Failed to login to Docker");
@@ -225,7 +225,7 @@ namespace AWS.Deploy.Orchestration
         private async Task TagDockerImage(string sourceTagName, string targetTagName)
         {
             var dockerTagCommand = $"docker tag {sourceTagName} {targetTagName}";
-            var result = await _commandLineWrapper.TryRunWithResult(dockerTagCommand);
+            var result = await _commandLineWrapper.TryRunWithResult(dockerTagCommand, streamOutputToInteractiveService: true);
 
             if (result.ExitCode != 0)
                 throw new DockerTagFailedException("Failed to tag Docker image");
@@ -234,7 +234,7 @@ namespace AWS.Deploy.Orchestration
         private async Task PushDockerImage(string targetTagName)
         {
             var dockerPushCommand = $"docker push {targetTagName}";
-            var result = await _commandLineWrapper.TryRunWithResult(dockerPushCommand, redirectIO: false);
+            var result = await _commandLineWrapper.TryRunWithResult(dockerPushCommand, streamOutputToInteractiveService: true);
 
             if (result.ExitCode != 0)
                 throw new DockerPushFailedException("Failed to push Docker Image");

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -171,7 +171,7 @@ namespace AWS.Deploy.Orchestration
                     }
                     finally
                     {
-                        _cdkProjectHandler.DeleteTemporaryCdkProject(cdkProject);
+                        _cdkProjectHandler.DeleteTemporaryCdkProject(_session, cdkProject);
                     }
                     break;
                 default:
@@ -235,16 +235,18 @@ namespace AWS.Deploy.Orchestration
             {
                 await _deploymentBundleHandler.CreateDotnetPublishZip(recommendation);
             }
-            catch (DotnetPublishFailedException ex)
+            catch (DotnetPublishFailedException exception)
             {
                 _interactiveService.LogErrorMessageLine("We were unable to package the application using 'dotnet publish' due to the following error:");
-                _interactiveService.LogErrorMessageLine(ex.Message);
+                _interactiveService.LogErrorMessageLine(exception.Message);
+                _interactiveService.LogDebugLine(exception.PrettyPrint());
                 return false;
             }
-            catch (FailedToCreateZipFileException)
+            catch (FailedToCreateZipFileException exception)
             {
                 _interactiveService.LogErrorMessageLine("We were unable to create a zip archive of the packaged application.");
                 _interactiveService.LogErrorMessageLine("Normally this indicates a problem running the \"zip\" utility. Make sure that application is installed and available in your PATH.");
+                _interactiveService.LogDebugLine(exception.PrettyPrint());
                 return false;
             }
 

--- a/src/AWS.Deploy.Orchestration/SystemCapabilities.cs
+++ b/src/AWS.Deploy.Orchestration/SystemCapabilities.cs
@@ -1,15 +1,17 @@
+using System;
+
 namespace AWS.Deploy.Orchestration
 {
     public class SystemCapabilities
     {
-        public bool NodeJsMinVersionInstalled { get; set; }
+        public Version? NodeJsVersion { get; set; }
         public DockerInfo DockerInfo { get; set; }
 
         public SystemCapabilities(
-            bool nodeJsMinVersionInstalled,
+            Version? nodeJsVersion,
             DockerInfo dockerInfo)
         {
-            NodeJsMinVersionInstalled = nodeJsMinVersionInstalled;
+            NodeJsVersion = nodeJsVersion;
             DockerInfo = dockerInfo;
         }
     }

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -124,16 +124,18 @@ namespace AWS.Deploy.Orchestration.Utilities
                 catch (FailedToUpdateLocalUserSettingsFileException ex)
                 {
                     _orchestratorInteractiveService.LogErrorMessageLine(ex.Message);
+                    _orchestratorInteractiveService.LogDebugLine(ex.PrettyPrint());
                 }
                 catch (InvalidLocalUserSettingsFileException ex)
                 {
                     _orchestratorInteractiveService.LogErrorMessageLine(ex.Message);
+                    _orchestratorInteractiveService.LogDebugLine(ex.PrettyPrint());
                 }
             }
 
             return compatibleApplications
                 .OrderByDescending(x => x.LastUpdatedTime)
-                .ToList(); ;
+                .ToList();
         }
     }
 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/DeploymentManifestFile/DeploymentManifestFileTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/DeploymentManifestFile/DeploymentManifestFileTests.cs
@@ -105,7 +105,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.DeploymentManifestFile
 
             // Assert
             Assert.True(_fileManager.Exists(deploymentManifestFilePath));
-            recipeDefinitionPaths.Count.ShouldEqual(3);
+            recipeDefinitionPaths.Count.ShouldEqual(3, $"Custom recipes found: {Environment.NewLine} {string.Join(Environment.NewLine, recipeDefinitionPaths)}");
             recipeDefinitionPaths.ShouldContain(saveCdkDirectoryFullPath);
             recipeDefinitionPaths.ShouldContain(saveCdkDirectoryFullPath2);
             recipeDefinitionPaths.ShouldContain(saveCdkDirectoryFullPath3);

--- a/test/AWS.Deploy.CLI.IntegrationTests/Extensions/ReadAllLinesStreamReaderExtension.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Extensions/ReadAllLinesStreamReaderExtension.cs
@@ -15,7 +15,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Extensions
         /// </summary>
         /// <param name="reader">Reader that allows line by line reading</param>
         /// <returns>Read lines</returns>
-        public static IEnumerable<string> ReadAllLines(this StreamReader reader)
+        public static IList<string> ReadAllLines(this StreamReader reader)
         {
             var lines = new List<string>();
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Extensions/TestServiceCollectionExtension.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Extensions/TestServiceCollectionExtension.cs
@@ -26,6 +26,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Extensions
         {
             serviceCollection.AddSingleton<InMemoryInteractiveService>();
             serviceCollection.AddSingleton<IToolInteractiveService>(serviceProvider => serviceProvider.GetService<InMemoryInteractiveService>());
+            serviceCollection.AddSingleton<IOrchestratorInteractiveService>(serviceProvider => serviceProvider.GetService<InMemoryInteractiveService>());
         }
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudFormationHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudFormationHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
+using AWS.Deploy.Common;
 using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Helpers

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/HttpHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/HttpHelper.cs
@@ -4,12 +4,21 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using AWS.Deploy.Common;
 using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Helpers
 {
     public class HttpHelper
     {
+        private readonly InMemoryInteractiveService _interactiveService;
+
+        public HttpHelper(InMemoryInteractiveService interactiveService)
+        {
+            _interactiveService = interactiveService;
+        }
+
         public async Task WaitUntilSuccessStatusCode(string url, TimeSpan frequency, TimeSpan timeout)
         {
             using var client = new HttpClient();
@@ -22,8 +31,9 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
                     return httpResponseMessage.IsSuccessStatusCode;
                 }, frequency, timeout);
             }
-            catch (TimeoutException)
+            catch (TimeoutException ex)
             {
+                _interactiveService.WriteErrorLine(ex.PrettyPrint());
                 Assert.True(false, $"{url} URL is not reachable.");
             }
         }

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/CustomRecipeLocatorTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/CustomRecipeLocatorTests.cs
@@ -44,7 +44,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 
             // ASSERT
             File.Exists(Path.Combine(webAppWithDockerFilePath, "aws-deployments.json")).ShouldBeTrue();
-            customRecipePaths.Count.ShouldEqual(2);
+            customRecipePaths.Count.ShouldEqual(2, $"Custom recipes found: {Environment.NewLine} {string.Join(Environment.NewLine, customRecipePaths)}");
             customRecipePaths.ShouldContain(Path.Combine(tempDirectoryPath, "MyCdkApp1"));
             customRecipePaths.ShouldContain(Path.Combine(tempDirectoryPath, "MyCdkApp1"));
         }
@@ -70,7 +70,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 
             // ASSERT
             File.Exists(Path.Combine(webAppNoDockerFilePath, "aws-deployments.json")).ShouldBeFalse();
-            customRecipePaths.Count.ShouldEqual(2);
+            customRecipePaths.Count.ShouldEqual(2, $"Custom recipes found: {Environment.NewLine} {string.Join(Environment.NewLine, customRecipePaths)}");
             customRecipePaths.ShouldContain(Path.Combine(tempDirectoryPath, "MyCdkApp1"));
             customRecipePaths.ShouldContain(Path.Combine(tempDirectoryPath, "MyCdkApp1"));
         }

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/CustomRecipeLocatorTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/CustomRecipeLocatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
 using AWS.Deploy.CLI.Utilities;
 using AWS.Deploy.Common.DeploymentManifest;
@@ -10,17 +11,19 @@ using Xunit;
 using Task = System.Threading.Tasks.Task;
 using Should;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.IntegrationTests.Services;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 {
-    public class CustomRecipeLocatorTests
+    public class CustomRecipeLocatorTests : IDisposable
     {
         private readonly CommandLineWrapper _commandLineWrapper;
+        private readonly InMemoryInteractiveService _inMemoryInteractiveService;
 
         public CustomRecipeLocatorTests()
         {
-            _commandLineWrapper = new CommandLineWrapper(new ConsoleOrchestratorLogger(new ConsoleInteractiveServiceImpl()));
-        }
+            _inMemoryInteractiveService = new InMemoryInteractiveService();
+            _commandLineWrapper = new CommandLineWrapper(_inMemoryInteractiveService);        }
 
         [Fact]
         public async Task LocateCustomRecipePathsWithManifestFile()
@@ -77,10 +80,24 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var directoryManager = new DirectoryManager();
             var fileManager = new FileManager();
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
-            var consoleInteractiveServiceImpl = new ConsoleInteractiveServiceImpl();
-            var consoleOrchestratorLogger = new ConsoleOrchestratorLogger(consoleInteractiveServiceImpl);
-            var commandLineWrapper = new CommandLineWrapper(consoleOrchestratorLogger);
-            return new CustomRecipeLocator(deploymentManifestEngine, consoleOrchestratorLogger, commandLineWrapper, directoryManager);
+            var commandLineWrapper = new CommandLineWrapper(_inMemoryInteractiveService);
+            return new CustomRecipeLocator(deploymentManifestEngine, _inMemoryInteractiveService, commandLineWrapper, directoryManager);
         }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inMemoryInteractiveService.ReadStdOutStartToEnd();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~CustomRecipeLocatorTests() => Dispose(false);
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -204,7 +204,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var fileManager = new FileManager();
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var localUserSettingsEngine = new LocalUserSettingsEngine(fileManager, directoryManager);
-            var consoleInteractiveServiceImpl = new ConsoleInteractiveServiceImpl();
             var commandLineWrapper = new CommandLineWrapper(_inMemoryInteractiveService);
             var customRecipeLocator = new CustomRecipeLocator(deploymentManifestEngine, _inMemoryInteractiveService, commandLineWrapper, directoryManager);
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/SaveCdkDeploymentProjectTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/SaveCdkDeploymentProjectTests.cs
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
 using System.Linq;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.CLI.Utilities;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
@@ -12,13 +14,15 @@ using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 {
-    public class SaveCdkDeploymentProjectTests 
+    public class SaveCdkDeploymentProjectTests : IDisposable
     {
         private readonly CommandLineWrapper _commandLineWrapper;
+        private readonly InMemoryInteractiveService _inMemoryInteractiveService;
 
         public SaveCdkDeploymentProjectTests()
         {
-            _commandLineWrapper = new CommandLineWrapper(new ConsoleOrchestratorLogger(new ConsoleInteractiveServiceImpl()));
+            _inMemoryInteractiveService = new InMemoryInteractiveService();
+            _commandLineWrapper = new CommandLineWrapper(_inMemoryInteractiveService);
         }
 
         [Fact]
@@ -71,5 +75,21 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var saveDirectoryPath = Path.Combine(tempDirectoryPath, "MyCdkApp");
             await Utilities.CreateCDKDeploymentProject(targetApplicationProjectPath, saveDirectoryPath, false);
         }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inMemoryInteractiveService.ReadStdOutStartToEnd();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~SaveCdkDeploymentProjectTests() => Dispose(false);
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Services/InMemoryInteractiveServiceTests.cs
@@ -54,17 +54,17 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             service.WriteErrorLine("Error Line 2");
             service.WriteErrorLine("Error Line 3");
 
-            Assert.Equal("Error Line 1", service.StdErrorReader.ReadLine());
-            Assert.Equal("Error Line 2", service.StdErrorReader.ReadLine());
-            Assert.Equal("Error Line 3", service.StdErrorReader.ReadLine());
+            Assert.Equal("Error Line 1", service.StdOutReader.ReadLine());
+            Assert.Equal("Error Line 2", service.StdOutReader.ReadLine());
+            Assert.Equal("Error Line 3", service.StdOutReader.ReadLine());
 
             service.WriteErrorLine("Error Line 4");
             service.WriteErrorLine("Error Line 5");
             service.WriteErrorLine("Error Line 6");
 
-            Assert.Equal("Error Line 4", service.StdErrorReader.ReadLine());
-            Assert.Equal("Error Line 5", service.StdErrorReader.ReadLine());
-            Assert.Equal("Error Line 6", service.StdErrorReader.ReadLine());
+            Assert.Equal("Error Line 4", service.StdOutReader.ReadLine());
+            Assert.Equal("Error Line 5", service.StdOutReader.ReadLine());
+            Assert.Equal("Error Line 6", service.StdOutReader.ReadLine());
         }
 
         [Fact]
@@ -76,17 +76,17 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             service.WriteDebugLine("Debug Line 2");
             service.WriteDebugLine("Debug Line 3");
 
-            Assert.Equal("Debug Line 1", service.StdDebugReader.ReadLine());
-            Assert.Equal("Debug Line 2", service.StdDebugReader.ReadLine());
-            Assert.Equal("Debug Line 3", service.StdDebugReader.ReadLine());
+            Assert.Equal("Debug Line 1", service.StdOutReader.ReadLine());
+            Assert.Equal("Debug Line 2", service.StdOutReader.ReadLine());
+            Assert.Equal("Debug Line 3", service.StdOutReader.ReadLine());
 
             service.WriteDebugLine("Debug Line 4");
             service.WriteDebugLine("Debug Line 5");
             service.WriteDebugLine("Debug Line 6");
 
-            Assert.Equal("Debug Line 4", service.StdDebugReader.ReadLine());
-            Assert.Equal("Debug Line 5", service.StdDebugReader.ReadLine());
-            Assert.Equal("Debug Line 6", service.StdDebugReader.ReadLine());
+            Assert.Equal("Debug Line 4", service.StdOutReader.ReadLine());
+            Assert.Equal("Debug Line 5", service.StdOutReader.ReadLine());
+            Assert.Equal("Debug Line 6", service.StdOutReader.ReadLine());
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -29,11 +29,6 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
         public WebAppNoDockerFileTests()
         {
-            _httpHelper = new HttpHelper();
-
-            var cloudFormationClient = new AmazonCloudFormationClient();
-            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
-
             var serviceCollection = new ServiceCollection();
 
             serviceCollection.AddCustomServices();
@@ -46,6 +41,11 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
             _interactiveService = serviceProvider.GetService<InMemoryInteractiveService>();
             Assert.NotNull(_interactiveService);
+
+            _httpHelper = new HttpHelper(_interactiveService);
+
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
 
             _testAppManager = new TestAppManager();
         }
@@ -63,21 +63,16 @@ namespace AWS.Deploy.CLI.IntegrationTests
             // Deploy
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
             var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
-            await _app.Run(deployArgs);
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
             Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
 
-            var deployStdDebug = _interactiveService.StdDebugReader.ReadAllLines();
-
-            var tempCdkProject = deployStdDebug.FirstOrDefault(line => line.Trim().Contains("The CDK Project is saved at: "))?
-                .Split(": ")[1]
-                .Trim();
-
-            Assert.NotNull(tempCdkProject);
-            Assert.False(Directory.Exists(tempCdkProject));
-
             var deployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+
+            var tempCdkProjectLine = deployStdOut.First(line => line.StartsWith("The CDK Project is saved at:"));
+            var tempCdkProject = tempCdkProjectLine.Split(":")[1].Trim();
+            Assert.False(Directory.Exists(tempCdkProject), $"{tempCdkProject} must not exist.");
 
             // Example:     Endpoint: http://52.36.216.238/
             var applicationUrl = deployStdOut.First(line => line.Trim().StartsWith($"Endpoint"))
@@ -88,20 +83,20 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _httpHelper.WaitUntilSuccessStatusCode(applicationUrl, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
 
             // list
-            var listArgs = new[] { "list-deployments" };
-            await _app.Run(listArgs);
+            var listArgs = new[] { "list-deployments", "--diagnostics" };
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
-            Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
+            var listStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            Assert.Contains(listStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete
             await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
             await _interactiveService.StdInWriter.FlushAsync();
-            var deleteArgs = new[] { "delete-deployment", _stackName };
+            var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics" };
 
             // Delete
-            await _app.Run(deleteArgs);
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deleteArgs));;
 
             // Verify application is deleted
             Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
@@ -124,6 +119,8 @@ namespace AWS.Deploy.CLI.IntegrationTests
                 {
                     _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
                 }
+
+                _interactiveService.ReadStdOutStartToEnd();
             }
 
             _isDisposed = true;

--- a/test/AWS.Deploy.CLI.UnitTests/ServerModeAuthTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ServerModeAuthTests.cs
@@ -255,8 +255,6 @@ namespace AWS.Deploy.CLI.UnitTests
             await interactiveService.StdInWriter.FlushAsync();
 
             var serverCommand = new ServerModeCommand(interactiveService, portNumber, null, false);
-
-
             var cancelSource = new CancellationTokenSource();
             Exception actualException = null;
             try


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. **Serialization of parallel integration tests ouput**
Integration tests run in parallel which emits logs in a non-deterministic order, this creates log reading painful and hard to debug. This change combines all types of logs to one stream and puts on the Console at the end of test class disposal.
2. All test commands now use diagnostics flag and assert on the return value [Run method](https://github.com/aws/aws-dotnet-deploy/blob/main/src/AWS.Deploy.CLI/App.cs#L25)
3. Fix various test failures
4. Log exceptions that are caught be never rethrown

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
