### PR TITLE
ci: remove on push trigger for checks

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -1,10 +1,6 @@
 name: AWS CodeBuild CI
 
 on:
-  push:
-    branches:
-      - main
-      - dev
   pull_request:
     branches:
       - main


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current setup runs multiple runs checks on release PR. This will only allows one check per release PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
