### PR TITLE
feat: Update all CDK references to version 128

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -24,9 +24,9 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.121.0" />
+    <PackageReference Include="Amazon.CDK" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.128.0" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RollForward>Major</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>
     <!-- The value "AWSDeployRecipesCDKCommonVersion" is replaced by the project template system. -->
@@ -26,10 +25,10 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.107.0" />
-    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.107.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.107.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.107.0" />
+    <PackageReference Include="Amazon.CDK" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.128.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RollForward>Major</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>
     <!-- The value "AWSDeployRecipesCDKCommonVersion" is replaced by the project template system. -->
@@ -26,9 +25,9 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ElasticBeanstalk" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.121.0" />
+    <PackageReference Include="Amazon.CDK" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ElasticBeanstalk" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.128.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.61" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RollForward>Major</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>
     <!-- The value "AWSDeployRecipesCDKCommonVersion" is replaced by the project template system. -->
@@ -26,11 +25,11 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.CloudFront" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.CloudFront.Origins" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3.Deployment" Version="1.121.0" />
+    <PackageReference Include="Amazon.CDK" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.CloudFront" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.CloudFront.Origins" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.S3.Deployment" Version="1.128.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RollForward>Major</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>
     <!-- The value "AWSDeployRecipesCDKCommonVersion" is replaced by the project template system. -->
@@ -26,10 +25,10 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.121.0" />
+    <PackageReference Include="Amazon.CDK" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.128.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppECSFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppECSFargateService.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RollForward>Major</RollForward>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>
     <!-- The value "AWSDeployRecipesCDKCommonVersion" is replaced by the project template system. -->
@@ -26,10 +25,10 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.121.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.121.0" />
+    <PackageReference Include="Amazon.CDK" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.128.0" />
+    <PackageReference Include="Amazon.CDK.AWS.S3.Assets" Version="1.128.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props


### PR DESCRIPTION
*Description of changes:*
Update all CDK references to the current version of the CDK 128.

Besides getting latest features I also suspect some of the reason for integ test failures is we had a mix of CDK versions being referenced and when those tests were being run in parallel it caused CDK to complain about downgrading.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
