### PR TITLE
feat: add rolling updates configuration to beanstalk deployments

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -25,6 +25,7 @@ namespace AWS.Deploy.Common.Recipes
         DynamoDBTableName,
         SQSQueueUrl,
         SNSTopicArn,
-        S3BucketName
+        S3BucketName,
+        BeanstalkRollingUpdates
     };
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
@@ -20,9 +20,13 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// Supports replacement tokens {{Min}} and {{Max}}
         /// </summary>
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
+        public bool AllowEmptyString { get; set; }
 
         public ValidationResult Validate(object input)
         {
+            if (AllowEmptyString && string.IsNullOrEmpty(input?.ToString()))
+                return ValidationResult.Valid();
+
             if (int.TryParse(input?.ToString(), out var result) &&
                 result >= Min &&
                 result <= Max)

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -75,6 +75,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         /// The health check URL to use.
         /// </summary>
         public string HealthCheckURL { get; set; }
+        
+        /// <summary>
+        /// Specifies whether to enable or disable Rolling Updates.
+        /// </summary>
+        public ElasticBeanstalkRollingUpdatesConfiguration ElasticBeanstalkRollingUpdates { get; set; }
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
@@ -95,6 +100,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             string ec2KeyPair,
             ElasticBeanstalkManagedPlatformUpdatesConfiguration elasticBeanstalkManagedPlatformUpdates,
             string healthCheckURL,
+            ElasticBeanstalkRollingUpdatesConfiguration elasticBeanstalkRollingUpdates,
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
             string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
             string reverseProxy = Recipe.REVERSEPROXY_NGINX,
@@ -108,6 +114,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             ElasticBeanstalkPlatformArn = elasticBeanstalkPlatformArn;
             EC2KeyPair = ec2KeyPair;
             ElasticBeanstalkManagedPlatformUpdates = elasticBeanstalkManagedPlatformUpdates;
+            ElasticBeanstalkRollingUpdates = elasticBeanstalkRollingUpdates;
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/ElasticBeanstalkRollingUpdatesConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/ElasticBeanstalkRollingUpdatesConfiguration.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a generated file from the original deployment recipe. It contains properties for
+// all of the settings defined in the recipe file. It is recommended to not modify this file in order
+// to allow easy updates to the file when the original recipe that this project was created from has updates.
+// This class is marked as a partial class. If you add new settings to the recipe file, those settings should be
+// added to partial versions of this class outside of the Generated folder for example in the Configuration folder.
+
+namespace AspNetAppElasticBeanstalkLinux.Configurations
+{
+    public partial class ElasticBeanstalkRollingUpdatesConfiguration
+    {
+        public bool RollingUpdatesEnabled { get; set; } = false;
+        public string RollingUpdateType { get; set; } = "Time";
+        public int? MaxBatchSize { get; set; }
+        public int? MinInstancesInService { get; set; }
+        public string? PauseTime { get; set; }
+        public string Timeout { get; set; } = "PT30M";
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -262,6 +262,60 @@ namespace AspNetAppElasticBeanstalkLinux
                     }
                 );
             }
