### PR TITLE
feat: improve telemetry and error visibility in server mode

### DIFF
--- a/src/AWS.Deploy.CLI/AWSUtilities.cs
+++ b/src/AWS.Deploy.CLI/AWSUtilities.cs
@@ -80,7 +80,7 @@ namespace AWS.Deploy.CLI
                 var sharedCredentials = new SharedCredentialsFile();
                 if (sharedCredentials.ListProfileNames().Count == 0)
                 {
-                    throw new NoAWSCredentialsFoundException("Unable to resolve AWS credentials to access AWS.");
+                    throw new NoAWSCredentialsFoundException(DeployToolErrorCode.UnableToResolveAWSCredentials, "Unable to resolve AWS credentials to access AWS.");
                 }
 
                 var selectedProfileName = _consoleUtilities.AskUserToChoose(sharedCredentials.ListProfileNames(), "Select AWS Credentials Profile", null);
@@ -91,7 +91,7 @@ namespace AWS.Deploy.CLI
                     return selectedProfileCredentials;
                 }
 
-                throw new NoAWSCredentialsFoundException($"Unable to create AWS credentials for profile {selectedProfileName}.");
+                throw new NoAWSCredentialsFoundException(DeployToolErrorCode.UnableToCreateAWSCredentials, $"Unable to create AWS credentials for profile {selectedProfileName}.");
             }
 
             var credentials = await Resolve();

--- a/src/AWS.Deploy.CLI/CommandReturnCodes.cs
+++ b/src/AWS.Deploy.CLI/CommandReturnCodes.cs
@@ -16,8 +16,8 @@ namespace AWS.Deploy.CLI
         /// exception was thrown.  This usually means there is an intermittent io problem
         /// or bug in the code base.
         /// <para />
-        /// Unexpected exception are any exception not marked by
-        /// <see cref="AWSDeploymentExpectedExceptionAttribute"/>
+        /// Unexpected exceptions are any exception that do not inherit from
+        /// <see cref="DeployToolException"/>
         /// </summary>
         public const int UNHANDLED_EXCEPTION = -1;
         /// <summary>
@@ -25,8 +25,8 @@ namespace AWS.Deploy.CLI
         /// configuration or system configuration problem.  For example, a required
         /// dependency like Docker is not installed.
         /// <para />
-        /// Expected problems are usually indicated by throwing an exception that is
-        /// decorated with <see cref="AWSDeploymentExpectedExceptionAttribute"/>
+        /// Expected problems are usually indicated by throwing an exception that
+        /// inherits from <see cref="DeployToolException"/>
         /// </summary>
         public const int USER_ERROR = 1;
         /// <summary>

--- a/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
@@ -126,10 +126,10 @@ namespace AWS.Deploy.CLI.Commands
 
             if (stack.StackStatus.IsFailed())
             {
-                throw new FailedToDeleteException($"The stack {stackName} is in a failed state. You may need to delete it from the AWS Console.");
+                throw new FailedToDeleteException(DeployToolErrorCode.FailedToDeleteStack, $"The stack {stackName} is in a failed state. You may need to delete it from the AWS Console.");
             }
 
-            throw new FailedToDeleteException($"Failed to delete {stackName} stack: {stack.StackStatus}");
+            throw new FailedToDeleteException(DeployToolErrorCode.FailedToDeleteStack, $"Failed to delete {stackName} stack: {stack.StackStatus}");
         }
 
         private async Task<Stack?> StabilizeStack(string stackName)

--- a/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
@@ -80,7 +80,7 @@ namespace AWS.Deploy.CLI.Commands
                 if (newDirectoryCreated)
                     _directoryManager.Delete(saveCdkDirectoryPath);
                 errorMessage = $"Failed to generate deployment project.{Environment.NewLine}{errorMessage}";
-                throw new InvalidSaveDirectoryForCdkProject(errorMessage.Trim());
+                throw new InvalidSaveDirectoryForCdkProject(DeployToolErrorCode.InvalidSaveDirectoryForCdkProject, errorMessage.Trim());
             }
             
             var directoryUnderSourceControl = await IsDirectoryUnderSourceControl(saveCdkDirectoryPath);
@@ -122,7 +122,7 @@ namespace AWS.Deploy.CLI.Commands
             var recommendations = await orchestrator.GenerateRecommendationsToSaveDeploymentProject();
             if (recommendations.Count == 0)
             {
-                throw new FailedToGenerateAnyRecommendations("The project you are trying to deploy is currently not supported.");
+                throw new FailedToGenerateAnyRecommendations(DeployToolErrorCode.DeploymentProjectNotSupported, "The project you are trying to deploy is currently not supported.");
             }
             return recommendations;
         }

--- a/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ServerModeCommand.cs
@@ -39,7 +39,7 @@ namespace AWS.Deploy.CLI.Commands
             IEncryptionProvider encryptionProvider = CreateEncryptionProvider();
 
             if (IsPortInUse(_port))
-                throw new TcpPortInUseException("The port you have selected is currently in use by another process.");
+                throw new TcpPortInUseException(DeployToolErrorCode.TcpPortInUse, "The port you have selected is currently in use by another process.");
 
             var url = $"http://localhost:{_port}";
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
@@ -57,7 +57,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             return new BeanstalkApplicationTypeHintResponse(
                 userResponse.CreateNew,
                 userResponse.SelectedOption?.ApplicationName ?? userResponse.NewName
-                    ?? throw new UserPromptForNameReturnedNullException("The user response for a new application name was null.")
+                    ?? throw new UserPromptForNameReturnedNullException(DeployToolErrorCode.BeanstalkAppPromptForNameReturnedNull, "The user response for a new application name was null.")
                 );
         }
     }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
@@ -48,7 +48,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 askNewName: true,
                 defaultNewName: currentValue.ToString() ?? "");
             return userResponse.SelectedOption ?? userResponse.NewName
-                ?? throw new UserPromptForNameReturnedNullException("The user response for a new environment name was null.");
+                ?? throw new UserPromptForNameReturnedNullException(DeployToolErrorCode.BeanstalkEnvPromptForNameReturnedNull, "The user response for a new environment name was null.");
         }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
@@ -47,7 +47,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             var resultString = ValidateBuildArgs(dockerBuildArgs);
             if (!string.IsNullOrEmpty(resultString))
-                throw new InvalidOverrideValueException(resultString);
+                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerBuildArgs, resultString);
             recommendation.DeploymentBundle.DockerBuildArgs = dockerBuildArgs;
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
@@ -48,7 +48,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             var resultString = ValidateExecutionDirectory(executionDirectory);
             if (!string.IsNullOrEmpty(resultString))
-                throw new InvalidOverrideValueException(resultString);
+                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerExecutionDirectory, resultString);
             recommendation.DeploymentBundle.DockerExecutionDirectory = executionDirectory;
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -48,7 +48,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             var resultString = ValidateDotnetPublishArgs(publishArgs);
             if (!string.IsNullOrEmpty(resultString))
