### PR TITLE
fix: Fixed issue where existing applications deployed from a deployment project can't be redeployed to.

### DIFF
--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -150,9 +150,11 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// </summary>
         public bool IsCompatible(CloudApplication application, Recommendation recommendation)
         {
+            // For persisted projects check both the recipe id and the base recipe id for compatibility. The base recipe id check is for stacks that
+            // were first created by a system recipe and then later moved to a persisted deployment project.
             if (recommendation.Recipe.PersistedDeploymentProject)
             {
-                return string.Equals(recommendation.Recipe.BaseRecipeId, application.RecipeId, StringComparison.Ordinal);
+                return string.Equals(recommendation.Recipe.Id, application.RecipeId, StringComparison.Ordinal) || string.Equals(recommendation.Recipe.BaseRecipeId, application.RecipeId, StringComparison.Ordinal);
             }
             return string.Equals(recommendation.Recipe.Id, application.RecipeId, StringComparison.Ordinal);
         }

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
@@ -10,6 +10,7 @@ using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Orchestration.Utilities;
@@ -64,30 +65,116 @@ namespace AWS.Deploy.Orchestration.UnitTests
         }
 
         [Fact]
-        public async Task GetExistingDeployedApplications_DeployCall()
+        public async Task GetExistingDeployedApplications_CompatibleSystemRecipes()
         {
-            var stack = new Stack
-            {
-                Tags = new List<Tag>() { new Tag {
-                    Key = Constants.CloudFormationIdentifier.STACK_TAG,
-                    Value = "AspNetAppEcsFargate"
-                } },
-                Description = Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX,
-                StackStatus = StackStatus.CREATE_COMPLETE,
-                StackName = "Stack1"
+            var stacks = new List<Stack> {
+                new Stack{
+                    Tags = new List<Tag>() { new Tag {
+                        Key = Constants.CloudFormationIdentifier.STACK_TAG,
+                        Value = "AspNetAppEcsFargate"
+                    } },
+                    Description = Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX,
+                    StackStatus = StackStatus.CREATE_COMPLETE,
+                    StackName = "WebApp"
+                },
+                new Stack{
+                    Tags = new List<Tag>() { new Tag {
+                        Key = Constants.CloudFormationIdentifier.STACK_TAG,
+                        Value = "ConsoleAppEcsFargateService"
+                    } },
+                    Description = Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX,
+                    StackStatus = StackStatus.CREATE_COMPLETE,
+                    StackName = "ServiceProcessor"
+                }
             };
 
             _mockAWSResourceQueryer
                 .Setup(x => x.GetCloudFormationStacks())
-                .Returns(Task.FromResult(new List<Stack>() { stack }));
+                .Returns(Task.FromResult(stacks));
 
             var deployedApplicationQueryer = new DeployedApplicationQueryer(
                 _mockAWSResourceQueryer.Object,
                 _mockLocalUserSettingsEngine.Object,
                 _mockOrchestratorInteractiveService.Object);
 
-            var result = await deployedApplicationQueryer.GetCompatibleApplications(new List<Recommendation>());
-            Assert.Empty(result);
+            var recommendations = new List<Recommendation>
+            {
+                new Recommendation(new RecipeDefinition("AspNetAppEcsFargate", "0.2.0",  "ASP.NET Core ECS", DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "" ), null, null, 100, new Dictionary<string, string>())
+                {
+
+                }
+            };
+
+
+            var result = await deployedApplicationQueryer.GetCompatibleApplications(recommendations);
+            Assert.Single(result);
+            Assert.Equal("AspNetAppEcsFargate", result[0].RecipeId);
+        }
+
+        [Fact]
+        public async Task GetExistingDeployedApplications_WithDeploymentProjects()
+        {
+            var stacks = new List<Stack> {
+                // Existing stack from the base recipe which should be valid
+                new Stack{
+                    Tags = new List<Tag>() { new Tag {
+                        Key = Constants.CloudFormationIdentifier.STACK_TAG,
+                        Value = "AspNetAppEcsFargate"
+                    } },
+                    Description = Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX,
+                    StackStatus = StackStatus.CREATE_COMPLETE,
+                    StackName = "WebApp"
+                },
+                // Existing stack that was deployed custom deployment project. Should be valid.
+                new Stack{
+                    Tags = new List<Tag>() { new Tag {
+                        Key = Constants.CloudFormationIdentifier.STACK_TAG,
+                        Value = "AspNetAppEcsFargate-Custom"
+                    } },
+                    Description = Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX,
+                    StackStatus = StackStatus.CREATE_COMPLETE,
+                    StackName = "WebApp-Custom"
+                },
+                // Stack created from a different recipe and should not be valid.
+                new Stack{
+                    Tags = new List<Tag>() { new Tag {
+                        Key = Constants.CloudFormationIdentifier.STACK_TAG,
+                        Value = "ConsoleAppEcsFargateService"
+                    } },
+                    Description = Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX,
+                    StackStatus = StackStatus.CREATE_COMPLETE,
+                    StackName = "ServiceProcessor"
+                }
+            };
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.GetCloudFormationStacks())
+                .Returns(Task.FromResult(stacks));
+
+            var deployedApplicationQueryer = new DeployedApplicationQueryer(
+                _mockAWSResourceQueryer.Object,
+                _mockLocalUserSettingsEngine.Object,
+                _mockOrchestratorInteractiveService.Object);
+
+            var recommendations = new List<Recommendation>
+            {
+                new Recommendation(new RecipeDefinition("AspNetAppEcsFargate-Custom", "0.2.0",  "Saved Deployment Project",
+                                                            DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "" )
+                                                            {
+                                                                PersistedDeploymentProject = true,
+                                                                BaseRecipeId = "AspNetAppEcsFargate"
+                                                            },
+                                                            null, null, 100, new Dictionary<string, string>())
+                {
+
+                }
+            };
+
+
+            var result = await deployedApplicationQueryer.GetCompatibleApplications(recommendations);
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, x => string.Equals("AspNetAppEcsFargate", x.RecipeId));
+            Assert.Contains(result, x => string.Equals("AspNetAppEcsFargate-Custom", x.RecipeId));
         }
 
         [Theory]


### PR DESCRIPTION
*Description of changes:*
If a user deploys with an deployment project. When the user attempts to redeploy the existing stack is not displayed because the code is incorrectly only checking the base recipe id when it should check for both base and actual recipe id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
