### PR TITLE
feat: Add type hints on child settings

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DynamoDBTableCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DynamoDBTableCommand.cs
@@ -38,9 +38,12 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             const string NO_VALUE = "*** Do not select table ***";
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var typeHintData = optionSetting.GetTypeHintData<DynamoDBTableTypeHintData>();
             var tables = await GetData();
 
-            tables.Add(NO_VALUE);
+            if (typeHintData?.AllowNoValue ?? false)
+                tables.Add(NO_VALUE);
+
             var userResponse = _consoleUtilities.AskUserToChoose(
                 values: tables,
                 title: "Select a DynamoDB table:",

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/InstanceTypeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/InstanceTypeCommand.cs
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class InstanceTypeCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public InstanceTypeCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        private async Task<List<InstanceTypeInfo>?> GetData(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            return await _awsResourceQueryer.ListOfAvailableInstanceTypes();
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var instanceType = await GetData(recommendation, optionSetting);
+            return instanceType?
+                .Select(x => new TypeHintResource(x.InstanceType.Value, x.InstanceType.Value))
+                .Distinct()
+                .OrderBy(x => x)
+                .ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var instanceTypes = await GetData(recommendation, optionSetting);
+            var instanceTypeDefaultValue = recommendation.GetOptionSettingDefaultValue<string>(optionSetting);
+            if (instanceTypes == null)
+            {
+                return _consoleUtilities.AskUserForValue("Select EC2 Instance Type:", instanceTypeDefaultValue ?? string.Empty, true);
+            }
+
+            var freeTierEligibleAnswer = _consoleUtilities.AskYesNoQuestion("Do you want the EC2 instance to be free tier eligible?", "true");
+            var freeTierEligible = freeTierEligibleAnswer == YesNo.Yes;
+
+            var architectureAllowedValues = new List<string> { "x86_64", "arm64"};
+
+            var architecture = _consoleUtilities.AskUserToChoose(architectureAllowedValues, "The architecture of the EC2 instances created for the environment.", "x86_64");
+
+            var cpuCores = instanceTypes
+                .Where(x => x.FreeTierEligible.Equals(freeTierEligible))
+                .Where(x => x.ProcessorInfo.SupportedArchitectures.Contains(architecture))
+                .Select(x => x.VCpuInfo.DefaultCores).Distinct().OrderBy(x => x).ToList();
+
+            if (cpuCores.Count == 0)
+                return _consoleUtilities.AskUserForValue("Select EC2 Instance Type:", instanceTypeDefaultValue ?? string.Empty, true);
+
+            var cpuCoreCount = int.Parse(_consoleUtilities.AskUserToChoose(cpuCores.Select(x => x.ToString()).ToList(), "Select EC2 Instance CPU Cores:", "1"));
+
+            var memory = instanceTypes
+                .Where(x => x.FreeTierEligible.Equals(freeTierEligible))
+                .Where(x => x.ProcessorInfo.SupportedArchitectures.Contains(architecture))
+                .Where(x => x.VCpuInfo.DefaultCores.Equals(cpuCoreCount))
+                .Select(x => x.MemoryInfo.SizeInMiB).Distinct().OrderBy(x => x).ToList();
+
+            if (memory.Count == 0)
+                return _consoleUtilities.AskUserForValue("Select EC2 Instance Type:", instanceTypeDefaultValue ?? string.Empty, true);
+
+            var memoryCount = _consoleUtilities.AskUserToChoose(memory.Select(x => x.ToString()).ToList(), "Select EC2 Instance Memory:", "1024");
+
+            var availableInstanceTypes = instanceTypes
+                .Where(x => x.FreeTierEligible.Equals(freeTierEligible))
+                .Where(x => x.ProcessorInfo.SupportedArchitectures.Contains(architecture))
+                .Where(x => x.VCpuInfo.DefaultCores.Equals(cpuCoreCount))
+                .Where(x => x.MemoryInfo.SizeInMiB.Equals(long.Parse(memoryCount)))
+                .Select(x => x.InstanceType.Value).Distinct().OrderBy(x => x).ToList();
+
+            if (availableInstanceTypes.Count == 0)
+                return _consoleUtilities.AskUserForValue("Select EC2 Instance Type:", instanceTypeDefaultValue ?? string.Empty, true);
+
+            var userResponse = _consoleUtilities.AskUserToChoose(availableInstanceTypes, "Select EC2 Instance Type:", availableInstanceTypes.First());
+
+            return userResponse;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/S3BucketNameCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/S3BucketNameCommand.cs
@@ -39,9 +39,12 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             const string NO_VALUE = "*** Do not select bucket ***";
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var typeHintData = optionSetting.GetTypeHintData<S3BucketNameTypeHintData>();
             var buckets = (await GetData()).Select(bucket => bucket.BucketName).ToList();
 
-            buckets.Add(NO_VALUE);
+            if (typeHintData?.AllowNoValue ?? false)
+                buckets.Add(NO_VALUE);
+
             var userResponse = _consoleUtilities.AskUserToChoose(
                 values: buckets,
                 title: "Select a S3 bucket:",

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
@@ -33,6 +33,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             const string NO_VALUE = "*** Do not select topic ***";
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var typeHintData = optionSetting.GetTypeHintData<SNSTopicArnsTypeHintData>();
             var currentValueStr = currentValue.ToString() ?? string.Empty;
             var topicArns = await GetResources(recommendation, optionSetting);
 
@@ -43,7 +44,8 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 currentName = currentValueStr.Substring(currentValueStr.LastIndexOf(':') + 1);
             }
 
-            topicNames.Add(NO_VALUE);
+            if (typeHintData?.AllowNoValue ?? false)
+                topicNames.Add(NO_VALUE);
             var userResponse = _consoleUtilities.AskUserToChoose(
                 values: topicNames,
                 title: "Select a SNS topic:",

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
@@ -33,6 +33,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             const string NO_VALUE = "*** Do not select queue ***";
             var currentValue = recommendation.GetOptionSettingValue(optionSetting);
+            var typeHintData = optionSetting.GetTypeHintData<SQSQueueUrlTypeHintData>();
             var currentValueStr = currentValue.ToString() ?? string.Empty;
             var queueUrls = await GetResources(recommendation, optionSetting);
 
@@ -43,7 +44,8 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 currentName = currentValueStr.Substring(currentValueStr.LastIndexOf('/') + 1);
             }
 
-            queueNames.Add(NO_VALUE);
+            if (typeHintData?.AllowNoValue ?? false)
+                queueNames.Add(NO_VALUE);
             var userResponse = _consoleUtilities.AskUserToChoose(
                 values: queueNames,
                 title: "Select a SQS queue:",

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -38,22 +38,27 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             _commands = new Dictionary<OptionSettingTypeHint, ITypeHintCommand>
             {
                 { OptionSettingTypeHint.BeanstalkApplication, new BeanstalkApplicationCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ExistingBeanstalkApplication, new BeanstalkApplicationCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.BeanstalkEnvironment, new BeanstalkEnvironmentCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.DotnetBeanstalkPlatformArn, new DotnetBeanstalkPlatformArnCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.EC2KeyPair, new EC2KeyPairCommand(toolInteractiveService, awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.IAMRole, new IAMRoleCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ExistingIAMRole, new IAMRoleCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.Vpc, new VpcCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ExistingVpc, new VpcCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishAdditionalBuildArguments, new DotnetPublishArgsCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishSelfContainedBuild, new DotnetPublishSelfContainedBuildCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DotnetPublishBuildConfiguration, new DotnetPublishBuildConfigurationCommand(consoleUtilities) },
                 { OptionSettingTypeHint.DockerExecutionDirectory, new DockerExecutionDirectoryCommand(consoleUtilities, directoryManager) },
                 { OptionSettingTypeHint.DockerBuildArgs, new DockerBuildArgsCommand(consoleUtilities) },
                 { OptionSettingTypeHint.ECSCluster, new ECSClusterCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ExistingECSCluster, new ECSClusterCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.ExistingApplicationLoadBalancer, new ExistingApplicationLoadBalancerCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.DynamoDBTableName, new DynamoDBTableCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.SQSQueueUrl, new SQSQueueUrlCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.SNSTopicArn, new SNSTopicArnsCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.S3BucketName, new S3BucketNameCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.InstanceType, new InstanceTypeCommand(awsResourceQueryer, consoleUtilities) },
             };
         }
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -26,6 +26,10 @@ namespace AWS.Deploy.Common.Recipes
         SQSQueueUrl,
         SNSTopicArn,
         S3BucketName,
-        BeanstalkRollingUpdates
+        BeanstalkRollingUpdates,
+        ExistingIAMRole,
+        ExistingECSCluster,
+        ExistingVpc,
+        ExistingBeanstalkApplication
     };
 }

--- a/src/AWS.Deploy.Common/TypeHintData/DynamoDBTableTypeHintData.cs
+++ b/src/AWS.Deploy.Common/TypeHintData/DynamoDBTableTypeHintData.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.Common.TypeHintData
+{
+    /// <summary>
+    /// Holds additional data for <see cref="OptionSettingTypeHint.DynamoDBTableName"/> processing.
+    /// </summary>
+    public class DynamoDBTableTypeHintData
+    {
+        /// <summary>
+        /// Determines whether to allow no value or not.
+        /// </summary>
+        public bool AllowNoValue { get; set; }
+
+        public DynamoDBTableTypeHintData(bool allowNoValue)
+        {
+            AllowNoValue = allowNoValue;
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/TypeHintData/S3BucketNameTypeHintData.cs
+++ b/src/AWS.Deploy.Common/TypeHintData/S3BucketNameTypeHintData.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.Common.TypeHintData
+{
+    /// <summary>
+    /// Holds additional data for <see cref="OptionSettingTypeHint.S3BucketName"/> processing.
+    /// </summary>
+    public class S3BucketNameTypeHintData
+    {
+        /// <summary>
+        /// Determines whether to allow no value or not.
+        /// </summary>
+        public bool AllowNoValue { get; set; }
+
+        public S3BucketNameTypeHintData(bool allowNoValue)
+        {
+            AllowNoValue = allowNoValue;
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/TypeHintData/SNSTopicArnsTypeHintData.cs
+++ b/src/AWS.Deploy.Common/TypeHintData/SNSTopicArnsTypeHintData.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.Common.TypeHintData
+{
+    /// <summary>
+    /// Holds additional data for <see cref="OptionSettingTypeHint.SNSTopicArn"/> processing.
+    /// </summary>
+    public class SNSTopicArnsTypeHintData
+    {
+        /// <summary>
+        /// Determines whether to allow no value or not.
+        /// </summary>
+        public bool AllowNoValue { get; set; }
+
+        public SNSTopicArnsTypeHintData(bool allowNoValue)
+        {
+            AllowNoValue = allowNoValue;
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/TypeHintData/SQSQueueUrlTypeHintData.cs
+++ b/src/AWS.Deploy.Common/TypeHintData/SQSQueueUrlTypeHintData.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.Common.TypeHintData
+{
+    /// <summary>
+    /// Holds additional data for <see cref="OptionSettingTypeHint.SQSQueueUrl"/> processing.
+    /// </summary>
+    public class SQSQueueUrlTypeHintData
+    {
+        /// <summary>
+        /// Determines whether to allow no value or not.
+        /// </summary>
+        public bool AllowNoValue { get; set; }
+
+        public SQSQueueUrlTypeHintData(bool allowNoValue)
+        {
+            AllowNoValue = allowNoValue;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -39,6 +39,7 @@ namespace AWS.Deploy.Orchestration.Data
 {
     public interface IAWSResourceQueryer
     {
+        Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes();
         Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
         Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
         Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentId);
@@ -76,6 +77,20 @@ namespace AWS.Deploy.Orchestration.Data
         public AWSResourceQueryer(IAWSClientFactory awsClientFactory)
         {
             _awsClientFactory = awsClientFactory;
+        }
+
+        public async Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes()
+        {
+            var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>();
+            var instanceTypes = new List<InstanceTypeInfo>();
+            var listInstanceTypesPaginator = ec2Client.Paginators.DescribeInstanceTypes(new DescribeInstanceTypesRequest());
+
+            await foreach (var response in listInstanceTypesPaginator.Responses)
+            {
+                instanceTypes.AddRange(response.InstanceTypes);
+            }
+
+            return instanceTypes;
         }
 
         public async Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn)

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -108,6 +108,10 @@
                     "Name": "Existing Role ARN",
                     "Description": "The ARN of the existing role to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "tasks.apprunner.amazonaws.com"
+                    },
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "DependsOn": [
@@ -145,6 +149,10 @@
                     "Name": "Existing Role ARN",
                     "Description": "The ARN of the existing role to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "build.apprunner.amazonaws.com"
+                    },
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "DependsOn": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -92,6 +92,7 @@
                     "Name": "Existing Cluster ARN",
                     "Description": "The ARN of the existing cluster to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingECSCluster",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -202,6 +203,10 @@
                     "Name": "Existing Role ARN",
                     "Description": "The ARN of the existing role to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "ecs-tasks.amazonaws.com"
+                    },
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "Validators": [
@@ -261,6 +266,7 @@
                     "Name": "Existing VPC ID",
                     "Description": "The ID of the existing VPC to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingVpc",
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": false,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -98,6 +98,7 @@
                     "Name": "Application Name",
                     "Description": "The Elastic Beanstalk application name.",
                     "Type": "String",
+                    "TypeHint": "ExistingBeanstalkApplication",
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
@@ -139,7 +140,6 @@
             "Description": "The EC2 instance type of the EC2 instances created for the environment.",
             "Type": "String",
             "TypeHint": "InstanceType",
-            "DefaultValue": "",
             "AdvancedSetting": true,
             "Updatable": true
         },
@@ -211,6 +211,10 @@
                     "Name": "Existing Role ARN",
                     "Description": "The ARN of the existing role to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "elasticbeanstalk.amazonaws.com"
+                    },
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "DependsOn": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
@@ -222,6 +222,10 @@
                     "Name": "Logging Bucket",
                     "Description": "S3 bucket to use for storing access logs",
                     "Type": "String",
+                    "TypeHint": "S3BucketName",
+                    "TypeHintData": {
+                        "AllowNoValue": true
+                    },
                     "DefaultValue": true,
                     "AdvancedSetting": true,
                     "Updatable": true,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -119,6 +119,7 @@
                     "Name": "Existing Cluster ARN",
                     "Description": "The ARN of the existing cluster to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingECSCluster",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -191,6 +192,10 @@
                     "Name": "Existing Role ARN",
                     "Description": "The ARN of the existing role to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "ecs-tasks.amazonaws.com"
+                    },
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "Validators": [
@@ -260,6 +265,7 @@
                     "Name": "Existing VPC ID",
                     "Description": "The ID of the existing VPC to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingVpc",
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": false,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -119,6 +119,7 @@
                     "Name": "Existing Cluster ARN",
                     "Description": "The ARN of the existing cluster to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingECSCluster",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -229,6 +230,10 @@
                     "Name": "Existing Role ARN",
                     "Description": "The ARN of the existing role to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "ecs-tasks.amazonaws.com"
+                    },
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "Validators": [
@@ -288,6 +293,7 @@
                     "Name": "Existing VPC ID",
                     "Description": "The ID of the existing VPC to use.",
                     "Type": "String",
+                    "TypeHint": "ExistingVpc",
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": false,

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -53,5 +53,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<string>> ListOfSQSQueuesUrls() => throw new NotImplementedException();
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
+        public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -78,5 +78,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<string>> ListOfSQSQueuesUrls() => throw new NotImplementedException();
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
+        public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5570
*Description of changes:*
* Add type hints on child settings to enable visual studio toolkit to query the child typehint and return the resources that can be selected. The CLI will still use the parent type hint to display the Object type. The toolkit can decide to use either.
* Added Typehint data for S3BucketName, DynamoDbTable, SNSTopicArns and SQSQueueUrl to choose whether the typehint list allows empty values or not.
* Added a filtering mechanism to retrieve instance types
![PR414](https://user-images.githubusercontent.com/53088140/145428456-a3828361-fef0-44f5-b0b2-96b0af9d4885.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
