### PR TITLE
fix: Perform certificate verification on AWS.Deploy.CLI.dll in Server-Mode

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/CertificateVerificationEngine.cs
+++ b/src/AWS.Deploy.ServerMode.Client/CertificateVerificationEngine.cs
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace AWS.Deploy.ServerMode.Client
+{
+    public class CertificateVerificationEngine
+    {
+        private const string DEFAULT_DEPLOY_TOOL_ROOT = "dotnet aws";
+        private const string CERTIFICATE_SUBJECT_NAME = "Amazon Web Services, Inc.";
+        private const string CERTIFICATE_ISSUER_NAME = "DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1";
+
+        public virtual void VerifyCertificate(string deployToolRoot)
+        {
+            var deployToolDllPath = GetDeployToolDllPath(deployToolRoot);
+            var cert = new X509Certificate2(X509Certificate.CreateFromSignedFile(deployToolDllPath));
+            var chain = new X509Chain();
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+
+            // verifies that no certificate in the certificate chain is expired or revoked.
+            if (!chain.Build(cert))
+            {
+                throw new InvalidOperationException("The security certificate associated with AWS.Deploy.CLI.dll is either expired or revoked");
+            }
+            if (!string.Equals(cert.GetNameInfo(X509NameType.SimpleName, false), CERTIFICATE_SUBJECT_NAME, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"The security certificate associated with AWS.Deploy.CLI.dll is not authotized by {CERTIFICATE_SUBJECT_NAME}");
+            }
+            if (!string.Equals(cert.GetNameInfo(X509NameType.SimpleName, true), CERTIFICATE_ISSUER_NAME, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"The security certificate associated with AWS.Deploy.CLI.dll is not issued by {CERTIFICATE_ISSUER_NAME}");
+            }
+        }
+
+        private string GetDeployToolDllPath(string deployToolRoot)
+        {
+            var deployToolRootPath = string.Empty;
+            if (string.Equals(deployToolRoot, DEFAULT_DEPLOY_TOOL_ROOT, StringComparison.Ordinal))
+            {
+                foreach (var path in Environment.GetEnvironmentVariable("PATH").Split(';'))
+                {
+                    if (path.Contains(".dotnet" + Path.DirectorySeparatorChar + "tools"))
+                    {
+                        deployToolRootPath = Path.Combine(path, ".store", "aws.deploy.cli");
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                deployToolRootPath = new DirectoryInfo(deployToolRoot).Parent.FullName;
+            }
+
+            if (string.IsNullOrEmpty(deployToolRootPath) || !Directory.Exists(deployToolRootPath))
+            {
+                throw new FailedToFindDeployToolPathException("Could not find path to AWS.Deploy.CLI.dll");
+            }
+
+            var deployToolDllPath = Directory.GetFiles(deployToolRootPath, "AWS.Deploy.CLI.dll", SearchOption.AllDirectories).FirstOrDefault();
+            if (string.IsNullOrEmpty(deployToolDllPath))
+            {
+                throw new FailedToFindDeployToolPathException("Could not find path to AWS.Deploy.CLI.dll");
+            }
+            return deployToolDllPath;
+        }
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/Exceptions.cs
+++ b/src/AWS.Deploy.ServerMode.Client/Exceptions.cs
@@ -34,4 +34,14 @@ namespace AWS.Deploy.ServerMode.Client
         {
         }
     }
+
+    /// <summary>
+    /// Thrown if failed to find the path to AWS.Deploy.CLI.dll
+    /// </summary>
+    public class FailedToFindDeployToolPathException : Exception
+    {
+        public FailedToFindDeployToolPathException(string message, Exception? innerException = null) : base(message, innerException)
+        {
+        }
+    }
 }

--- a/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
@@ -69,6 +69,7 @@ namespace AWS.Deploy.ServerMode.Client
         private readonly HttpClientHandler _httpClientHandler;
         private readonly TimeSpan _serverTimeout;
         private readonly string _deployToolPath;
+        private readonly CertificateVerificationEngine _certificateVerificationEngine;
 
         private string? _baseUrl;
         private Aes? _aes;
@@ -89,6 +90,7 @@ namespace AWS.Deploy.ServerMode.Client
         public ServerModeSession(int startPort = 10000, int endPort = 10100, string deployToolPath = "", bool diagnosticLoggingEnabled = false)
             : this(new CommandLineWrapper(diagnosticLoggingEnabled),
                 new HttpClientHandler(),
+                new CertificateVerificationEngine(),
                 TimeSpan.FromSeconds(60),
                 startPort,
                 endPort,
@@ -98,6 +100,7 @@ namespace AWS.Deploy.ServerMode.Client
 
         public ServerModeSession(CommandLineWrapper commandLineWrapper,
             HttpClientHandler httpClientHandler,
+            CertificateVerificationEngine certificateVerificationEngine,
             TimeSpan serverTimeout,
             int startPort = 10000,
             int endPort = 10100,
@@ -107,6 +110,7 @@ namespace AWS.Deploy.ServerMode.Client
             _endPort = endPort;
             _commandLineWrapper = commandLineWrapper;
             _httpClientHandler = httpClientHandler;
+            _certificateVerificationEngine = certificateVerificationEngine;
             _serverTimeout = serverTimeout;
             _deployToolPath = deployToolPath;
         }
@@ -121,6 +125,8 @@ namespace AWS.Deploy.ServerMode.Client
 
                 deployToolRoot = _deployToolPath;
             }
+
+            _certificateVerificationEngine.VerifyCertificate(deployToolRoot);
 
             var currentProcessId = Process.GetCurrentProcess().Id;
 

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/ServerModeSessionTests.cs
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/ServerModeSessionTests.cs
@@ -15,12 +15,14 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         private readonly ServerModeSession _serverModeSession;
         private readonly Mock<HttpClientHandler> _httpClientHandlerMock;
         private readonly Mock<CommandLineWrapper> _commandLineWrapper;
+        private readonly Mock<CertificateVerificationEngine> _certificateVerificationEngineMock;
 
         public ServerModeSessionTests()
         {
             _httpClientHandlerMock = new Mock<HttpClientHandler>();
             _commandLineWrapper = new Mock<CommandLineWrapper>(false);
-            _serverModeSession = new ServerModeSession(_commandLineWrapper.Object, _httpClientHandlerMock.Object, TimeSpan.FromSeconds(5));
+            _certificateVerificationEngineMock = new Mock<CertificateVerificationEngine>();
+            _serverModeSession = new ServerModeSession(_commandLineWrapper.Object, _httpClientHandlerMock.Object, _certificateVerificationEngineMock.Object, TimeSpan.FromSeconds(5));
         }
 
         [Fact]
@@ -29,6 +31,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
+            MockVerifyCertificate();
 
             // Act
             var exception = await Record.ExceptionAsync(async () =>
@@ -46,6 +49,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(-100);
             MockHttpGet(HttpStatusCode.NotFound, TimeSpan.FromSeconds(5));
+            MockVerifyCertificate();
 
             // Act & Assert
             await Assert.ThrowsAsync<PortUnavailableException>(async () =>
@@ -60,6 +64,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGetThrows();
+            MockVerifyCertificate();
 
             // Act & Assert
             await Assert.ThrowsAsync<InternalServerModeException>(async () =>
@@ -74,6 +79,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.Forbidden);
+            MockVerifyCertificate();
 
             // Act & Assert
             await Assert.ThrowsAsync<InternalServerModeException>(async () =>
@@ -98,6 +104,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
+            MockVerifyCertificate();
             await _serverModeSession.Start(CancellationToken.None);
 
             MockHttpGetThrows();
@@ -115,6 +122,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
+            MockVerifyCertificate();
             await _serverModeSession.Start(CancellationToken.None);
 
             // Act
@@ -130,6 +138,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
+            MockVerifyCertificate();
             await _serverModeSession.Start(CancellationToken.None);
 
             MockHttpGet(HttpStatusCode.Forbidden);
@@ -147,6 +156,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
+            MockVerifyCertificate();
             await _serverModeSession.Start(CancellationToken.None);
 
             // Act
@@ -178,6 +188,7 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             // Arrange
             MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
+            MockVerifyCertificate();
             await _serverModeSession.Start(CancellationToken.None);
 
             // Act
@@ -237,6 +248,10 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
             _commandLineWrapper
                 .Setup(wrapper => wrapper.Run(It.IsAny<string>(), It.IsAny<string[]>()))
                 .ReturnsAsync(statusCode, delay);
+
+        private void MockVerifyCertificate() =>
+            _certificateVerificationEngineMock
+            .Setup(engine => engine.VerifyCertificate(It.IsAny<string>()));
 
         private Task<AWSCredentials> CredentialGenerator() => throw new NotImplementedException();
     }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5276

*Description of changes:*
This PR adds certificate verification on `AWS.Deploy.CLI.dll` before starting a `ServerModeSession`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
