### PR TITLE
fix: publish continues after a Docker failure

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
@@ -34,7 +34,9 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
         {
             if (_selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.Container)
             {
-                await _orchestrator.CreateContainerDeploymentBundle(_cloudApplication, _selectedRecommendation);
+                var dockerBuildDeploymentBundleResult = await _orchestrator.CreateContainerDeploymentBundle(_cloudApplication, _selectedRecommendation);
+                if (!dockerBuildDeploymentBundleResult)
+                    throw new FailedToCreateDeploymentBundleException("Failed to create a deployment bundle");
             }
             else if (_selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.DotnetPublishZipFile)
             {


### PR DESCRIPTION
*Issue #, if available:*
IDE-6042

*Description of changes:*
Docker build failure does not fail the deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
