### PR TITLE
feat: Add DynamoDB, S3, SQS and SNS type hints

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DynamoDBTableCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DynamoDBTableCommand.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class DynamoDBTableCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public DynamoDBTableCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        private async Task<List<string>> GetData()
+        {
+            return await _awsResourceQueryer.ListOfDyanmoDBTables();
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var tables = await GetData();
+            return tables.Select(tableName => new TypeHintResource(tableName, tableName)).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            const string NO_VALUE = "*** Do not select table ***";
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var tables = await GetData();
+
+            tables.Add(NO_VALUE);
+            var userResponse = _consoleUtilities.AskUserToChoose(
+                values: tables,
+                title: "Select a DynamoDB table:",
+                defaultValue: currentValue.ToString() ?? "");
+
+            return userResponse == null || string.Equals(NO_VALUE, userResponse, StringComparison.InvariantCultureIgnoreCase) ? string.Empty : userResponse;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/S3BucketNameCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/S3BucketNameCommand.cs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+using Amazon.S3.Model;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class S3BucketNameCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public S3BucketNameCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        private async Task<List<S3Bucket>> GetData()
+        {
+            return await _awsResourceQueryer.ListOfS3Buckets();
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var buckets = await GetData();
+            return buckets.Select(bucket => new TypeHintResource(bucket.BucketName, bucket.BucketName)).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            const string NO_VALUE = "*** Do not select bucket ***";
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var buckets = (await GetData()).Select(bucket => bucket.BucketName).ToList();
+
+            buckets.Add(NO_VALUE);
+            var userResponse = _consoleUtilities.AskUserToChoose(
+                values: buckets,
+                title: "Select a S3 bucket:",
+                defaultValue: currentValue.ToString() ?? "");
+
+            return userResponse == null || string.Equals(NO_VALUE, userResponse, StringComparison.InvariantCultureIgnoreCase) ? string.Empty : userResponse;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.Data;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class SNSTopicArnsCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public SNSTopicArnsCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var topicArns = await _awsResourceQueryer.ListOfSNSTopicArns();
+            return topicArns.Select(topicArn => new TypeHintResource(topicArn, topicArn.Substring(topicArn.LastIndexOf(':') + 1))).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            const string NO_VALUE = "*** Do not select topic ***";
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var currentValueStr = currentValue.ToString() ?? string.Empty;
+            var topicArns = await GetResources(recommendation, optionSetting);
+
+            var topicNames = topicArns.Select(queue => queue.DisplayName).ToList();
+            var currentName = string.Empty;
+            if (currentValue.ToString()?.LastIndexOf(':') != -1)
+            {
+                currentName = currentValueStr.Substring(currentValueStr.LastIndexOf(':') + 1);
+            }
+
+            topicNames.Add(NO_VALUE);
+            var userResponse = _consoleUtilities.AskUserToChoose(
+                values: topicNames,
+                title: "Select a SNS topic:",
+                defaultValue: currentName);
+
+            var selectedTopicArn = topicArns.FirstOrDefault(x => string.Equals(x.DisplayName, userResponse, StringComparison.OrdinalIgnoreCase));
+            return selectedTopicArn?.SystemName ?? string.Empty;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class SQSQueueUrlCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public SQSQueueUrlCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var queueUrls = await _awsResourceQueryer.ListOfSQSQueuesUrls();
+            return queueUrls.Select(queueUrl => new TypeHintResource(queueUrl, queueUrl.Substring(queueUrl.LastIndexOf('/') + 1))).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            const string NO_VALUE = "*** Do not select queue ***";
+            var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var currentValueStr = currentValue.ToString() ?? string.Empty;
+            var queueUrls = await GetResources(recommendation, optionSetting);
+
+            var queueNames = queueUrls.Select(queue => queue.DisplayName).ToList();
+            var currentName = string.Empty;
+            if (currentValue.ToString()?.LastIndexOf('/') != -1)
+            {
+                currentName = currentValueStr.Substring(currentValueStr.LastIndexOf('/') + 1);
+            }
+
+            queueNames.Add(NO_VALUE);
+            var userResponse = _consoleUtilities.AskUserToChoose(
+                values: queueNames,
+                title: "Select a SQS queue:",
+                defaultValue: currentName);
+
+            var selectedQueueUrl = queueUrls.FirstOrDefault(x => string.Equals(x.DisplayName, userResponse, StringComparison.OrdinalIgnoreCase));
+            return selectedQueueUrl?.SystemName ?? string.Empty;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -50,6 +50,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.DockerBuildArgs, new DockerBuildArgsCommand(consoleUtilities) },
                 { OptionSettingTypeHint.ECSCluster, new ECSClusterCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.ExistingApplicationLoadBalancer, new ExistingApplicationLoadBalancerCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.DynamoDBTableName, new DynamoDBTableCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.SQSQueueUrl, new SQSQueueUrlCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.SNSTopicArn, new SNSTopicArnsCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.S3BucketName, new S3BucketNameCommand(awsResourceQueryer, consoleUtilities) },
             };
         }
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -21,6 +21,10 @@ namespace AWS.Deploy.Common.Recipes
         DotnetPublishAdditionalBuildArguments,
         DockerExecutionDirectory,
         DockerBuildArgs,
