### PR TITLE
fix: Fix incorrectly checking if parent pid has been passed into ServerMode

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
@@ -54,7 +54,7 @@ namespace AWS.Deploy.CLI.Commands
 
             var host = builder.Build();
 
-            if (_parentPid.HasValue && _parentPid.Value != 0)
+            if (_parentPid.GetValueOrDefault() == 0)
             {
                 await host.RunAsync(cancellationToken);
             }


### PR DESCRIPTION
*Description of changes:*
IDE team found that ServerMode was not shutting down after Visual Studio exited. That was because we were incorrectly checking if the nullable `int?` has a value when deciding if we should track a parent pid for shutdown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
