### PR TITLE
feat: Add ability to set Reverse Proxy in Beanstalk deployment

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -61,6 +61,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         /// </summary>
         public bool XRayTracingSupportEnabled { get; set; } = false;
 
+        /// <summary>
+        /// The reverse proxy to use. 
+        /// </summary>
+        public string ReverseProxy { get; set; } = Recipe.REVERSEPROXY_NGINX;
+
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
         /// The warnings are disabled since a parameterless constructor will allow non-nullable properties to be initialized with null values.
@@ -81,6 +86,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             ElasticBeanstalkManagedPlatformUpdatesConfiguration elasticBeanstalkManagedPlatformUpdates,
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
             string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
+            string reverseProxy = Recipe.REVERSEPROXY_NGINX,
             bool xrayTracingSupportEnabled = false)
         {
             ApplicationIAMRole = applicationIAMRole;
@@ -93,6 +99,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;
+            ReverseProxy = reverseProxy;
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -26,6 +26,8 @@ namespace AspNetAppElasticBeanstalkLinux
 
         public const string LOADBALANCERTYPE_APPLICATION = "application";
 
+        public const string REVERSEPROXY_NGINX = "nginx";
+
         public IRole? AppIAMRole { get; private set; }
 
         public IRole? BeanstalkServiceRole { get; private set; }
@@ -218,6 +220,18 @@ namespace AspNetAppElasticBeanstalkLinux
                     OptionName = "UpdateLevel",
                     Value = settings.ElasticBeanstalkManagedPlatformUpdates.UpdateLevel
                 });
+            }
+
+            if (!string.IsNullOrEmpty(settings.ReverseProxy))
+            {
+                optionSettingProperties.Add(
+                    new CfnEnvironment.OptionSettingProperty
+                    {
+                        Namespace = "aws:elasticbeanstalk:environment:proxy",
+                        OptionName = "ProxyServer",
+                        Value = settings.ReverseProxy
+                    }
+                );
             }
 
             BeanstalkEnvironment = new CfnEnvironment(this, nameof(BeanstalkEnvironment), InvokeCustomizeCDKPropsEvent(nameof(BeanstalkEnvironment), this, new CfnEnvironmentProps

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -338,6 +338,19 @@
             "DefaultValue": false,
             "AdvancedSetting": true,
             "Updatable": true
+        },
+        {
+            "Id": "ReverseProxy",
+            "Name": "Reverse Proxy",
+            "Description": "By default Nginx is used as a reverse proxy in front of the .NET Core web server Kestrel. To use Kestrel as the front facing web server then select `none` as the reverse proxy.",
+            "Type": "String",
+            "DefaultValue": "nginx",
+            "AllowedValues": [
+                "nginx",
+                "none"
+            ],
+            "AdvancedSetting": true,
+            "Updatable": true
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4805

*Description of changes:*
Added Reverse Proxy configuration for Beanstalk deployments.
![image](https://user-images.githubusercontent.com/53088140/142675298-d6d17b72-3031-4d59-871e-72b2b7b23b8d.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
