### PR TITLE
fix: InstanceType hint returns 500 in server mode

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/InstanceTypeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/InstanceTypeCommand.cs
@@ -23,24 +23,24 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             _consoleUtilities = consoleUtilities;
         }
 
-        private async Task<List<InstanceTypeInfo>?> GetData(Recommendation recommendation, OptionSettingItem optionSetting)
+        private async Task<List<InstanceTypeInfo>?> GetData()
         {
             return await _awsResourceQueryer.ListOfAvailableInstanceTypes();
         }
 
         public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            var instanceType = await GetData(recommendation, optionSetting);
+            var instanceType = await GetData();
+
             return instanceType?
+                .OrderBy(x => x.InstanceType.Value)
                 .Select(x => new TypeHintResource(x.InstanceType.Value, x.InstanceType.Value))
-                .Distinct()
-                .OrderBy(x => x)
                 .ToList();
         }
 
         public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            var instanceTypes = await GetData(recommendation, optionSetting);
+            var instanceTypes = await GetData();
             var instanceTypeDefaultValue = recommendation.GetOptionSettingDefaultValue<string>(optionSetting);
             if (instanceTypes == null)
             {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5622

*Description of changes:*
Added ability to attach to running server mode to simplify debugging
Fixed bug with InstanceType type hint that was returning a 500 error in server mode due to sorting a list incorrectly.
Previously, using linq, we were converting the Instance types into a TypeHintResource and then doing an OrderBy. This was failing because we dont have a comparator for TypeHintResource. To fix this, I simply did the OrderBy before creating the TypeHintResource.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
