### PR TITLE
fix: Improve error message when deploying to an existing Beanstalk environment via a new CF stack

### DIFF
--- a/src/AWS.Deploy.CLI/TypeHintResponses/BeanstalkEnvironmentTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/BeanstalkEnvironmentTypeHintResponse.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.CLI.TypeHintResponses
+{
+    /// <summary>
+    /// The <see cref="BeanstalkApplicationTypeHintResponse"/> class encapsulates
+    /// <see cref="OptionSettingTypeHint.BeanstalkEnvironment"/> type hint response
+    /// </summary>
+    public class BeanstalkEnvironmentTypeHintResponse : IDisplayable
+    {
+        public bool CreateNew { get; set; }
+        public string EnvironmentName { get; set; }
+
+        public BeanstalkEnvironmentTypeHintResponse(
+            bool createNew,
+            string environmentName)
+        {
+            CreateNew = createNew;
+            EnvironmentName = environmentName;
+        }
+
+        public string ToDisplayString() => EnvironmentName;
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/BeanstalkEnvironmentConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/BeanstalkEnvironmentConfiguration.cs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a generated file from the original deployment recipe. It contains properties for
+// all of the settings defined in the recipe file. It is recommended to not modify this file in order
+// to allow easy updates to the file when the original recipe that this project was created from has updates.
+// This class is marked as a partial class. If you add new settings to the recipe file, those settings should be
+// added to partial versions of this class outside of the Generated folder for example in the Configuration folder.
+
+namespace AspNetAppElasticBeanstalkLinux.Configurations
+{
+    public partial class BeanstalkEnvironmentConfiguration
+    {
+        public bool CreateNew { get; set; }
+        public string EnvironmentName { get; set; }
+
+        /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
+        /// or the classes will fail to initialize.
+        /// The warnings are disabled since a parameterless constructor will allow non-nullable properties to be initialized with null values.
+#nullable disable warnings
+        public BeanstalkEnvironmentConfiguration()
+        {
+
+        }
+#nullable restore warnings
+
+        public BeanstalkEnvironmentConfiguration(
+            bool createNew,
+            string environmentName)
+        {
+            CreateNew = createNew;
+            EnvironmentName = environmentName;
+        }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -29,9 +29,9 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         public string InstanceType { get; set; }
 
         /// <summary>
-        /// The Elastic Beanstalk environment name.
+        /// The Elastic Beanstalk environment.
         /// </summary>
-        public string EnvironmentName { get; set; }
+        public BeanstalkEnvironmentConfiguration BeanstalkEnvironment { get; set; }
 
         /// <summary>
         /// The Elastic Beanstalk application.
@@ -106,7 +106,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         public Configuration(
             IAMRoleConfiguration applicationIAMRole,
             string instanceType,
-            string environmentName,
+            BeanstalkEnvironmentConfiguration beanstalkEnvironment,
             BeanstalkApplicationConfiguration beanstalkApplication,
             string elasticBeanstalkPlatformArn,
             string ec2KeyPair,
@@ -123,7 +123,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         {
             ApplicationIAMRole = applicationIAMRole;
             InstanceType = instanceType;
-            EnvironmentName = environmentName;
+            BeanstalkEnvironment = beanstalkEnvironment;
             BeanstalkApplication = beanstalkApplication;
             ElasticBeanstalkPlatformArn = elasticBeanstalkPlatformArn;
             EC2KeyPair = ec2KeyPair;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -330,9 +330,12 @@ namespace AspNetAppElasticBeanstalkLinux
                 }
             }
 
+            if (!settings.BeanstalkEnvironment.CreateNew)
+                throw new InvalidOrMissingConfigurationException("The ability to deploy an Elastic Beanstalk application to an existing environment via a new CloudFormation stack is not supported yet.");
+
             BeanstalkEnvironment = new CfnEnvironment(this, nameof(BeanstalkEnvironment), InvokeCustomizeCDKPropsEvent(nameof(BeanstalkEnvironment), this, new CfnEnvironmentProps
             {
-                EnvironmentName = settings.EnvironmentName,
+                EnvironmentName = settings.BeanstalkEnvironment.EnvironmentName,
                 ApplicationName = settings.BeanstalkApplication.ApplicationName,
                 PlatformArn = settings.ElasticBeanstalkPlatformArn,
                 OptionSettings = optionSettingProperties.ToArray(),

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -115,22 +115,43 @@
             ]
         },
         {
-            "Id": "EnvironmentName",
+            "Id": "BeanstalkEnvironment",
             "ParentSettingId": "BeanstalkApplication.ApplicationName",
             "Name": "Environment Name",
             "Description": "The Elastic Beanstalk environment name.",
-            "Type": "String",
+            "Type": "Object",
             "TypeHint": "BeanstalkEnvironment",
-            "DefaultValue": "{StackName}-dev",
             "AdvancedSetting": false,
             "Updatable": false,
-            "Validators": [
+            "ChildOptionSettings": [
                 {
-                    "ValidatorType": "Regex",
-                    "Configuration" : {
-                        "Regex": "^[a-zA-Z0-9][a-zA-Z0-9-]{2,38}[a-zA-Z0-9]$",
-                        "ValidationFailedMessage": "Invalid Environment Name. The Environment Name Must be from 4 to 40 characters in length. The name can contain only letters, numbers, and hyphens. It can't start or end with a hyphen."
-                    }
+                    "Id": "CreateNew",
+                    "Name": "Create new Elastic Beanstalk environment",
+                    "Description": "Do you want to create a new environment?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
+                },
+                {
+                    "Id": "EnvironmentName",
+                    "ParentSettingId": "BeanstalkApplication.ApplicationName",
+                    "Name": "Environment Name",
+                    "Description": "The Elastic Beanstalk environment name.",
+                    "Type": "String",
+                    "TypeHint": "BeanstalkEnvironment",
+                    "DefaultValue": "{StackName}-dev",
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration" : {
+                                "Regex": "^[a-zA-Z0-9][a-zA-Z0-9-]{2,38}[a-zA-Z0-9]$",
+                                "ValidationFailedMessage": "Invalid Environment Name. The Environment Name Must be from 4 to 40 characters in length. The name can contain only letters, numbers, and hyphens. It can't start or end with a hyphen."
+                            }
+                        }
+                    ]
                 }
             ]
         },

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;
             Assert.Equal("True", optionSettingDictionary["BeanstalkApplication.CreateNew"]);
             Assert.Equal("MyApplication", optionSettingDictionary["BeanstalkApplication.ApplicationName"]);
-            Assert.Equal("MyEnvironment", optionSettingDictionary["EnvironmentName"]);
+            Assert.Equal("MyEnvironment", optionSettingDictionary["BeanstalkEnvironment.EnvironmentName"]);
             Assert.Equal("MyInstance", optionSettingDictionary["InstanceType"]);
             Assert.Equal("SingleInstance", optionSettingDictionary["EnvironmentType"]);
             Assert.Equal("application", optionSettingDictionary["LoadBalancerType"]);

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkKeyValueDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkKeyValueDeploymentTest.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;
             Assert.Equal("True", optionSettingDictionary["BeanstalkApplication.CreateNew"]);
             Assert.Equal("MyApplication", optionSettingDictionary["BeanstalkApplication.ApplicationName"]);
-            Assert.Equal("MyEnvironment", optionSettingDictionary["EnvironmentName"]);
+            Assert.Equal("MyEnvironment", optionSettingDictionary["BeanstalkEnvironment.EnvironmentName"]);
             Assert.Equal("MyInstance", optionSettingDictionary["InstanceType"]);
             Assert.Equal("SingleInstance", optionSettingDictionary["EnvironmentType"]);
             Assert.Equal("application", optionSettingDictionary["LoadBalancerType"]);

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkConfigFile.json
@@ -3,28 +3,26 @@
     "AWSRegion": "us-west-2",
     "StackName": "MyAppStack",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
-    "OptionSettingsConfig":
-    {
-        "BeanstalkApplication": 
-        {
+    "OptionSettingsConfig": {
+        "BeanstalkApplication": {
             "CreateNew": true,
             "ApplicationName": "MyApplication"
         },
-        "EnvironmentName": "MyEnvironment",
+        "BeanstalkEnvironment": {
+            "CreateNew": true,
+            "EnvironmentName": "MyEnvironment"
+        },
         "InstanceType": "MyInstance",
         "EnvironmentType": "SingleInstance",
         "LoadBalancerType": "application",
-        "ApplicationIAMRole":
-        {
+        "ApplicationIAMRole": {
             "CreateNew": true
         },
         "ElasticBeanstalkPlatformArn": "MyPlatformArn",
-        "ElasticBeanstalkManagedPlatformUpdates": 
-        {
+        "ElasticBeanstalkManagedPlatformUpdates": {
             "ManagedActionsEnabled": true,
             "PreferredStartTime": "Mon:12:00",
             "UpdateLevel": "minor"
         }
     }
   }
-  

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkKeyPairConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkKeyPairConfigFile.json
@@ -3,24 +3,23 @@
     "AWSRegion": "us-west-2",
     "StackName": "MyAppStack",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
-    "OptionSettingsConfig":
-    {
-        "BeanstalkApplication": 
-        {
+    "OptionSettingsConfig": {
+        "BeanstalkApplication": {
             "CreateNew": true,
             "ApplicationName": "MyApplication"
         },
-        "EnvironmentName": "MyEnvironment",
+        "BeanstalkEnvironment": {
+            "CreateNew": true,
+            "EnvironmentName": "MyEnvironment"
+        },
         "InstanceType": "MyInstance",
         "EnvironmentType": "SingleInstance",
         "LoadBalancerType": "application",
-        "ApplicationIAMRole":
-        {
+        "ApplicationIAMRole": {
             "CreateNew": true
         },
         "ElasticBeanstalkPlatformArn": "MyPlatformArn",
-        "ElasticBeanstalkManagedPlatformUpdates": 
-        {
+        "ElasticBeanstalkManagedPlatformUpdates": {
             "ManagedActionsEnabled": true,
             "PreferredStartTime": "Mon:12:00",
             "UpdateLevel": "minor"
@@ -30,4 +29,3 @@
         }
     }
   }
-  

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -255,7 +255,7 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var beanstalkRecommendation = recommendations.FirstOrDefault(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
-            var beanstalEnvNameSetting = beanstalkRecommendation.Recipe.OptionSettings.FirstOrDefault(x => string.Equals("EnvironmentName", x.Id));
+            var beanstalEnvNameSetting = beanstalkRecommendation.GetOptionSetting("BeanstalkEnvironment.EnvironmentName");
 
             beanstalkRecommendation.AddReplacementToken("{StackName}", "MyAppStack");
             Assert.Equal("MyAppStack-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));

--- a/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
+++ b/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
@@ -1,18 +1,18 @@
 {
     "StackName": "ElasticBeanStalk{Suffix}",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
-    "OptionSettingsConfig":
-    {
-        "BeanstalkApplication":
-        {
+    "OptionSettingsConfig": {
+        "BeanstalkApplication": {
             "CreateNew": true,
             "ApplicationName": "MyApplication{Suffix}"
         },
-        "EnvironmentName": "MyEnvironment{Suffix}",
+        "BeanstalkEnvironment": {
+            "CreateNew": true,
+            "EnvironmentName": "MyEnvironment{Suffix}"
+        },
         "EnvironmentType": "LoadBalanced",
         "LoadBalancerType": "application",
-        "ApplicationIAMRole":
-        {
+        "ApplicationIAMRole": {
             "CreateNew": true
         }
     }


### PR DESCRIPTION
**Description of changes:**
The PR does the following:
* Change Elastic Beanstalk environment to be a complex object. This adds a `CreateNew` child option setting which can be used in the CDK application to determine if a new environment needs to be provisioned.
* Adds a clear error message when a user tries to perform a deployment to an existing Beanstalk environment via a new CloudFormation stack.

**Steps to reproduce the error**
* Perform the first deployment with the following configuration

```
{
    Recipe: ASP.NET Core App to AWS Elastic Beanstalk on Linux,
    StackName: MyAppStack1
    ApplicationName: MyAppStack1-app
    EnvironmentName: MyAppStack1-dev
}

```
* Perform the second deployment with the following configuration

```
{
    Recipe: ASP.NET Core App to AWS Elastic Beanstalk on Linux,
    StackName: MyAppStack2 (new stack)
    ApplicationName: MyAppStack1-app (existing application)
    EnvironmentName: MyAppStack1-dev (existing environment)
}

```
* The second deployment will fail with the following error message
![image](https://user-images.githubusercontent.com/36622308/147704210-468b813f-c391-48bc-95e8-142cc5e867db.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