-        AppRunnerService
+        AppRunnerService,
+        DynamoDBTableName,
+        SQSQueueUrl,
+        SNSTopicArn,
+        S3BucketName
     };
 }

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.83" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.25" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.53" />
     <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.3.14" />
     <PackageReference Include="AWSSDK.CloudFront" Version="3.7.3.10" />
     <PackageReference Include="AWSSDK.EC2" Version="3.7.19.1" />

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -49,5 +49,9 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer>> ListOfLoadBalancers(LoadBalancerTypeEnum loadBalancerType) => throw new NotImplementedException();
         public Task<Distribution> GetCloudFrontDistribution(string distributionId) => throw new NotImplementedException();
+        public Task<List<string>> ListOfDyanmoDBTables() => throw new NotImplementedException();
+        public Task<List<string>> ListOfSQSQueuesUrls() => throw new NotImplementedException();
+        public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
+        public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using Xunit;
+
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.Data;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class TypeHintTests
+    {
+        [Fact]
+        public async Task TestDynamoDBTableNameTypeHint()
+        {
+            var listPaginator = new Mock<IListTablesPaginator>();
+            listPaginator.Setup(x => x.TableNames)
+                .Returns(new MockPaginatedEnumerable<string>(new string[] { "Table1", "Table2" }));
+
+            var ddbPaginators = new Mock<IDynamoDBv2PaginatorFactory>();
+            ddbPaginators.Setup(x => x.ListTables(It.IsAny<ListTablesRequest>()))
+                    .Returns(listPaginator.Object);
+
+            var ddbClient = new Mock<IAmazonDynamoDB>();
+            ddbClient.Setup(x => x.Paginators)
+                    .Returns(ddbPaginators.Object);
+
+            var awsClientFactory = new Mock<IAWSClientFactory>();
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonDynamoDB>())
+                    .Returns(ddbClient.Object);
+
+            var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
+            var typeHintCommand = new DynamoDBTableCommand(awsResourceQueryer, null);
+
+            var resources = await typeHintCommand.GetResources(null, null);
+            Assert.Equal(2, resources.Count);
+            Assert.Equal("Table1", resources[0].DisplayName);
+            Assert.Equal("Table1", resources[0].SystemName);
+            Assert.Equal("Table2", resources[1].DisplayName);
+            Assert.Equal("Table2", resources[1].SystemName);
+        }
+
+        [Fact]
+        public async Task TestSQSQueueUrlTypeHint()
+        {
+            var listPaginator = new Mock<IListQueuesPaginator>();
+            listPaginator.Setup(x => x.QueueUrls)
+                .Returns(new MockPaginatedEnumerable<string>(new string[] { "https://sqs.us-west-2.amazonaws.com/123412341234/queue1", "https://sqs.us-west-2.amazonaws.com/123412341234/queue2" }));
+
+            var sqsPaginators = new Mock<ISQSPaginatorFactory>();
+            sqsPaginators.Setup(x => x.ListQueues(It.IsAny<ListQueuesRequest>()))
+                    .Returns(listPaginator.Object);
+
+            var sqsClient = new Mock<IAmazonSQS>();
+            sqsClient.Setup(x => x.Paginators)
+                    .Returns(sqsPaginators.Object);
+
+            var awsClientFactory = new Mock<IAWSClientFactory>();
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonSQS>())
+                    .Returns(sqsClient.Object);
+
+            var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
+            var typeHintCommand = new SQSQueueUrlCommand(awsResourceQueryer, null);
+
+            var resources = await typeHintCommand.GetResources(null, null);
+            Assert.Equal(2, resources.Count);
+            Assert.Equal("queue1", resources[0].DisplayName);
+            Assert.Equal("https://sqs.us-west-2.amazonaws.com/123412341234/queue1", resources[0].SystemName);
+            Assert.Equal("queue2", resources[1].DisplayName);
+            Assert.Equal("https://sqs.us-west-2.amazonaws.com/123412341234/queue2", resources[1].SystemName);
+        }
+
+        [Fact]
+        public async Task TestSNSTopicArnTypeHint()
+        {
+            var listPaginator = new Mock<IListTopicsPaginator>();
+            listPaginator.Setup(x => x.Topics)
+                .Returns(new MockPaginatedEnumerable<Topic>(new Topic[] { new Topic { TopicArn = "arn:aws:sns:us-west-2:123412341234:Topic1" }, new Topic { TopicArn = "arn:aws:sns:us-west-2:123412341234:Topic2" } }));
+
+            var snsPaginators = new Mock<ISimpleNotificationServicePaginatorFactory>();
+            snsPaginators.Setup(x => x.ListTopics(It.IsAny<ListTopicsRequest>()))
+                    .Returns(listPaginator.Object);
+
+            var snsClient = new Mock<IAmazonSimpleNotificationService>();
+            snsClient.Setup(x => x.Paginators)
+                    .Returns(snsPaginators.Object);
+
+            var awsClientFactory = new Mock<IAWSClientFactory>();
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonSimpleNotificationService>())
+                    .Returns(snsClient.Object);
+
+            var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
+            var typeHintCommand = new SNSTopicArnsCommand(awsResourceQueryer, null);
+
+            var resources = await typeHintCommand.GetResources(null, null);
+            Assert.Equal(2, resources.Count);
+            Assert.Equal("Topic1", resources[0].DisplayName);
+            Assert.Equal("arn:aws:sns:us-west-2:123412341234:Topic1", resources[0].SystemName);
+            Assert.Equal("Topic2", resources[1].DisplayName);
+            Assert.Equal("arn:aws:sns:us-west-2:123412341234:Topic2", resources[1].SystemName);
+        }
+
+        [Fact]
+        public async Task TestS3BucketNameTypeHint()
+        {
+            var s3Client = new Mock<IAmazonS3>();
+            s3Client.Setup(x => x.ListBucketsAsync(It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new ListBucketsResponse { Buckets = new List<S3Bucket> { new S3Bucket {BucketName = "Bucket1" }, new S3Bucket { BucketName = "Bucket2" } } }));
+
+            var awsClientFactory = new Mock<IAWSClientFactory>();
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonS3>())
+                    .Returns(s3Client.Object);
+
+            var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
+            var typeHintCommand = new S3BucketNameCommand(awsResourceQueryer, null);
+
+            var resources = await typeHintCommand.GetResources(null, null);
+            Assert.Equal(2, resources.Count);
+            Assert.Equal("Bucket1", resources[0].DisplayName);
+            Assert.Equal("Bucket1", resources[0].SystemName);
+            Assert.Equal("Bucket2", resources[1].DisplayName);
+            Assert.Equal("Bucket2", resources[1].SystemName);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/MockPaginatedEnumerable.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/MockPaginatedEnumerable.cs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+
+namespace AWS.Deploy.CLI.UnitTests.Utilities
+{
+    public class MockPaginatedEnumerable<T> : IPaginatedEnumerable<T>
+    {
+        readonly T[] _data;
+
+        public MockPaginatedEnumerable(T[] data)
+        {
+            _data = data;
+        }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new MockAsyncEnumerator<T>(_data);
+        }
+
+        class MockAsyncEnumerator<T> : IAsyncEnumerator<T>
+        {
+            readonly T[] _data;
+            int _position;
+
+            public MockAsyncEnumerator(T[] data)
+            {
+                _data = data;
+            }
+
+            public T Current => _data[_position - 1];
+
+            public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
+            public ValueTask<bool> MoveNextAsync()
+            {
+                _position++;
+                return new ValueTask<bool>(_position <= _data.Length);
+            }
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -74,5 +74,9 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         Task<string> IAWSResourceQueryer.GetS3BucketLocation(string bucketName) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer>> ListOfLoadBalancers(LoadBalancerTypeEnum loadBalancerType) => throw new NotImplementedException();
         public Task<Distribution> GetCloudFrontDistribution(string distributionId) => throw new NotImplementedException();
+        public Task<List<string>> ListOfDyanmoDBTables() => throw new NotImplementedException();
+        public Task<List<string>> ListOfSQSQueuesUrls() => throw new NotImplementedException();
+        public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
+        public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Description of changes:*
Add the following type hints that will help users that have development projects easily add application resources as option settings.

* DynamoDB table name
* SQS queue urls
* SNS Topic arns
* S3 bucket names


![TypeHints](https://user-images.githubusercontent.com/1653751/138374319-bbf836fc-1781-4261-8c9b-12618965a965.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
