### PR TITLE
feat: add environment variables config to beanstalk deployments

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -114,7 +114,7 @@ namespace AWS.Deploy.Common.Recipes
                 !AllowedValues.Contains(valueOverride.ToString() ?? ""))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, $"Invalid value for option setting item '{Name}'");
 
-            if (valueOverride is bool || valueOverride is int || valueOverride is long || valueOverride is double)
+            if (valueOverride is bool || valueOverride is int || valueOverride is long || valueOverride is double || valueOverride is Dictionary<string, string>)
             {
                 _valueOverride = valueOverride;
             }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingValueType.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingValueType.cs
@@ -9,6 +9,7 @@ namespace AWS.Deploy.Common.Recipes
         Int,
         Double,
         Bool,
+        KeyValue,
         Object
     };
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -7,6 +7,8 @@
 // This class is marked as a partial class. If you add new settings to the recipe file, those settings should be
 // added to partial versions of this class outside of the Generated folder for example in the Configuration folder.
 
+using System.Collections.Generic;
+
 namespace AspNetAppElasticBeanstalkLinux.Configurations
 {
     public partial class Configuration
@@ -86,6 +88,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         /// </summary>
         public string CNamePrefix { get; set; }
 
+        /// <summary>
+        /// The environment variables that are set for the beanstalk environment.
+        /// </summary>
+        public Dictionary<string, string> ElasticBeanstalkEnvironmentVariables { get; set; } = new Dictionary<string, string> { };
+
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
         /// The warnings are disabled since a parameterless constructor will allow non-nullable properties to be initialized with null values.
@@ -107,6 +114,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             string healthCheckURL,
             ElasticBeanstalkRollingUpdatesConfiguration elasticBeanstalkRollingUpdates,
             string cnamePrefix,
+            Dictionary<string, string> elasticBeanstalkEnvironmentVariables,
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
             string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
             string reverseProxy = Recipe.REVERSEPROXY_NGINX,
@@ -121,6 +129,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             EC2KeyPair = ec2KeyPair;
             ElasticBeanstalkManagedPlatformUpdates = elasticBeanstalkManagedPlatformUpdates;
             ElasticBeanstalkRollingUpdates = elasticBeanstalkRollingUpdates;
+            ElasticBeanstalkEnvironmentVariables = elasticBeanstalkEnvironmentVariables;
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -317,6 +317,19 @@ namespace AspNetAppElasticBeanstalkLinux
                 }
             }
 
