### PR TITLE
fix: Remove Swagger UI from ServerMode

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.3.12" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.35" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.CLI/ServerMode/Startup.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Startup.cs
@@ -82,10 +82,6 @@ namespace AWS.Deploy.CLI.ServerMode
             }
 
             app.UseSwagger();
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "AWS .NET Deploy Tool Server Mode API");
-            });
 
             app.UseRouting();
 


### PR DESCRIPTION
*Description of changes:*
Remove the unused swagger UI that was configured in server mode. This reduces the NuGet package that VS has to download from 6.7 megs to 5.6 megs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
