### PR TITLE
fix: install nodejs in publish image to support SPA app publish

### DIFF
--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
@@ -12,6 +12,10 @@ WORKDIR "/src/{project-folder}"
 RUN dotnet build "{project-name}" -c Release -o /app/build
 
 FROM build AS publish
+RUN apt-get update -yq \
+    && apt-get install curl gnupg -yq \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash \
+    && apt-get install nodejs -yq
 RUN dotnet publish "{project-name}" -c Release -o /app/publish
 
 FROM base AS final


### PR DESCRIPTION
*Issue #, if available:*
#165 

*Description of changes:*
final image doesn't have any nodejs dependencies, this change is only for publish image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
