### PR TITLE
chore: Add build suppression for ASP0000 (Multiple IServiceProviders)

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -15,7 +15,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/aws/aws-dotnet-deploy</PackageProjectUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1570;1591</NoWarn>
+    <NoWarn>$(NoWarn);1570;1591;ASP0000</NoWarn>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 


### PR DESCRIPTION
*Description of changes:*
Due to unique use case of the deploy being both a CLI and Web Application we need to suppress build analyzer ASP0000 triggered when there are multiple IServiceProviders created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