+            
+            if (settings.ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled)
+            {
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:autoscaling:updatepolicy:rollingupdate",
+                    OptionName = "RollingUpdateEnabled",
+                    Value = settings.ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled.ToString().ToLower()
+                });
+
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:autoscaling:updatepolicy:rollingupdate",
+                    OptionName = "RollingUpdateType",
+                    Value = settings.ElasticBeanstalkRollingUpdates.RollingUpdateType
+                });
+
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:autoscaling:updatepolicy:rollingupdate",
+                    OptionName = "Timeout",
+                    Value = settings.ElasticBeanstalkRollingUpdates.Timeout
+                });
+
+                if (settings.ElasticBeanstalkRollingUpdates.MaxBatchSize != null)
+                {
+                    optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                    {
+                        Namespace = "aws:autoscaling:updatepolicy:rollingupdate",
+                        OptionName = "MaxBatchSize",
+                        Value = settings.ElasticBeanstalkRollingUpdates.MaxBatchSize.ToString()
+                    });
+                }
+
+                if (settings.ElasticBeanstalkRollingUpdates.MinInstancesInService != null)
+                {
+                    optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                    {
+                        Namespace = "aws:autoscaling:updatepolicy:rollingupdate",
+                        OptionName = "MinInstancesInService",
+                        Value = settings.ElasticBeanstalkRollingUpdates.MinInstancesInService.ToString()
+                    });
+                }
+
+                if (settings.ElasticBeanstalkRollingUpdates.PauseTime != null)
+                {
+                    optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                    {
+                        Namespace = "aws:autoscaling:updatepolicy:rollingupdate",
+                        OptionName = "PauseTime",
+                        Value = settings.ElasticBeanstalkRollingUpdates.PauseTime
+                    });
+                }
+            }
 
             BeanstalkEnvironment = new CfnEnvironment(this, nameof(BeanstalkEnvironment), InvokeCustomizeCDKPropsEvent(nameof(BeanstalkEnvironment), this, new CfnEnvironmentProps
             {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -387,6 +387,149 @@
             ],
             "AdvancedSetting": true,
             "Updatable": true
+        },
+        {
+            "Id": "ElasticBeanstalkRollingUpdates",
+            "Name": "Rolling Updates",
+            "Description": "When a configuration change requires replacing instances, Elastic Beanstalk can perform the update in batches to avoid downtime while the change is propagated. During a rolling update, capacity is only reduced by the size of a single batch, which you can configure. Elastic Beanstalk takes one batch of instances out of service, terminates them, and then launches a batch with the new configuration. After the new batch starts serving requests, Elastic Beanstalk moves on to the next batch.",
+            "Type": "Object",
+            "TypeHint": "BeanstalkRollingUpdates",
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "DependsOn": [
+                {
+                    "Id": "EnvironmentType",
+                    "Value": "LoadBalanced"
+                }
+            ],
+            "ChildOptionSettings": [
+                {
+                    "Id": "RollingUpdatesEnabled",
+                    "Name": "Enable Rolling Updates",
+                    "Description": "Do you want to enable Rolling Updates?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": true,
+                    "Updatable": true
+                },
+                {
+                    "Id": "RollingUpdateType",
+                    "Name": "Rolling Update Type",
+                    "Description": "This includes three types: time-based rolling updates, health-based rolling updates, and immutable updates. Time-based rolling updates apply a PauseTime between batches. Health-based rolling updates wait for new instances to pass health checks before moving on to the next batch. Immutable updates launch a full set of instances in a new Auto Scaling group.",
+                    "Type": "String",
+                    "DefaultValue": "Time",
+                    "AllowedValues": [
+                        "Time",
+                        "Health",
+                        "Immutable"
+                    ],
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
+                    "Id": "MaxBatchSize",
+                    "Name": "Max Batch Size",
+                    "Description": "The number of instances included in each batch of the rolling update.",
+                    "Type": "Int",
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled",
+                            "Value": true
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1,
+                                "Max": 10000,
+                                "AllowEmptyString": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "MinInstancesInService",
+                    "Name": "Min Instances In Service",
+                    "Description": "The minimum number of instances that must be in service within the Auto Scaling group while other instances are terminated.",
+                    "Type": "Int",
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled",
+                            "Value": true
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 9999,
+                                "AllowEmptyString": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "PauseTime",
+                    "Name": "Pause Time",
+                    "Description": "The amount of time (in seconds, minutes, or hours) the Elastic Beanstalk service waits after it completed updates to one batch of instances and before it continues on to the next batch. (ISO8601 duration format: PT#H#M#S where each # is the number of hours, minutes, and/or seconds, respectively.)",
+                    "Type": "String",
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled",
+                            "Value": true
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^P([0-9]+(?:[,\\.][0-9]+)?Y)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?D)?(?:T([0-9]+(?:[,\\.][0-9]+)?H)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?S)?)?$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid PauseTime. The PauseTime follows the ISO8601 duration format: PT#H#M#S where each # is the number of hours, minutes, and/or seconds, respectively."
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "Timeout",
+                    "Name": "Timeout",
+                    "Description": "The maximum amount of time (in minutes or hours) to wait for all instances in a batch of instances to pass health checks before canceling the update. (ISO8601 duration format: PT#H#M#S where each # is the number of hours, minutes, and/or seconds, respectively.)",
+                    "Type": "String",
+                    "DefaultValue": "PT30M",
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "ElasticBeanstalkRollingUpdates.RollingUpdatesEnabled",
+                            "Value": true
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^P([0-9]+(?:[,\\.][0-9]+)?Y)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?D)?(?:T([0-9]+(?:[,\\.][0-9]+)?H)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?S)?)?$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid Timeout. The Timeout follows the ISO8601 duration format: PT#H#M#S where each # is the number of hours, minutes, and/or seconds, respectively."
+                            }
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
@@ -78,6 +78,20 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             Validate(optionSettingItem, value, isValid);
         }
 
+        [Theory]
+        [InlineData("PT10M", true)]
+        [InlineData("PT1H", true)]
+        [InlineData("PT25S", true)]
+        [InlineData("PT1H20M30S", true)]
+        [InlineData("invalid", false)]
+        [InlineData("PTB1H20M30S", false)]
+        public void ElasticBeanstalkRollingUpdatesPauseTime(string value, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("^P([0-9]+(?:[,\\.][0-9]+)?Y)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?D)?(?:T([0-9]+(?:[,\\.][0-9]+)?H)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?S)?)?$"));
+            Validate(optionSettingItem, value, isValid);
+        }
+
         private OptionSettingItemValidatorConfig GetRegexValidatorConfig(string regex)
         {
             var regexValidatorConfig = new OptionSettingItemValidatorConfig


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4810

*Description of changes:*
add rolling updates configuration to beanstalk deployments
add new validator that allows null and empty values for int types. We need this because "MaxBatchSize" and "MinInstancesInService" have default values that are calculated dynamically in beanstalk and cannot be specified in the recipe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
