### PR TITLE
test: make sure only one thread at a time allowed to perform cdk inst…

### DIFF
--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
@@ -25,6 +26,7 @@ namespace AWS.Deploy.Orchestration
     /// </summary>
     public class Orchestrator
     {
+        private static readonly SemaphoreSlim s_cdkManagerSemaphoreSlim = new(1,1);
         private const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
 
         private readonly ICdkProjectHandler? _cdkProjectHandler;
@@ -163,7 +165,17 @@ namespace AWS.Deploy.Orchestration
 
                     var projFiles = _directoryManager.GetProjFiles(cdkProject);
                     var cdkVersion = _cdkVersionDetector.Detect(projFiles);
-                    await _cdkManager.EnsureCompatibleCDKExists(Constants.CDK.DeployToolWorkspaceDirectoryRoot, cdkVersion);
+
+                    await s_cdkManagerSemaphoreSlim.WaitAsync();
+
+                    try
+                    {
+                        await _cdkManager.EnsureCompatibleCDKExists(Constants.CDK.DeployToolWorkspaceDirectoryRoot, cdkVersion);
+                    }
+                    finally
+                    {
+                        s_cdkManagerSemaphoreSlim.Release();
+                    }
 
                     try
                     {


### PR DESCRIPTION
*Issue #, if available:*
A thread is installing the CDK, while another is trying to use CDK CLI while has not finished installation. In this race condition, multiple threads can lead to using broken CDK CLI.

*Description of changes:*
Use SemaphoreSlim to lock async code and made sure that only one thread allowed to perform check at a time.

Removed installing cdk cli from CI CodeBuild job. This makes sure that the release pipeline and CI job has the same operating conditions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
