### PR TITLE
fix: Issue with docker detection due to extra whitepace added to container type field

### DIFF
--- a/src/AWS.Deploy.Orchestration/SystemCapabilities.cs
+++ b/src/AWS.Deploy.Orchestration/SystemCapabilities.cs
@@ -26,7 +26,7 @@ namespace AWS.Deploy.Orchestration
             string dockerContainerType)
         {
             DockerInstalled = dockerInstalled;
-            DockerContainerType = dockerContainerType;
+            DockerContainerType = dockerContainerType.Trim();
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
I found on my machine the `dockerContainerType` field had extra newline characters at the end which was triggering a failure detected that docker was running in Linux mode. The value I was seeing is `linux\r\n\r`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