+            if (settings.ElasticBeanstalkEnvironmentVariables != null)
+            {
+                foreach (var (key, value) in settings.ElasticBeanstalkEnvironmentVariables)
+                {
+                    optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                    {
+                        Namespace = "aws:elasticbeanstalk:application:environment",
+                        OptionName = key,
+                        Value = value
+                    });
+                }
+            }
+
             BeanstalkEnvironment = new CfnEnvironment(this, nameof(BeanstalkEnvironment), InvokeCustomizeCDKPropsEvent(nameof(BeanstalkEnvironment), this, new CfnEnvironmentProps
             {
                 EnvironmentName = settings.EnvironmentName,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -539,6 +539,14 @@
             "DefaultValue": "",
             "AdvancedSetting": true,
             "Updatable": false
+        },
+        {
+            "Id": "ElasticBeanstalkEnvironmentVariables",
+            "Name": "Environment Variables",
+            "Description": "Configure environment properties for your application.",
+            "Type": "KeyValue",
+            "AdvancedSetting": false,
+            "Updatable": true
         }
     ]
 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkKeyValueDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkKeyValueDeploymentTest.cs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using AWS.Deploy.Common;
+using Xunit;
+
+namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
+{
+    public class ElasticBeanStalkKeyValueDeploymentTest
+    {
+        private readonly UserDeploymentSettings _userDeploymentSettings;
+        public ElasticBeanStalkKeyValueDeploymentTest()
+        {
+            var filePath = Path.Combine("ConfigFileDeployment", "TestFiles", "UnitTestFiles", "ElasticBeanStalkKeyPairConfigFile.json");
+            var userDeploymentSettings = UserDeploymentSettings.ReadSettings(filePath);
+            _userDeploymentSettings = userDeploymentSettings;
+        }
+
+        [Fact]
+        public void VerifyJsonParsing()
+        {
+            Assert.Equal("default", _userDeploymentSettings.AWSProfile);
+            Assert.Equal("us-west-2", _userDeploymentSettings.AWSRegion);
+            Assert.Equal("MyAppStack", _userDeploymentSettings.StackName);
+            Assert.Equal("AspNetAppElasticBeanstalkLinux", _userDeploymentSettings.RecipeId);
+
+            var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;
+            Assert.Equal("True", optionSettingDictionary["BeanstalkApplication.CreateNew"]);
+            Assert.Equal("MyApplication", optionSettingDictionary["BeanstalkApplication.ApplicationName"]);
+            Assert.Equal("MyEnvironment", optionSettingDictionary["EnvironmentName"]);
+            Assert.Equal("MyInstance", optionSettingDictionary["InstanceType"]);
+            Assert.Equal("SingleInstance", optionSettingDictionary["EnvironmentType"]);
+            Assert.Equal("application", optionSettingDictionary["LoadBalancerType"]);
+            Assert.Equal("True", optionSettingDictionary["ApplicationIAMRole.CreateNew"]);
+            Assert.Equal("MyPlatformArn", optionSettingDictionary["ElasticBeanstalkPlatformArn"]);
+            Assert.Equal("True", optionSettingDictionary["ElasticBeanstalkManagedPlatformUpdates.ManagedActionsEnabled"]);
+            Assert.Equal("Mon:12:00", optionSettingDictionary["ElasticBeanstalkManagedPlatformUpdates.PreferredStartTime"]);
+            Assert.Equal("minor", optionSettingDictionary["ElasticBeanstalkManagedPlatformUpdates.UpdateLevel"]);
+            Assert.Equal("VarValue", optionSettingDictionary["ElasticBeanstalkEnvironmentVariables.VarName"]);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkKeyPairConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkKeyPairConfigFile.json
@@ -1,0 +1,33 @@
+{
+    "AWSProfile": "default",
+    "AWSRegion": "us-west-2",
+    "StackName": "MyAppStack",
+    "RecipeId": "AspNetAppElasticBeanstalkLinux",
+    "OptionSettingsConfig":
+    {
+        "BeanstalkApplication": 
+        {
+            "CreateNew": true,
+            "ApplicationName": "MyApplication"
+        },
+        "EnvironmentName": "MyEnvironment",
+        "InstanceType": "MyInstance",
+        "EnvironmentType": "SingleInstance",
+        "LoadBalancerType": "application",
+        "ApplicationIAMRole":
+        {
+            "CreateNew": true
+        },
+        "ElasticBeanstalkPlatformArn": "MyPlatformArn",
+        "ElasticBeanstalkManagedPlatformUpdates": 
+        {
+            "ManagedActionsEnabled": true,
+            "PreferredStartTime": "Mon:12:00",
+            "UpdateLevel": "minor"
+        },
+        "ElasticBeanstalkEnvironmentVariables": {
+            "VarName": "VarValue"
+        }
+    }
+  }
+  


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-4809

*Description of changes:*
add environment variables config to beanstalk deployments
![PR410](https://user-images.githubusercontent.com/53088140/145270611-1eac32e2-5316-49c2-96cf-bc439d7cee8a.gif)

Introduce new KeyValue type that supports a Dictionary.
The KeyValue type is Dictionary that serializes the same way as Object types are defined in config files that users can deploy from. This makes it harder to distinguish between an Object and a Dictionary.
![image](https://user-images.githubusercontent.com/53088140/145270876-f01b966e-4e29-46d0-9ea9-6cb4dc5eb740.png)
In the image above, one is an Object and the other is a Dictionary. For this reason, I have updated the GetOptionSetting method to check if the OptionSettingItem is a KeyValue type to return it.

Updated UX to ask user for key value pairs with ability to Add, Update and Delete

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
