### PR TITLE
feat: Update Docker template to use Node.js 14 instead of 10 which is deprecated

### DIFF
--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
@@ -14,7 +14,7 @@ RUN dotnet build "{project-name}" -c Release -o /app/build
 FROM build AS publish
 RUN apt-get update -yq \
     && apt-get install curl gnupg -yq \
-    && curl -sL https://deb.nodesource.com/setup_10.x | bash \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash \
     && apt-get install nodejs -yq
 RUN dotnet publish "{project-name}" -c Release -o /app/publish
 


### PR DESCRIPTION
*Description of changes:*
The Docker template used when containerizing applications was installing Node 10 but 10 is deprecated. This updates to the latest Node LTS which is 14.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
