### PR TITLE
feat: add enhanced health reporting setting to beanstalk deployments

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -65,6 +65,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         /// The reverse proxy to use. 
         /// </summary>
         public string ReverseProxy { get; set; } = Recipe.REVERSEPROXY_NGINX;
+        
+        /// <summary>
+        /// Specifies whether to enable or disable enhanced health reporting.
+        /// </summary>
+        public string EnhancedHealthReporting { get; set; } = Recipe.ENHANCED_HEALTH_REPORTING;
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
@@ -87,7 +92,8 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
             string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
             string reverseProxy = Recipe.REVERSEPROXY_NGINX,
-            bool xrayTracingSupportEnabled = false)
+            bool xrayTracingSupportEnabled = false,
+            string enhancedHealthReporting = Recipe.ENHANCED_HEALTH_REPORTING)
         {
             ApplicationIAMRole = applicationIAMRole;
             InstanceType = instanceType;
@@ -100,6 +106,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             LoadBalancerType = loadBalancerType;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;
             ReverseProxy = reverseProxy;
+            EnhancedHealthReporting = enhancedHealthReporting;
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -27,6 +27,8 @@ namespace AspNetAppElasticBeanstalkLinux
         public const string LOADBALANCERTYPE_APPLICATION = "application";
 
         public const string REVERSEPROXY_NGINX = "nginx";
+        
+        public const string ENHANCED_HEALTH_REPORTING = "enhanced";
 
         public IRole? AppIAMRole { get; private set; }
 
@@ -152,6 +154,12 @@ namespace AspNetAppElasticBeanstalkLinux
                         Namespace = "aws:elasticbeanstalk:xray",
                         OptionName = "XRayEnabled",
                         Value = settings.XRayTracingSupportEnabled.ToString().ToLower()
+                   },
+                   new CfnEnvironment.OptionSettingProperty
+                   {
+                        Namespace = "aws:elasticbeanstalk:healthreporting:system",
+                        OptionName = "SystemType",
+                        Value = settings.EnhancedHealthReporting
                    }
                 };
 

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -74,8 +74,6 @@
         }
     ],
 
-
-
     "OptionSettings": [
         {
             "Id": "BeanstalkApplication",
@@ -351,6 +349,29 @@
             ],
             "AdvancedSetting": true,
             "Updatable": true
+        },
+        {
+            "Id": "EnhancedHealthReporting",
+            "Name": "Enhanced Health Reporting",
+            "Description": "Enhanced health reporting provides free real-time application and operating system monitoring of the instances and other resources in your environment.",
+            "Type": "String",
+            "DefaultValue": "enhanced",
+            "AllowedValues": [
+                "enhanced",
+                "basic"
+            ],
+            "ValueMapping": {
+                "enhanced": "Enhanced",
+                "basic": "Basic"
+            },
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "DependsOn": [
+                {
+                    "Id": "ElasticBeanstalkManagedPlatformUpdates.ManagedActionsEnabled",
+                    "Value": false
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4807

*Description of changes:*
add enhanced health reporting setting to beanstalk deployments
add recipe validator because disabling enhanced health reporting is not compatible with enabled managed platform updates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
