### PR TITLE
fix: Allow spaces in the deploy tool installation location in server-mode command.

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
@@ -144,7 +144,7 @@ namespace AWS.Deploy.ServerMode.Client
 
                 var keyInfoStdin = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(keyInfo)));
 
-                var command = $"{deployToolRoot} server-mode --port {port} --parent-pid {currentProcessId}";
+                var command = $"\"{deployToolRoot}\" server-mode --port {port} --parent-pid {currentProcessId}";
                 var startServerTask = _commandLineWrapper.Run(command, keyInfoStdin);
 
                 _baseUrl = $"http://localhost:{port}";


### PR DESCRIPTION
*Issue #, if available:*
https://sim.amazon.com/issues/DOTNET-5571

*Description of changes:*
Currently, the `server-mode` command fails if the deploy-tool installation location contains an empty space.
This PR solves this problem by surrounding the installation location with quotes (`"`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
