### PR TITLE
feat: Add more metadata to the ServerMode APIs

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -135,9 +135,11 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             foreach (var recommendation in state.NewRecommendations)
             {
                 output.Recommendations.Add(new RecommendationSummary(
-                    recommendation.Recipe.Id,
-                    recommendation.Name,
-                    recommendation.ShortDescription
+                    recipeId: recommendation.Recipe.Id,
+                    name: recommendation.Name,
+                    shortDescription: recommendation.ShortDescription,
+                    description: recommendation.Description,
+                    targetService: recommendation.Recipe.TargetService
                     ));
             }
 
@@ -270,11 +272,17 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             foreach(var deployment in state.ExistingDeployments)
             {
+                var recommendation = state.NewRecommendations.First(x => string.Equals(x.Recipe.Id, deployment.RecipeId));
+
                 output.ExistingDeployments.Add(new ExistingDeploymentSummary(
-                    deployment.Name,
-                    deployment.RecipeId,
-                    deployment.LastUpdatedTime,
-                    deployment.UpdatedByCurrentUser));
+                    name: deployment.Name,
+                    recipeId: deployment.RecipeId,
+                    recipeName: recommendation.Name,
+                    shortDescription: recommendation.ShortDescription,
+                    description: recommendation.Description,
+                    targetService: recommendation.Recipe.TargetService,
+                    lastUpdatedTime: deployment.LastUpdatedTime,
+                    updatedByCurrentUser: deployment.UpdatedByCurrentUser));
             }
 
             return Ok(output);

--- a/src/AWS.Deploy.CLI/ServerMode/Models/ExistingDeploymentSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/ExistingDeploymentSummary.cs
@@ -14,6 +14,14 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public string RecipeId { get; set; }
 
+        public string RecipeName { get; set; }
+
+        public string ShortDescription { get; set; }
+
+        public string Description { get; set; }
+
+        public string TargetService { get; set; }
+
         public DateTime? LastUpdatedTime { get; set; }
 
         public bool UpdatedByCurrentUser { get; set; }
@@ -21,12 +29,20 @@ namespace AWS.Deploy.CLI.ServerMode.Models
         public ExistingDeploymentSummary(
             string name,
             string recipeId,
+            string recipeName,
+            string shortDescription,
+            string description,
+            string targetService,
             DateTime? lastUpdatedTime,
             bool updatedByCurrentUser
         )
         {
             Name = name;
             RecipeId = recipeId;
+            RecipeName = recipeName;
+            ShortDescription = shortDescription;
+            Description = description;
+            TargetService = targetService;
             LastUpdatedTime = lastUpdatedTime;
             UpdatedByCurrentUser = updatedByCurrentUser;
         }

--- a/src/AWS.Deploy.CLI/ServerMode/Models/RecommendationSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/RecommendationSummary.cs
@@ -11,17 +11,23 @@ namespace AWS.Deploy.CLI.ServerMode.Models
     {
         public string RecipeId { get; set; }
         public string Name { get; set; }
+        public string ShortDescription { get; set; }
         public string Description { get; set; }
+        public string TargetService { get; set; }
 
         public RecommendationSummary(
             string recipeId,
             string name,
-            string description
+            string shortDescription,
+            string description,
+            string targetService
         )
         {
             RecipeId = recipeId;
             Name = name;
+            ShortDescription = shortDescription;
             Description = description;
+            TargetService = targetService;
         }
     }
 }

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1415,6 +1415,18 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("recipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RecipeId { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("recipeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string RecipeName { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("shortDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ShortDescription { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("targetService", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string TargetService { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("lastUpdatedTime", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.DateTimeOffset? LastUpdatedTime { get; set; }
     
@@ -1575,8 +1587,14 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("shortDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ShortDescription { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Description { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("targetService", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string TargetService { get; set; }
     
     
     }


### PR DESCRIPTION
*Description of changes:*
Currently VS is making `GetRecipe` API calls for each item returned in the `GetRecommendations` and `GetExistingDeployments` APIs. This PR adds the missing metadata VS needs from GetRecipe to the list operations so everything can be retrieved in one API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
