### PR TITLE
fix: deployment bundle settings not appearing for redeployment

### DIFF
--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -29,7 +29,7 @@ namespace AWS.Deploy.Common
 
         public DeploymentBundle DeploymentBundle { get; }
 
-        private readonly List<OptionSettingItem> DeploymentBundleSettings = new ();
+        public readonly List<OptionSettingItem> DeploymentBundleSettings = new ();
 
         private readonly Dictionary<string, string> _replacementTokens = new();
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5619

*Description of changes:*
The Deployment Bundle settings are stored as a private property on the Recommendation class. This property is set when a Recommendation is instantiated. When we are doing a redeployment, we apply previous settings which involve doing a deep copy of the Recommendation object. The way we do the deep copy is via serialization/deserialization which is only including public properties. I changed the deployment bundle settings property to public to include it in the deep copy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
