### PR TITLE
feat: Add AWS X-Ray Tracing support to beanstalk deployments

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -56,6 +56,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         /// </summary>
         public ElasticBeanstalkManagedPlatformUpdatesConfiguration ElasticBeanstalkManagedPlatformUpdates { get; set; }
 
+        /// <summary>
+        /// Specifies whether to enable or disable AWS X-Ray tracing support.
+        /// </summary>
+        public bool XRayTracingSupportEnabled { get; set; } = false;
+
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
         /// The warnings are disabled since a parameterless constructor will allow non-nullable properties to be initialized with null values.
@@ -75,7 +80,8 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             string ec2KeyPair,
             ElasticBeanstalkManagedPlatformUpdatesConfiguration elasticBeanstalkManagedPlatformUpdates,
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
-            string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION)
+            string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
+            bool xrayTracingSupportEnabled = false)
         {
             ApplicationIAMRole = applicationIAMRole;
             InstanceType = instanceType;
@@ -86,6 +92,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             ElasticBeanstalkManagedPlatformUpdates = elasticBeanstalkManagedPlatformUpdates;
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
+            XRayTracingSupportEnabled = xrayTracingSupportEnabled;
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -144,6 +144,12 @@ namespace AspNetAppElasticBeanstalkLinux
                         Namespace = "aws:elasticbeanstalk:managedactions",
                         OptionName = "ManagedActionsEnabled",
                         Value = settings.ElasticBeanstalkManagedPlatformUpdates.ManagedActionsEnabled.ToString().ToLower()
+                   },
+                   new CfnEnvironment.OptionSettingProperty
+                   {
+                        Namespace = "aws:elasticbeanstalk:xray",
+                        OptionName = "XRayEnabled",
+                        Value = settings.XRayTracingSupportEnabled.ToString().ToLower()
                    }
                 };
 

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -329,6 +329,15 @@
                     ]
                 }
             ]
+        },
+        {
+            "Id": "XRayTracingSupportEnabled",
+            "Name": "Enable AWS X-Ray Tracing Support",
+            "Description": "AWS X-Ray is a service that collects data about requests that your application serves, and provides tools you can use to view, filter, and gain insights into that data to identify issues and opportunities for optimization. Do you want to enable AWS X-Ray tracing support?",
+            "Type": "Bool",
+            "DefaultValue": false,
+            "AdvancedSetting": true,
+            "Updatable": true
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4806

*Description of changes:*
Add AWS X-Ray Tracing support to beanstalk deployments
![image](https://user-images.githubusercontent.com/53088140/142695288-fd8ecadb-76ad-4866-89e3-3a323a44db2a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