-                throw new InvalidOverrideValueException(resultString);
+                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDotnetPublishArgs, resultString);
             recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments = publishArgs.Replace("\"", "\"\"");
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
@@ -68,7 +68,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 else
                 {
                     settingValue = userResponse.SelectedOption?.KeyName ?? userResponse.NewName ??
-                        throw new UserPromptForNameReturnedNullException("The user prompt for a new EC2 Key Pair name was null or empty.");
+                        throw new UserPromptForNameReturnedNullException(DeployToolErrorCode.EC2KeyPairPromptForNameReturnedNull, "The user prompt for a new EC2 Key Pair name was null or empty.");
                 }
 
                 if (userResponse.CreateNew && !string.IsNullOrEmpty(userResponse.NewName))

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -9,79 +9,71 @@ namespace AWS.Deploy.CLI
     /// <summary>
     /// Throw if no AWS credentials were found.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class NoAWSCredentialsFoundException : Exception
+    public class NoAWSCredentialsFoundException : DeployToolException
     {
-        public NoAWSCredentialsFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public NoAWSCredentialsFoundException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if Delete Command is unable to delete
     /// the specified stack
     /// </summary>
-    [AWSDeploymentExpectedException ]
-    public class FailedToDeleteException : Exception
+    public class FailedToDeleteException : DeployToolException
     {
-        public FailedToDeleteException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToDeleteException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if Deploy Command is unable to find a target to deploy.
     /// Currently, this is limited to .csproj or .fsproj files.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToFindDeployableTargetException : Exception
+    public class FailedToFindDeployableTargetException : DeployToolException
     {
-        public FailedToFindDeployableTargetException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToFindDeployableTargetException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if prompting the user for a name returns a null value.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class UserPromptForNameReturnedNullException : Exception
+    public class UserPromptForNameReturnedNullException : DeployToolException
     {
-        public UserPromptForNameReturnedNullException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public UserPromptForNameReturnedNullException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if the system capabilities were not provided.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class SystemCapabilitiesNotProvidedException : Exception
+    public class SystemCapabilitiesNotProvidedException : DeployToolException
     {
-        public SystemCapabilitiesNotProvidedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public SystemCapabilitiesNotProvidedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if TCP port is in use by another process.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class TcpPortInUseException : Exception
+    public class TcpPortInUseException : DeployToolException
     {
-        public TcpPortInUseException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public TcpPortInUseException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if unable to find a compatible recipe.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToFindCompatibleRecipeException : Exception
+    public class FailedToFindCompatibleRecipeException : DeployToolException
     {
-        public FailedToFindCompatibleRecipeException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToFindCompatibleRecipeException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if the directory specified to save the CDK deployment project is invalid.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidSaveDirectoryForCdkProject : Exception
+    public class InvalidSaveDirectoryForCdkProject : DeployToolException
     {
-        public InvalidSaveDirectoryForCdkProject(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidSaveDirectoryForCdkProject(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
-    public class FailedToFindDeploymentProjectRecipeIdException : Exception
+    public class FailedToFindDeploymentProjectRecipeIdException : DeployToolException
     {
-        public FailedToFindDeploymentProjectRecipeIdException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToFindDeploymentProjectRecipeIdException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Exceptions.cs
@@ -9,7 +9,6 @@ namespace AWS.Deploy.CLI.ServerMode
     /// <summary>
     /// Throw if the selected recommendation is null.
     /// </summary>
-    [AWSDeploymentExpectedException]
     public class SelectedRecommendationIsNullException : Exception
     {
         public SelectedRecommendationIsNullException(string message, Exception? innerException = null) : base(message, innerException) { }
@@ -18,7 +17,6 @@ namespace AWS.Deploy.CLI.ServerMode
     /// <summary>
     /// Throw if the tool was not able to retrieve the AWS Credentials.
     /// </summary>
-    [AWSDeploymentExpectedException]
     public class FailedToRetrieveAWSCredentialsException : Exception
     {
         public FailedToRetrieveAWSCredentialsException(string message, Exception? innerException = null) : base(message, innerException) { }
@@ -27,7 +25,6 @@ namespace AWS.Deploy.CLI.ServerMode
     /// <summary>
     /// Throw if encryption key info passed in through stdin is invalid.
     /// </summary>
-    [AWSDeploymentExpectedException]
     public class InvalidEncryptionKeyInfoException : Exception
     {
         public InvalidEncryptionKeyInfoException(string message, Exception? innerException = null) : base(message, innerException) { }

--- a/src/AWS.Deploy.CLI/ServerMode/Models/DeployToolExceptionSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/DeployToolExceptionSummary.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public class DeployToolExceptionSummary
+    {
+        public string ErrorCode { get; set; }
+        public string Message { get; set; }
+
+        public DeployToolExceptionSummary(string errorCode, string message)
+        {
+            ErrorCode = errorCode;
+            Message = message;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Models/GetDeploymentStatusOutput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/GetDeploymentStatusOutput.cs
@@ -11,5 +11,6 @@ namespace AWS.Deploy.CLI.ServerMode.Models
     public class GetDeploymentStatusOutput
     {
         public DeploymentStatus Status { get; set; }
+        public DeployToolExceptionSummary? Exception { get; set; }
     }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Startup.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Startup.cs
@@ -50,9 +50,10 @@ namespace AWS.Deploy.CLI.ServerMode
                     {
                         opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
                     });
-
+                    
             services.AddSwaggerGen(c =>
             {
+                c.UseAllOfToExtendReferenceSchemas();
                 c.EnableAnnotations();
                 c.SwaggerDoc("v1", new OpenApiInfo
                 {

--- a/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
@@ -36,13 +36,13 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
             {
                 var dockerBuildDeploymentBundleResult = await _orchestrator.CreateContainerDeploymentBundle(_cloudApplication, _selectedRecommendation);
                 if (!dockerBuildDeploymentBundleResult)
-                    throw new FailedToCreateDeploymentBundleException("Failed to create a deployment bundle");
+                    throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundle, "Failed to create a deployment bundle");
             }
             else if (_selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.DotnetPublishZipFile)
             {
                 var dotnetPublishDeploymentBundleResult = await _orchestrator.CreateDotnetPublishDeploymentBundle(_selectedRecommendation);
                 if (!dotnetPublishDeploymentBundleResult)
-                    throw new FailedToCreateDeploymentBundleException("Failed to create a deployment bundle");
+                    throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateDotnetPublishDeploymentBundle, "Failed to create a deployment bundle");
             }
         }
     }

--- a/src/AWS.Deploy.CLI/Utilities/ProjectParserUtility.cs
+++ b/src/AWS.Deploy.CLI/Utilities/ProjectParserUtility.cs
@@ -50,7 +50,7 @@ namespace AWS.Deploy.CLI.Utilities
                 else
                     errorMessage = $"A project was not found at the path {projectPath}";
 
-                throw new FailedToFindDeployableTargetException(errorMessage, ex);
+                throw new FailedToFindDeployableTargetException(DeployToolErrorCode.FailedToFindDeployableTarget, errorMessage, ex);
             }
         }
     }

--- a/src/AWS.Deploy.Common/DeploymentManifest/DeploymentManifestEngine.cs
+++ b/src/AWS.Deploy.Common/DeploymentManifest/DeploymentManifestEngine.cs
@@ -77,7 +77,7 @@ namespace AWS.Deploy.Common.DeploymentManifest
             }
             catch (Exception ex)
             {
-                throw new FailedToUpdateDeploymentManifestFileException($"Failed to update the deployment manifest file " +
+                throw new FailedToUpdateDeploymentManifestFileException(DeployToolErrorCode.DeploymentManifestUpdateFailed, $"Failed to update the deployment manifest file " +
                     $"for the deployment project stored at '{saveCdkDirectoryFullPath}'", ex);
             }
         }

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -8,171 +8,223 @@ using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Common
 {
-    public class ProjectFileNotFoundException : Exception
+    public abstract class DeployToolException : Exception
     {
-        public ProjectFileNotFoundException(string projectPath)
-            : base($"A project was not found at the path {projectPath}.")
-        {
-            Path = projectPath;
-        }
+        public DeployToolErrorCode ErrorCode { get; set; }
 
-        public string Path { get; set; }
+        public DeployToolException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(message, innerException)
+        {
+            ErrorCode = errorCode;
+        }
+    }
+
+    public enum DeployToolErrorCode
+    {
+        ProjectPathNotFound = 10000100,
+        ProjectParserNoSdkAttribute = 10000200,
+        InvalidCliArguments = 10000300,
+        SilentArgumentNeedsStackNameArgument = 10000400,
+        SilentArgumentNeedsDeploymentRecipe = 10000500,
+        DeploymentProjectPathNotFound = 10000600,
+        RuleHasInvalidTestType = 10000700,
+        MissingSystemCapabilities = 10000800,
+        NoDeploymentRecipesFound = 10000900,
+        NoCompatibleDeploymentRecipesFound = 10001000,
+        DeploymentProjectNotSupported = 10001100,
+        InvalidValueForOptionSettingItem = 10001200,
+        InvalidDockerBuildArgs = 10001300,
+        InvalidDockerExecutionDirectory = 10001400,
+        InvalidDotnetPublishArgs = 10001500,
+        ErrorParsingApplicationMetadata = 10001600,
+        FailedToCreateContainerDeploymentBundle = 10001700,
+        FailedToCreateDotnetPublishDeploymentBundle = 10001800,
+        OptionSettingItemDoesNotExistInRecipe = 10001900,
+        UnableToCreateValidatorInstance = 10002000,
+        OptionSettingItemValueValidationFailed = 10002100,
+        StackCreatedFromDifferentDeploymentRecommendation = 10002200,
+        DeploymentConfigurationNeedsAdjusting = 10002300,
+        UserDeploymentInvalidStackName = 10002400,
+        InvalidPropertyValueForUserDeployment = 10002500,
+        FailedToDeserializeUserDeploymentFile = 10002600,
+        DeploymentBundleDefinitionNotFound = 10002700,
+        DeploymentManifestUpdateFailed = 10002800,
+        DockerFileTemplateNotFound = 10002900,
+        UnableToMapProjectToDockerImage = 10003000,
+        NoValidDockerImageForProject = 10003100,
+        NoValidDockerMappingForSdkType = 10003200,
+        NoValidDockerMappingForTargetFramework = 10003300,
+        FailedToGenerateCDKProjectFromTemplate = 10003400,
+        FailedToInstallProjectTemplates = 10003500,
+        FailedToWritePackageJsonFile = 10003600,
+        FailedToInstallNpmPackages = 10003700,
+        DockerBuildFailed = 10003800,
+        FailedToGetCDKVersion = 10003900,
+        DockerLoginFailed = 10004000,
+        DockerTagFailed = 10004100,
+        DockerPushFailed = 10004200,
+        FailedToFindRecipeDefinitions = 10004300,
+        DotnetPublishFailed = 10004400,
+        FailedToFindZipUtility = 10004500,
+        ZipUtilityFailedToZip = 10004600,
+        FailedToGenerateDockerFile = 10004700,
+        BaseTemplatesInvalidPath = 10004800,
+        InvalidSolutionPath = 10004900,
+        InvalidAWSDeployRecipesCDKCommonVersion = 10005000,
+        FailedToDeployCdkApplication = 10005100,
+        AppRunnerServiceDoesNotExist = 10005200,
+        BeanstalkEnvironmentDoesNotExist = 10005300,
+        LoadBalancerDoesNotExist = 10005400,
+        LoadBalancerListenerDoesNotExist = 10005500,
+        CloudWatchRuleDoesNotExist = 10005600,
+        InvalidLocalUserSettingsFile = 10005700,
+        FailedToUpdateLocalUserSettingsFile = 10005800,
+        FailedToCheckDockerInfo = 10005900,
+        UnableToResolveAWSCredentials = 10006000,
+        UnableToCreateAWSCredentials = 10006100,
+        FailedToDeleteStack = 10006200,
+        FailedToFindDeployableTarget = 10006300,
+        BeanstalkAppPromptForNameReturnedNull = 10006400,
+        BeanstalkEnvPromptForNameReturnedNull = 10006500,
+        EC2KeyPairPromptForNameReturnedNull = 10006600,
+        TcpPortInUse = 10006700,
+        CompatibleRecommendationForRedeploymentNotFound = 10006800,
+        InvalidSaveDirectoryForCdkProject = 10006900,
+        FailedToFindDeploymentProjectRecipeId = 10007000,
+        UnexpectedError = 10007100
+    }
+
+    public class ProjectFileNotFoundException : DeployToolException
+    {
+        public ProjectFileNotFoundException(DeployToolErrorCode errorCode, string message, Exception? innerException = null)
+            : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Common exception if the user has passed invalid input from the command line
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidCliArgumentException : Exception
+    public class InvalidCliArgumentException : DeployToolException
     {
-        public InvalidCliArgumentException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidCliArgumentException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if the user attempts to deploy a <see cref="RecipeDefinition"/> but the recipe definition is invalid
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidRecipeDefinitionException : Exception
+    public class InvalidRecipeDefinitionException : DeployToolException
     {
-        public InvalidRecipeDefinitionException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidRecipeDefinitionException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if the user attempts to deploy a <see cref="ProjectDefinition"/> but the project definition is invalid
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidProjectDefinitionException : Exception
+    public class InvalidProjectDefinitionException : DeployToolException
     {
-        public InvalidProjectDefinitionException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidProjectDefinitionException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Thrown if there is a missing System Capability.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class MissingSystemCapabilityException : Exception
+    public class MissingSystemCapabilityException : DeployToolException
     {
-        public MissingSystemCapabilityException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public MissingSystemCapabilityException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if Recommendation Engine is unable to generate
     /// recommendations for a given target context
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToGenerateAnyRecommendations : Exception
+    public class FailedToGenerateAnyRecommendations : DeployToolException
     {
-        public FailedToGenerateAnyRecommendations(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToGenerateAnyRecommendations(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if a value is set that is not part of the allowed values
     /// of an option setting item
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidOverrideValueException : Exception
+    public class InvalidOverrideValueException : DeployToolException
     {
-        public InvalidOverrideValueException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidOverrideValueException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if there is a parse error reading the existing Cloud Application's metadata
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class ParsingExistingCloudApplicationMetadataException : Exception
+    public class ParsingExistingCloudApplicationMetadataException : DeployToolException
     {
-        public ParsingExistingCloudApplicationMetadataException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public ParsingExistingCloudApplicationMetadataException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if Orchestrator is unable to create
     /// the deployment bundle.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToCreateDeploymentBundleException : Exception
+    public class FailedToCreateDeploymentBundleException : DeployToolException
     {
-        public FailedToCreateDeploymentBundleException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToCreateDeploymentBundleException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if Option Setting Item does not exist
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class OptionSettingItemDoesNotExistException : Exception
+    public class OptionSettingItemDoesNotExistException : DeployToolException
     {
-        public OptionSettingItemDoesNotExistException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public OptionSettingItemDoesNotExistException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
-    [AWSDeploymentExpectedException]
-    public class InvalidValidatorTypeException : Exception
+    public class InvalidValidatorTypeException : DeployToolException
     {
-        public InvalidValidatorTypeException(string? message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidValidatorTypeException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Thrown if <see cref="OptionSettingItem.SetValueOverride"/> is given an invalid value.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class ValidationFailedException : Exception
+    public class ValidationFailedException : DeployToolException
     {
-        public ValidationFailedException(string? message, Exception? innerException = null) : base(message, innerException) { }
+        public ValidationFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if Project Path contains an invalid path
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidProjectPathException : Exception
+    public class InvalidProjectPathException : DeployToolException
     {
-        public InvalidProjectPathException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidProjectPathException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// Throw if an invalid <see cref="UserDeploymentSettings"/> is used.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidUserDeploymentSettingsException : Exception
+    public class InvalidUserDeploymentSettingsException : DeployToolException
     {
-        public InvalidUserDeploymentSettingsException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidUserDeploymentSettingsException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if we cannot retrieve deployment bundle definitions
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class NoDeploymentBundleDefinitionsFoundException : Exception
+    public class NoDeploymentBundleDefinitionsFoundException : DeployToolException
     {
-        public NoDeploymentBundleDefinitionsFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public NoDeploymentBundleDefinitionsFoundException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
     
     /// Exception thrown if a failure occured while trying to update the deployment manifest file.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToUpdateDeploymentManifestFileException : Exception
+    public class FailedToUpdateDeploymentManifestFileException : DeployToolException
     {
-        public FailedToUpdateDeploymentManifestFileException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToUpdateDeploymentManifestFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
-
-    /// <summary>
-    /// Indicates a specific strongly typed Exception can be anticipated.
-    /// Whoever throws this error should also present the user with helpful information
-    /// on what wrong and how to fix it.  This is the preferred UX.
-    /// <para />
-    /// Conversely, if an Exceptions not marked with attribute reaches the entry point
-    /// application (ie Program.cs) than all exception details will likely be presented to
-    /// user.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public class AWSDeploymentExpectedExceptionAttribute : Attribute { }
 
     public static class ExceptionExtensions
     {
         /// <summary>
-        /// True if the <paramref name="e"/> is decorated with
-        /// <see cref="AWSDeploymentExpectedExceptionAttribute"/>.
+        /// True if the <paramref name="e"/> inherits from
+        /// <see cref="DeployToolException"/>.
         /// </summary>
         public static bool IsAWSDeploymentExpectedException(this Exception e) =>
-            null != e?.GetType()
-                .GetCustomAttribute(typeof(AWSDeploymentExpectedExceptionAttribute), inherit: true);
+            e is DeployToolException;
 
         public static string PrettyPrint(this Exception? e)
         {

--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -85,7 +85,7 @@ namespace AWS.Deploy.Common
         private bool CheckIfDockerFileExists(string projectPath)
         {
             var dir = Directory.GetFiles(new FileInfo(projectPath).DirectoryName ??
-                                         throw new InvalidProjectPathException("The project path is invalid."), "Dockerfile");
+                                         throw new InvalidProjectPathException(DeployToolErrorCode.ProjectPathNotFound, "The project path is invalid."), "Dockerfile");
             return dir.Length == 1;
         }
 

--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -62,7 +62,7 @@ namespace AWS.Deploy.Common
 
             if (!_fileManager.Exists(projectPath))
             {
-                throw new ProjectFileNotFoundException(projectPath);
+                throw new ProjectFileNotFoundException(DeployToolErrorCode.ProjectPathNotFound, $"A project was not found at the path {projectPath}.");
             }
 
             var xmlProjectFile = new XmlDocument();
@@ -73,7 +73,7 @@ namespace AWS.Deploy.Common
                 projectPath,
                 await GetProjectSolutionFile(projectPath),
                 xmlProjectFile.DocumentElement?.Attributes["Sdk"]?.Value ??
-                    throw new InvalidProjectDefinitionException(
+                    throw new InvalidProjectDefinitionException(DeployToolErrorCode.ProjectParserNoSdkAttribute,
                         "The project file that is being referenced does not contain and 'Sdk' attribute.")
                 );
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -108,11 +108,11 @@ namespace AWS.Deploy.Common.Recipes
                 }
             }
             if (!isValid)
-                throw new ValidationFailedException(validationFailedMessage.Trim());
+                throw new ValidationFailedException(DeployToolErrorCode.OptionSettingItemValueValidationFailed, validationFailedMessage.Trim());
 
             if (AllowedValues != null && AllowedValues.Count > 0 && valueOverride != null &&
                 !AllowedValues.Contains(valueOverride.ToString() ?? ""))
-                throw new InvalidOverrideValueException($"Invalid value for option setting item '{Name}'");
+                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, $"Invalid value for option setting item '{Name}'");
 
             if (valueOverride is bool || valueOverride is int || valueOverride is long || valueOverride is double)
             {

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -47,7 +47,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
             {
                 var validatorInstance = Activator.CreateInstance(typeMappings[validatorType]);
                 if (validatorInstance == null)
-                    throw new InvalidValidatorTypeException($"Could not create an instance of validator type {validatorType}");
+                    throw new InvalidValidatorTypeException(DeployToolErrorCode.UnableToCreateValidatorInstance, $"Could not create an instance of validator type {validatorType}");
                 return validatorInstance;
             }
 
@@ -55,7 +55,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
             {
                 var validatorInstance = jObject.ToObject(typeMappings[validatorType]);
                 if (validatorInstance == null)
-                    throw new InvalidValidatorTypeException($"Could not create an instance of validator type {validatorType}");
+                    throw new InvalidValidatorTypeException(DeployToolErrorCode.UnableToCreateValidatorInstance, $"Could not create an instance of validator type {validatorType}");
                 return validatorInstance;
             }
 

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -98,7 +98,7 @@ namespace AWS.Deploy.Common
         public OptionSettingItem GetOptionSetting(string? jsonPath)
         {
             if (string.IsNullOrEmpty(jsonPath))
-                throw new OptionSettingItemDoesNotExistException($"The Option Setting Item {jsonPath} does not exist as part of the" +
+                throw new OptionSettingItemDoesNotExistException(DeployToolErrorCode.OptionSettingItemDoesNotExistInRecipe, $"The Option Setting Item {jsonPath} does not exist as part of the" +
                     $" {Recipe.Name} recipe");
 
             var ids = jsonPath.Split('.');
@@ -110,7 +110,7 @@ namespace AWS.Deploy.Common
                 optionSetting = optionSettings.FirstOrDefault(os => os.Id.Equals(id));
                 if (optionSetting == null)
                 {
-                    throw new OptionSettingItemDoesNotExistException($"The Option Setting Item {jsonPath} does not exist as part of the" +
+                    throw new OptionSettingItemDoesNotExistException(DeployToolErrorCode.OptionSettingItemDoesNotExistInRecipe, $"The Option Setting Item {jsonPath} does not exist as part of the" +
                     $" {Recipe.Name} recipe");
                 }
             }

--- a/src/AWS.Deploy.Common/UserDeploymentSettings.cs
+++ b/src/AWS.Deploy.Common/UserDeploymentSettings.cs
@@ -42,7 +42,7 @@ namespace AWS.Deploy.Common
             }
             catch (Exception ex)
             {
-                throw new InvalidUserDeploymentSettingsException("An error occured while trying to deserialize the User Deployment Settings file.", ex);
+                throw new InvalidUserDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, "An error occured while trying to deserialize the User Deployment Settings file.", ex);
             }
         }
 

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -56,7 +56,7 @@ namespace AWS.Deploy.DockerEngine
             var imageMapping = GetImageMapping();
             if (imageMapping == null)
             {
-                throw new UnknownDockerImageException($"Unable to determine a valid docker base and build image for project of type {_project.SdkType} and Target Framework {_project.TargetFramework}");
+                throw new UnknownDockerImageException(DeployToolErrorCode.NoValidDockerImageForProject, $"Unable to determine a valid docker base and build image for project of type {_project.SdkType} and Target Framework {_project.TargetFramework}");
             }
 
             var dockerFile = new DockerFile(imageMapping, projectFileName, _project.AssemblyName);
@@ -131,10 +131,10 @@ namespace AWS.Deploy.DockerEngine
             var definitions = JsonConvert.DeserializeObject<List<ImageDefinition>>(content);
             var mappings = definitions.FirstOrDefault(x => x.SdkType.Equals(_project.SdkType));
             if (mappings == null)
-                throw new UnsupportedProjectException($"The project with SDK Type {_project.SdkType} is not supported.");
+                throw new UnsupportedProjectException(DeployToolErrorCode.NoValidDockerMappingForSdkType, $"The project with SDK Type {_project.SdkType} is not supported.");
 
             return mappings.ImageMapping.FirstOrDefault(x => x.TargetFramework.Equals(_project.TargetFramework))
-                ?? throw new UnsupportedProjectException($"The project with Target Framework {_project.TargetFramework} is not supported.");
+                ?? throw new UnsupportedProjectException(DeployToolErrorCode.NoValidDockerMappingForTargetFramework, $"The project with Target Framework {_project.TargetFramework} is not supported.");
         }
 
         /// <summary>

--- a/src/AWS.Deploy.DockerEngine/Exceptions.cs
+++ b/src/AWS.Deploy.DockerEngine/Exceptions.cs
@@ -2,31 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using AWS.Deploy.Common;
 
 namespace AWS.Deploy.DockerEngine
 {
     public class DockerFileTemplateException : DockerEngineExceptionBase
     {
-        public DockerFileTemplateException(string message) : base(message) { }
+        public DockerFileTemplateException(DeployToolErrorCode errorCode, string message) : base(errorCode, message) { }
     }
 
     public class DockerEngineException : DockerEngineExceptionBase
     {
-        public DockerEngineException(string message) : base(message) { }
+        public DockerEngineException(DeployToolErrorCode errorCode, string message) : base(errorCode, message) { }
     }
 
     public class UnknownDockerImageException : DockerEngineExceptionBase
     {
-        public UnknownDockerImageException(string message) : base(message) { }
+        public UnknownDockerImageException(DeployToolErrorCode errorCode, string message) : base(errorCode, message) { }
     }
 
-    public class DockerEngineExceptionBase : Exception
+    public class DockerEngineExceptionBase : DeployToolException
     {
-        public DockerEngineExceptionBase(string message) : base(message) { }
+        public DockerEngineExceptionBase(DeployToolErrorCode errorCode, string message) : base(errorCode, message) { }
     }
 
     public class UnsupportedProjectException : DockerEngineExceptionBase
     {
-        public UnsupportedProjectException(string message) : base(message) { }
+        public UnsupportedProjectException(DeployToolErrorCode errorCode, string message) : base(errorCode, message) { }
     }
 }

--- a/src/AWS.Deploy.DockerEngine/ProjectUtilities.cs
+++ b/src/AWS.Deploy.DockerEngine/ProjectUtilities.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Reflection;
+using AWS.Deploy.Common;
 using AWS.Deploy.Common.Extensions;
 
 namespace AWS.Deploy.DockerEngine
@@ -21,7 +22,7 @@ namespace AWS.Deploy.DockerEngine
 
             if (string.IsNullOrWhiteSpace(template))
             {
-                throw new DockerEngineException($"The DockerEngine could not find the embedded config file responsible for mapping projects to Docker images.");
+                throw new DockerEngineException(DeployToolErrorCode.UnableToMapProjectToDockerImage, $"The DockerEngine could not find the embedded config file responsible for mapping projects to Docker images.");
             }
 
             return template;
@@ -36,7 +37,7 @@ namespace AWS.Deploy.DockerEngine
 
             if (string.IsNullOrWhiteSpace(template))
             {
-                throw new DockerFileTemplateException("The Dockerfile template for the project was not found.");
+                throw new DockerFileTemplateException(DeployToolErrorCode.DockerFileTemplateNotFound, "The Dockerfile template for the project was not found.");
             }
 
             return template;

--- a/src/AWS.Deploy.Orchestration/CDK/CDKInstaller.cs
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKInstaller.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AWS.Deploy.Common;
 using AWS.Deploy.Orchestration.Utilities;
 
 namespace AWS.Deploy.Orchestration.CDK
@@ -52,7 +53,7 @@ namespace AWS.Deploy.Orchestration.CDK
             }
             catch (Exception exception)
             {
-                throw new NPMCommandFailedException($"Failed to execute {command}", exception);
+                throw new NPMCommandFailedException(DeployToolErrorCode.FailedToGetCDKVersion, $"Failed to execute {command}", exception);
             }
 
             var standardOut = result.StandardOut ?? "";

--- a/src/AWS.Deploy.Orchestration/CDK/NPMPackageInitializer.cs
+++ b/src/AWS.Deploy.Orchestration/CDK/NPMPackageInitializer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Utilities;
 
@@ -85,7 +86,7 @@ namespace AWS.Deploy.Orchestration.CDK
             }
             catch (Exception exception)
             {
-                throw new PackageJsonFileException($"Failed to write {_packageJsonFileName} at {packageJsonFilePath}", exception);
+                throw new PackageJsonFileException(DeployToolErrorCode.FailedToWritePackageJsonFile, $"Failed to write {_packageJsonFileName} at {packageJsonFilePath}", exception);
             }
 
             try
@@ -95,7 +96,7 @@ namespace AWS.Deploy.Orchestration.CDK
             }
             catch (Exception exception)
             {
-                throw new NPMCommandFailedException($"Failed to install npm packages at {workingDirectory}", exception);
+                throw new NPMCommandFailedException(DeployToolErrorCode.FailedToInstallNpmPackages, $"Failed to install npm packages at {workingDirectory}", exception);
             }
         }
     }

--- a/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
+++ b/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
@@ -15,7 +15,7 @@ namespace AWS.Deploy.Orchestration
         {
             var projectPath = new FileInfo(recommendation.ProjectPath).Directory?.FullName;
             if (string.IsNullOrEmpty(projectPath))
-                throw new InvalidProjectPathException("The project path provided is invalid.");
+                throw new InvalidProjectPathException(DeployToolErrorCode.ProjectPathNotFound, "The project path provided is invalid.");
 
             // General Settings
             var appSettingsContainer = new RecipeProps<Dictionary<string, object>>(

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -87,7 +87,7 @@ namespace AWS.Deploy.Orchestration
                 streamOutputToInteractiveService: true);
 
             if (cdkDeploy.ExitCode != 0)
-                throw new FailedToDeployCDKAppException("We had an issue deploying your application to AWS. Check the deployment output for more details.");
+                throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToDeployCdkApplication, "We had an issue deploying your application to AWS. Check the deployment output for more details.");
         }
 
         public string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -89,7 +89,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (service == null)
             {
-                throw new AWSResourceNotFoundException($"The AppRunner service '{serviceArn}' does not exist.");
+                throw new AWSResourceNotFoundException(DeployToolErrorCode.AppRunnerServiceDoesNotExist, $"The AppRunner service '{serviceArn}' does not exist.");
             }
 
             return service;
@@ -113,7 +113,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (!environment.Environments.Any())
             {
-                throw new AWSResourceNotFoundException($"The elastic beanstalk environment '{environmentId}' does not exist.");
+                throw new AWSResourceNotFoundException(DeployToolErrorCode.BeanstalkEnvironmentDoesNotExist, $"The elastic beanstalk environment '{environmentId}' does not exist.");
             }
 
             return environment.Environments.First();
@@ -130,7 +130,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (!loadBalancers.LoadBalancers.Any())
             {
-                throw new AWSResourceNotFoundException($"The load balancer '{loadBalancerArn}' does not exist.");
+                throw new AWSResourceNotFoundException(DeployToolErrorCode.LoadBalancerDoesNotExist, $"The load balancer '{loadBalancerArn}' does not exist.");
             }
 
             return loadBalancers.LoadBalancers.First();
@@ -147,7 +147,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (!listeners.Listeners.Any())
             {
-                throw new AWSResourceNotFoundException($"The load balancer '{loadBalancerArn}' does not have any listeners.");
+                throw new AWSResourceNotFoundException(DeployToolErrorCode.LoadBalancerListenerDoesNotExist, $"The load balancer '{loadBalancerArn}' does not have any listeners.");
             }
 
             return listeners.Listeners;
@@ -164,7 +164,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (rule == null)
             {
-                throw new AWSResourceNotFoundException($"The CloudWatch rule'{ruleName}' does not exist.");
+                throw new AWSResourceNotFoundException(DeployToolErrorCode.CloudWatchRuleDoesNotExist, $"The CloudWatch rule'{ruleName}' does not exist.");
             }
 
             return rule;

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -7,189 +7,168 @@ namespace AWS.Deploy.Orchestration
     /// <summary>
     /// Exception is thrown if Microsoft Templating Engine is unable to generate a template
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class TemplateGenerationFailedException : Exception
+    public class TemplateGenerationFailedException : DeployToolException
     {
-        public TemplateGenerationFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public TemplateGenerationFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if Microsoft Templating Engine is unable to find location to install templates from
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DefaultTemplateInstallationFailedException : Exception
+    public class DefaultTemplateInstallationFailedException : DeployToolException
     {
-        public DefaultTemplateInstallationFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DefaultTemplateInstallationFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if Microsoft Templating Engine returns an error when running a command
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class RunCommandFailedException : Exception
+    public class RunCommandFailedException : DeployToolException
     {
-        public RunCommandFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public RunCommandFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if package.json file IO fails.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class PackageJsonFileException : Exception
+    public class PackageJsonFileException : DeployToolException
     {
-        public PackageJsonFileException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public PackageJsonFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if docker build attempt failed
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DockerBuildFailedException : Exception
+    public class DockerBuildFailedException : DeployToolException
     {
-        public DockerBuildFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DockerBuildFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if npm command fails to execute.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class NPMCommandFailedException : Exception
+    public class NPMCommandFailedException : DeployToolException
     {
-        public NPMCommandFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public NPMCommandFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if docker login attempt failed
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DockerLoginFailedException : Exception
+    public class DockerLoginFailedException : DeployToolException
     {
-        public DockerLoginFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DockerLoginFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if docker tag attempt failed
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DockerTagFailedException : Exception
+    public class DockerTagFailedException : DeployToolException
     {
-        public DockerTagFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DockerTagFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if docker push attempt failed
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DockerPushFailedException : Exception
+    public class DockerPushFailedException : DeployToolException
     {
-        public DockerPushFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DockerPushFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if we cannot retrieve recipe definitions
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class NoRecipeDefinitionsFoundException : Exception
+    public class NoRecipeDefinitionsFoundException : DeployToolException
     {
-        public NoRecipeDefinitionsFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public NoRecipeDefinitionsFoundException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception is thrown if dotnet publish attempt failed
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DotnetPublishFailedException : Exception
+    public class DotnetPublishFailedException : DeployToolException
     {
-        public DotnetPublishFailedException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DotnetPublishFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if Zip File Manager fails to create a Zip File
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToCreateZipFileException : Exception
+    public class FailedToCreateZipFileException : DeployToolException
     {
-        public FailedToCreateZipFileException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToCreateZipFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if Docker file could not be generated
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToGenerateDockerFileException : Exception
+    public class FailedToGenerateDockerFileException : DeployToolException
     {
-        public FailedToGenerateDockerFileException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToGenerateDockerFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if RecipePath contains an invalid path
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidRecipePathException : Exception
+    public class InvalidRecipePathException : DeployToolException
     {
-        public InvalidRecipePathException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidRecipePathException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if Solution Path contains an invalid path
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidSolutionPathException : Exception
+    public class InvalidSolutionPathException : DeployToolException
     {
-        public InvalidSolutionPathException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidSolutionPathException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if AWS Deploy Recipes CDK Common Product Version is invalid.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidAWSDeployRecipesCDKCommonVersionException : Exception
+    public class InvalidAWSDeployRecipesCDKCommonVersionException : DeployToolException
     {
-        public InvalidAWSDeployRecipesCDKCommonVersionException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidAWSDeployRecipesCDKCommonVersionException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if the 'cdk deploy' command failed.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToDeployCDKAppException : Exception
+    public class FailedToDeployCDKAppException : DeployToolException
     {
-        public FailedToDeployCDKAppException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToDeployCDKAppException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if an AWS Resource is not found or does not exist.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class AWSResourceNotFoundException : Exception
+    public class AWSResourceNotFoundException : DeployToolException
     {
-        public AWSResourceNotFoundException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public AWSResourceNotFoundException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if the Local User Settings File is invalid.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class InvalidLocalUserSettingsFileException : Exception
+    public class InvalidLocalUserSettingsFileException : DeployToolException
     {
-        public InvalidLocalUserSettingsFileException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public InvalidLocalUserSettingsFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Exception thrown if a failure occured while trying to update the Local User Settings file.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class FailedToUpdateLocalUserSettingsFileException : Exception
+    public class FailedToUpdateLocalUserSettingsFileException : DeployToolException
     {
-        public FailedToUpdateLocalUserSettingsFileException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>
     /// Throw if docker info failed to return output.
     /// </summary>
-    [AWSDeploymentExpectedException]
-    public class DockerInfoException : Exception
+    public class DockerInfoException : DeployToolException
     {
-        public DockerInfoException(string message, Exception? innerException = null) : base(message, innerException) { }
+        public DockerInfoException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 }

--- a/src/AWS.Deploy.Orchestration/LocalUserSettings/LocalUserSettingsEngine.cs
+++ b/src/AWS.Deploy.Orchestration/LocalUserSettings/LocalUserSettingsEngine.cs
@@ -42,9 +42,9 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             try
             {
                 if (string.IsNullOrEmpty(projectName))
-                    throw new FailedToUpdateLocalUserSettingsFileException("The Project Name is not defined.");
+                    throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, "The Project Name is not defined.");
                 if (string.IsNullOrEmpty(awsAccountId) || string.IsNullOrEmpty(awsRegion))
-                    throw new FailedToUpdateLocalUserSettingsFileException("The AWS Account Id or Region is not defined.");
+                    throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, "The AWS Account Id or Region is not defined.");
 
                 var localUserSettings = await GetLocalUserSettings();
                 var lastDeployedStack = localUserSettings?.LastDeployedStacks?
@@ -105,7 +105,7 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             }
             catch (Exception ex)
             {
-                throw new FailedToUpdateLocalUserSettingsFileException($"Failed to update the local user settings file " +
+                throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, $"Failed to update the local user settings file " +
                     $"to include the last deployed to stack '{stackName}'.", ex);
             }
         }
@@ -118,9 +118,9 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             try
             {
                 if (string.IsNullOrEmpty(projectName))
-                    throw new FailedToUpdateLocalUserSettingsFileException("The Project Name is not defined.");
+                    throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, "The Project Name is not defined.");
                 if (string.IsNullOrEmpty(awsAccountId) || string.IsNullOrEmpty(awsRegion))
-                    throw new FailedToUpdateLocalUserSettingsFileException("The AWS Account Id or Region is not defined.");
+                    throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, "The AWS Account Id or Region is not defined.");
 
                 var localUserSettings = await GetLocalUserSettings();
                 var lastDeployedStack = localUserSettings?.LastDeployedStacks?
@@ -135,7 +135,7 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             }
             catch (Exception ex)
             {
-                throw new FailedToUpdateLocalUserSettingsFileException($"Failed to update the local user settings file " +
+                throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, $"Failed to update the local user settings file " +
                     $"to delete the stack '{stackName}'.", ex);
             }
         }
@@ -148,9 +148,9 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             try
             {
                 if (string.IsNullOrEmpty(projectName))
-                    throw new FailedToUpdateLocalUserSettingsFileException("The Project Name is not defined.");
+                    throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, "The Project Name is not defined.");
                 if (string.IsNullOrEmpty(awsAccountId) || string.IsNullOrEmpty(awsRegion))
-                    throw new FailedToUpdateLocalUserSettingsFileException("The AWS Account Id or Region is not defined.");
+                    throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, "The AWS Account Id or Region is not defined.");
 
                 var localUserSettings = await GetLocalUserSettings();
                 var localStacks = localUserSettings?.LastDeployedStacks?
@@ -167,7 +167,7 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             }
             catch (Exception ex)
             {
-                throw new FailedToUpdateLocalUserSettingsFileException($"Failed to update the local user settings file " +
+                throw new FailedToUpdateLocalUserSettingsFileException(DeployToolErrorCode.FailedToUpdateLocalUserSettingsFile, $"Failed to update the local user settings file " +
                     $"to delete orphan stacks.", ex);
             }
         }
@@ -204,7 +204,7 @@ namespace AWS.Deploy.Orchestration.LocalUserSettings
             }
             catch (Exception ex)
             {
-                throw new InvalidLocalUserSettingsFileException("The Local User Settings file is invalid.", ex);
+                throw new InvalidLocalUserSettingsFileException(DeployToolErrorCode.InvalidLocalUserSettingsFile, "The Local User Settings file is invalid.", ex);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -107,7 +107,7 @@ namespace AWS.Deploy.Orchestration
             if (_directoryManager == null)
                 throw new InvalidOperationException($"{nameof(_directoryManager)} is null as part of the orchestartor object");
             if (!_directoryManager.Exists(deploymentProjectPath))
-                throw new InvalidCliArgumentException($"The path '{deploymentProjectPath}' does not exists on the file system. Please provide a valid deployment project path and try again.");
+                throw new InvalidCliArgumentException(DeployToolErrorCode.DeploymentProjectPathNotFound, $"The path '{deploymentProjectPath}' does not exists on the file system. Please provide a valid deployment project path and try again.");
 
             var engine = new RecommendationEngine.RecommendationEngine(new List<string> { deploymentProjectPath }, _session);
             var additionalReplacements = await GetReplacements();
@@ -199,7 +199,7 @@ namespace AWS.Deploy.Orchestration
                 }
                 catch (DockerEngineExceptionBase ex)
                 {
-                    throw new FailedToGenerateDockerFileException("Failed to generate a docker file", ex);
+                    throw new FailedToGenerateDockerFileException(DeployToolErrorCode.FailedToGenerateDockerFile, "Failed to generate a docker file", ex);
                 }
             }
 

--- a/src/AWS.Deploy.Orchestration/RecipeHandler.cs
+++ b/src/AWS.Deploy.Orchestration/RecipeHandler.cs
@@ -51,7 +51,7 @@ namespace AWS.Deploy.Orchestration
             }
             catch(IOException)
             {
-                throw new NoRecipeDefinitionsFoundException("Failed to find recipe definitions");
+                throw new NoRecipeDefinitionsFoundException(DeployToolErrorCode.FailedToFindRecipeDefinitions, "Failed to find recipe definitions");
             }
 
             return recipeDefinitions;

--- a/src/AWS.Deploy.Orchestration/RecommendationEngine/RecommendationEngine.cs
+++ b/src/AWS.Deploy.Orchestration/RecommendationEngine/RecommendationEngine.cs
@@ -101,10 +101,10 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
             }
             catch(IOException)
             {
-                throw new NoDeploymentBundleDefinitionsFoundException("Failed to find a deployment bundle definition");
+                throw new NoDeploymentBundleDefinitionsFoundException(DeployToolErrorCode.DeploymentBundleDefinitionNotFound, "Failed to find a deployment bundle definition");
             }
 
-            throw new NoDeploymentBundleDefinitionsFoundException("Failed to find a deployment bundle definition");
+            throw new NoDeploymentBundleDefinitionsFoundException(DeployToolErrorCode.DeploymentBundleDefinitionNotFound, "Failed to find a deployment bundle definition");
         }
 
         public async Task<RulesResult> EvaluateRules(IList<RecommendationRuleItem> rules)
@@ -125,7 +125,7 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
                 {
                     if(!availableTests.TryGetValue(test.Type, out var testInstance))
                     {
-                        throw new InvalidRecipeDefinitionException($"Invalid test type [{test.Type}] found in rule.");
+                        throw new InvalidRecipeDefinitionException(DeployToolErrorCode.RuleHasInvalidTestType, $"Invalid test type [{test.Type}] found in rule.");
                     }
 
                     var input = new RecommendationTestInput(

--- a/src/AWS.Deploy.Orchestration/SystemCapabilityEvaluator.cs
+++ b/src/AWS.Deploy.Orchestration/SystemCapabilityEvaluator.cs
@@ -50,7 +50,7 @@ namespace AWS.Deploy.Orchestration
                     processExitCode = proc.ExitCode;
                     containerType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                         proc.StandardOut?.TrimEnd('\n') ??
-                            throw new DockerInfoException("Failed to check if Docker is running in Windows or Linux container mode.") :
+                            throw new DockerInfoException(DeployToolErrorCode.FailedToCheckDockerInfo, "Failed to check if Docker is running in Windows or Linux container mode.") :
                         "linux";
                 });
 

--- a/src/AWS.Deploy.Orchestration/TemplateEngine.cs
+++ b/src/AWS.Deploy.Orchestration/TemplateEngine.cs
@@ -46,7 +46,7 @@ namespace AWS.Deploy.Orchestration
             //The location of the base template that will be installed into the templating engine
             var cdkProjectTemplateDirectory = Path.Combine(
                 Path.GetDirectoryName(recommendation.Recipe.RecipePath) ??
-                    throw new InvalidRecipePathException($"The following RecipePath is invalid as we could not retrieve the parent directory: {recommendation.Recipe.RecipePath}"),
+                    throw new InvalidRecipePathException(DeployToolErrorCode.BaseTemplatesInvalidPath, $"The following RecipePath is invalid as we could not retrieve the parent directory: {recommendation.Recipe.RecipePath}"),
                 recommendation.Recipe.CdkProjectTemplate);
 
             //Installing the base template into the templating engine to make it available for generation
@@ -69,7 +69,7 @@ namespace AWS.Deploy.Orchestration
                 // CDK Template projects can parameterize the version number of the AWS.Deploy.Recipes.CDK.Common package. This avoid
                 // projects having to be modified every time the package version is bumped.
                 { "AWSDeployRecipesCDKCommonVersion", FileVersionInfo.GetVersionInfo(typeof(Constants.CloudFormationIdentifier).Assembly.Location).ProductVersion
-                                                      ?? throw new InvalidAWSDeployRecipesCDKCommonVersionException("The version number of the AWS.Deploy.Recipes.CDK.Common package is invalid.") }
+                                                      ?? throw new InvalidAWSDeployRecipesCDKCommonVersionException(DeployToolErrorCode.InvalidAWSDeployRecipesCDKCommonVersion, "The version number of the AWS.Deploy.Recipes.CDK.Common package is invalid.") }
             };
 
             try
@@ -82,7 +82,7 @@ namespace AWS.Deploy.Orchestration
             }
             catch
             {
-                throw new TemplateGenerationFailedException("Failed to generate CDK project from template");
+                throw new TemplateGenerationFailedException(DeployToolErrorCode.FailedToGenerateCDKProjectFromTemplate, "Failed to generate CDK project from template");
             }
         }
 
@@ -97,7 +97,7 @@ namespace AWS.Deploy.Orchestration
             }
             catch(Exception e)
             {
-                throw new DefaultTemplateInstallationFailedException("Failed to install the default template that is required to the generate the CDK project", e);
+                throw new DefaultTemplateInstallationFailedException(DeployToolErrorCode.FailedToInstallProjectTemplates, "Failed to install the default template that is required to the generate the CDK project", e);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/Utilities/TemplateMetadataReader.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/TemplateMetadataReader.cs
@@ -78,7 +78,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             }
             catch(Exception e)
             {
-                throw new ParsingExistingCloudApplicationMetadataException("Error parsing existing application's metadata", e);
+                throw new ParsingExistingCloudApplicationMetadataException(DeployToolErrorCode.ErrorParsingApplicationMetadata, "Error parsing existing application's metadata", e);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/Utilities/ZipFileManager.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/ZipFileManager.cs
@@ -8,6 +8,7 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.Orchestration.Utilities
@@ -48,7 +49,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             var zipCLI = FindExecutableInPath("zip");
 
             if (string.IsNullOrEmpty(zipCLI))
-                throw new FailedToCreateZipFileException("Failed to find the \"zip\" utility program in path. This program is required to maintain Linux file permissions in the zip archive.");
+                throw new FailedToCreateZipFileException(DeployToolErrorCode.FailedToFindZipUtility, "Failed to find the \"zip\" utility program in path. This program is required to maintain Linux file permissions in the zip archive.");
 
             var args = new StringBuilder($"\"{destinationArchiveFileName}\"");
 
@@ -61,7 +62,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             var command = $"{zipCLI} {args}";
             var result = await _commandLineWrapper.TryRunWithResult(command, sourceDirectoryName);
             if (result.ExitCode != 0)
-                throw new FailedToCreateZipFileException("\"zip\" utility program has failed to create a zip archive.");
+                throw new FailedToCreateZipFileException(DeployToolErrorCode.ZipUtilityFailedToZip, "\"zip\" utility program has failed to create a zip archive.");
         }
 
         /// <summary>

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1477,6 +1477,18 @@ namespace AWS.Deploy.ServerMode.Client
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public partial class DeployToolExceptionSummary 
+    {
+        [Newtonsoft.Json.JsonProperty("errorCode", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ErrorCode { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("message", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Message { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
     public partial class DisplayedResourceSummary 
     {
         /// <summary>The Physical ID that represents a CloudFormation resource</summary>
@@ -1566,6 +1578,9 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public DeploymentStatus Status { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("exception", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public DeployToolExceptionSummary Exception { get; set; }
     
     
     }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5509
*Description of changes:*
The expected exceptions now include an error code that represents a failure. Error codes are not a 1:1 map with exceptions. 1 exception used in multiple places could have different error codes.
all expected exceptions now inherit from a Deploy Tool base exception, and that base exception is checked in the server mode controller GetDeploymentStatus.
We check if an exception occurred during the execution of the DeploymentTask and we surface it in the API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
