### PR TITLE
feat: Add input validation to option settings in ECS Fargate based recipes

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -407,7 +407,7 @@ namespace AWS.Deploy.CLI.Commands
             var validatorFailedResults =
                         recommendation.Recipe
                             .BuildValidators()
-                            .Select(validator => validator.Validate(recommendation.Recipe, _session))
+                            .Select(validator => validator.Validate(recommendation, _session))
                             .Where(x => !x.IsValid)
                             .ToList();
 
@@ -682,7 +682,7 @@ namespace AWS.Deploy.CLI.Commands
                     var validatorFailedResults =
                         recommendation.Recipe
                             .BuildValidators()
-                            .Select(validator => validator.Validate(recommendation.Recipe, _session))
+                            .Select(validator => validator.Validate(recommendation, _session))
                             .Where(x => !x.IsValid)
                             .ToList();
 

--- a/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
@@ -10,6 +10,6 @@ namespace AWS.Deploy.Common.Recipes.Validation
     /// </summary>
     public interface IRecipeValidator
     {
-        ValidationResult Validate(RecipeDefinition recipe, IDeployToolValidationContext deployValidationContext);
+        ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
@@ -8,6 +8,11 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="FargateTaskCpuMemorySizeValidator"/>
         /// </summary>
-        FargateTaskSizeCpuMemoryLimits
+        FargateTaskSizeCpuMemoryLimits,
+
+        /// <summary>
+        /// Must be paired with <see cref="MinMaxConstraintValidator"/>
+        /// </summary>
+        MinMaxConstraint
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/MinMaxConstraintValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/MinMaxConstraintValidator.cs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// This validator enforces a constraint that the value for one option setting item is less than another option setting item.
+    /// The setting that holds the minimum value is identified by the 'MinValueOptionSettingsId'.
+    /// The setting that holds the maximum value is identified by the 'MaxValueOptionSettingsId'.
+    /// </summary>
+    public class MinMaxConstraintValidator : IRecipeValidator
+    {
+        public string MinValueOptionSettingsId { get; set; } = string.Empty;
+        public string MaxValueOptionSettingsId { get; set; } = string.Empty;
+        public string ValidationFailedMessage { get; set; } = "The value specified for {{MinValueOptionSettingsId}} must be less than or equal to the value specified for {{MaxValueOptionSettingsId}}";
+
+        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
+        {
+            double minVal;
+            double maxValue;
+
+            try
+            {
+                minVal = recommendation.GetOptionSettingValue<double>(recommendation.GetOptionSetting(MinValueOptionSettingsId));
+                maxValue = recommendation.GetOptionSettingValue<double>(recommendation.GetOptionSetting(MaxValueOptionSettingsId));
+            }
+            catch (OptionSettingItemDoesNotExistException)
+            {
+                return ValidationResult.Failed($"Could not find a valid value for {MinValueOptionSettingsId} or {MaxValueOptionSettingsId}. Please provide a valid value and try again.");
+            }
+
+            if (minVal <= maxValue)
+                return ValidationResult.Valid();
+
+            var failureMessage =
+                ValidationFailedMessage
+                    .Replace("{{MinValueOptionSettingsId}}", MinValueOptionSettingsId)
+                    .Replace("{{MaxValueOptionSettingsId}}", MaxValueOptionSettingsId);
+
+            return ValidationResult.Failed(failureMessage);
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -22,7 +22,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()
         {
-            { RecipeValidatorList.FargateTaskSizeCpuMemoryLimits, typeof(FargateTaskCpuMemorySizeValidator) }
+            { RecipeValidatorList.FargateTaskSizeCpuMemoryLimits, typeof(FargateTaskCpuMemorySizeValidator) },
+            { RecipeValidatorList.MinMaxConstraint, typeof(MinMaxConstraintValidator) }
         };
 
         public static IOptionSettingItemValidator[] BuildValidators(this OptionSettingItem optionSettingItem)

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -65,6 +65,14 @@
     "Validators": [
         {
             "ValidatorType": "FargateTaskSizeCpuMemoryLimits"
+        },
+        {
+            "ValidatorType": "MinMaxConstraint",
+            "Configuration":
+            {
+                "MinValueOptionSettingsId": "AutoScaling.MinCapacity",
+                "MaxValueOptionSettingsId": "AutoScaling.MaxCapacity"
+            }
         }
     ],
 
@@ -414,6 +422,17 @@
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": 
+                            {
+                                "Regex": "arn:[^:]+:elasticloadbalancing:[^:]*:[0-9]{12}:loadbalancer/.+",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid load balancer ARN. The ARN should contain the arn:[PARTITION]:elasticloadbalancing namespace, followed by the Region of the load balancer, the AWS account ID of the load balancer owner, the loadbalancer namespace, and then the load balancer name. For example, arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "LoadBalancer.CreateNew",
@@ -428,7 +447,17 @@
                     "Type": "Int",
                     "DefaultValue": 60,
                     "AdvancedSetting": true,
-                    "Updatable": true
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600 
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "HealthCheckPath",
@@ -442,11 +471,21 @@
                 {
                     "Id": "HealthCheckInternval",
                     "Name": "Health Check Interval",
-                    "Description": "The number of consecutive health check successes required before considering an unhealthy target healthy.",
+                    "Description": "The approximate interval, in seconds, between health checks of an individual instance.",
                     "Type": "Int",
                     "DefaultValue": 30,
                     "AdvancedSetting": true,
-                    "Updatable": true
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 5,
+                                "Max": 300 
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "HealthyThresholdCount",
@@ -455,7 +494,17 @@
                     "Type": "Int",
                     "DefaultValue": 5,
                     "AdvancedSetting": true,
-                    "Updatable": true
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 2,
+                                "Max": 10 
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "UnhealthyThresholdCount",
@@ -464,7 +513,17 @@
                     "Type": "Int",
                     "DefaultValue": 2,
                     "AdvancedSetting": true,
-                    "Updatable": true
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 2,
+                                "Max": 10 
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "ListenerConditionType",
@@ -493,6 +552,17 @@
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": 
+                            {
+                                "Regex": "^/[a-zA-Z0-9*?&_\\-.$/~\"'@:+]{0,127}$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid listener condition path. The path is case-sensitive and can be up to 128. It starts with '/' and consists of alpha-numeric characters, wildcards (* and ?), & (using &amp;), and the following special characters: '_-.$/~\"'@:+'"
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "LoadBalancer.CreateNew",
@@ -508,10 +578,20 @@
                     "Id": "ListenerConditionPriority",
                     "Name": "Listener Condition Priority",
                     "Description": "Priority of the condition rule. The value must be unique for the Load Balancer listener.",
-                    "Type": "Double",
+                    "Type": "Int",
                     "DefaultValue": 100,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 1,
+                                "Max": 50000
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "LoadBalancer.CreateNew",
@@ -550,6 +630,16 @@
                     "DefaultValue": 3,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 1,
+                                "Max": 5000
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -565,6 +655,16 @@
                     "DefaultValue": 6,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 1,
+                                "Max": 5000
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -595,11 +695,21 @@
                 {
                     "Id": "CpuTypeTargetUtilizationPercent",
                     "Name": "CPU Target Utilization",
-                    "Description": "The target cpu utilization that triggers a scaling change.",
+                    "Description": "The target cpu utilization percentage that triggers a scaling change.",
                     "Type": "Double",
                     "DefaultValue": 70,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 1,
+                                "Max": 100
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -619,6 +729,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -638,6 +758,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -652,11 +782,21 @@
                 {
                     "Id": "MemoryTypeTargetUtilizationPercent",
                     "Name": "Memory Target Utilization",
-                    "Description": "The target memory utilization that triggers a scaling change.",
+                    "Description": "The target memory utilization percentage that triggers a scaling change.",
                     "Type": "Double",
                     "DefaultValue": 70,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 1,
+                                "Max": 100
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -676,6 +816,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -695,6 +845,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -714,6 +874,15 @@
                     "DefaultValue": 1000,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 1
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -733,6 +902,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -752,6 +931,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": 
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -93,7 +93,16 @@
     "Validators": [
         {
             "ValidatorType": "FargateTaskSizeCpuMemoryLimits"
-        }],
+        },
+        {
+            "ValidatorType": "MinMaxConstraint",
+            "Configuration":
+            {
+                "MinValueOptionSettingsId": "AutoScaling.MinCapacity",
+                "MaxValueOptionSettingsId": "AutoScaling.MaxCapacity"
+            }
+        }
+    ],
 
     "OptionSettings": [
         {
@@ -440,6 +449,16 @@
                     "DefaultValue": 1,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 1,
+                                "Max": 5000
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -455,6 +474,16 @@
                     "DefaultValue": 3,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 1,
+                                "Max": 5000
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -484,11 +513,21 @@
                 {
                     "Id": "CpuTypeTargetUtilizationPercent",
                     "Name": "CPU Target Utilization",
-                    "Description": "The target cpu utilization that triggers a scaling change.",
+                    "Description": "The target cpu utilization percentage that triggers a scaling change.",
                     "Type": "Double",
                     "DefaultValue": 70,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 1,
+                                "Max": 100
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -508,6 +547,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -527,6 +576,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -541,11 +600,21 @@
                 {
                     "Id": "MemoryTypeTargetUtilizationPercent",
                     "Name": "Memory Target Utilization",
-                    "Description": "The target memory utilization that triggers a scaling change.",
+                    "Description": "The target memory utilization percentage that triggers a scaling change.",
                     "Type": "Double",
                     "DefaultValue": 70,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 1,
+                                "Max": 100
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -565,6 +634,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",
@@ -584,6 +663,16 @@
                     "DefaultValue": 300,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration":
+                            {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "AutoScaling.Enabled",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -334,7 +334,8 @@
                     "ValidatorType": {
                         "type": "string",
                         "enum": [
-                            "FargateTaskSizeCpuMemoryLimits"
+                            "FargateTaskSizeCpuMemoryLimits",
+                            "MinMaxConstraint"
                         ]
                     }
                 },
@@ -354,6 +355,28 @@
                                             "type": "string"
                                         },
                                         "MemoryOptionSettingsId":{
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": { "ValidatorType": { "const": "MinMaxConstraint" } }
+                        },
+                        "then": {
+                            "properties": {
+                                "Configuration": {
+                                    "properties": {
+                                        "ValidationFailedMessage": {
+                                            "type": "string"
+                                        },
+                                        "MinValueOptionSettingsId":{
+                                            "type": "string"
+                                        },
+                                        "MaxValueOptionSettingsId":{
                                             "type": "string"
                                         }
                                     }
@@ -516,6 +539,9 @@
                                                 },
                                                 "Max": {
                                                     "type": "integer"
+                                                },
+                                                "AllowEmptyString": {
+                                                    "type": "boolean"
                                                 },
                                                 "ValidationFailedMessage": {
                                                     "type": "string"

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -98,6 +98,32 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             Validate(optionSettingItem, value, isValid);
         }
 
+        [Theory]
+        [InlineData("arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/my-load-balancer", true)]
+        [InlineData("arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/app/my-load-balancer", true)]
+        [InlineData("arn:aws:elasticloadbalancing:012345678910:elasticloadbalancing:loadbalancer/my-load-balancer", false)] //missing region
+        [InlineData("arn:aws:elasticloadbalancing:012345678910:elasticloadbalancing:loadbalancer", false)] //missing resource path
+        [InlineData("arn:aws:elasticloadbalancing:01234567891:elasticloadbalancing:loadbalancer", false)] //11 digit account ID
+        public void LoadBalancerArnValidationTest(string value, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:elasticloadbalancing:[^:]*:[0-9]{12}:loadbalancer/.+"));
+            Validate(optionSettingItem, value, isValid);
+        }
+
+        [Theory]
+        [InlineData("/", true)]
+        [InlineData("/Api/*", true)]
+        [InlineData("/Api/Path/&*$-/@", true)]
+        [InlineData("Api/Path", false)] // does not start with '/'
+        [InlineData("/Api/Path/<dsd<>", false)] // contains invalid character '<' and '>'
+        public void ListenerConditionPathPatternValidationTest(string value, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("^/[a-zA-Z0-9*?&_\\-.$/~\"'@:+]{0,127}$"));
+            Validate(optionSettingItem, value, isValid);
+        }
+
         private OptionSettingItemValidatorConfig GetRegexValidatorConfig(string regex)
         {
             var regexValidatorConfig = new OptionSettingItemValidatorConfig


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5572


*Description of changes:*
This PR adds input validation to option setting items in ECS Fargate based recipes.

This PR also adds a new recipe level validator called `MinMaxConstraintValidator`. It enforces a constraint that the value for one option setting item is less than another option setting item.
![image](https://user-images.githubusercontent.com/36622308/145447454-aae795bd-32ad-41c3-809b-2a074af75c05.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
