### PR TITLE
chore: Refactor the code to support non-cloudformation based deployments

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -36,7 +36,7 @@ namespace AWS.Deploy.CLI.Commands
         private static readonly Option<string> _optionProfile = new("--profile", "AWS credential profile used to make calls to AWS.");
         private static readonly Option<string> _optionRegion = new("--region", "AWS region to deploy the application to. For example, us-west-2.");
         private static readonly Option<string> _optionProjectPath = new("--project-path", () => Directory.GetCurrentDirectory(), "Path to the project to deploy.");
-        private static readonly Option<string> _optionStackName = new("--stack-name", "Name the AWS stack to deploy your application to.");
+        private static readonly Option<string> _optionApplicationName = new("--application-name", "Name of the cloud application. If you choose to deploy via CloudFormation, this name will be used to identify the CloudFormation stack.");
         private static readonly Option<bool> _optionDiagnosticLogging = new(new[] { "-d", "--diagnostics" }, "Enable diagnostic output.");
         private static readonly Option<string> _optionApply = new("--apply", "Path to the deployment settings file to be applied.");
         private static readonly Option<bool> _optionDisableInteractive = new(new[] { "-s", "--silent" }, "Disable interactivity to deploy without any prompts for user input.");
@@ -153,7 +153,7 @@ namespace AWS.Deploy.CLI.Commands
                 deployCommand.Add(_optionProfile);
                 deployCommand.Add(_optionRegion);
                 deployCommand.Add(_optionProjectPath);
-                deployCommand.Add(_optionStackName);
+                deployCommand.Add(_optionApplicationName);
                 deployCommand.Add(_optionApply);
                 deployCommand.Add(_optionDiagnosticLogging);
                 deployCommand.Add(_optionDisableInteractive);
@@ -224,7 +224,7 @@ namespace AWS.Deploy.CLI.Commands
                         deploymentProjectPath = Path.GetFullPath(deploymentProjectPath, targetApplicationDirectoryPath);
                     }
 
-                    await deploy.ExecuteAsync(input.StackName ?? "", deploymentProjectPath, userDeploymentSettings);
+                    await deploy.ExecuteAsync(input.ApplicationName ?? string.Empty, deploymentProjectPath, userDeploymentSettings);
 
                     return CommandReturnCodes.SUCCESS;
                 }

--- a/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/DeployCommandHandlerInput.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/DeployCommandHandlerInput.cs
@@ -13,7 +13,7 @@ namespace AWS.Deploy.CLI.Commands.CommandHandlerInput
         public string? Profile { get; set; }
         public string? Region { get; set; }
         public string? ProjectPath { get; set; }
-        public string? StackName { get; set; }
+        public string? ApplicationName { get; set; }
         public string? Apply { get; set; }
         public bool Diagnostics { get; set; }
         public bool Silent { get; set; }

--- a/src/AWS.Deploy.CLI/Commands/ListDeploymentsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/ListDeploymentsCommand.cs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Utilities;
 
 namespace AWS.Deploy.CLI.Commands
@@ -26,10 +28,11 @@ namespace AWS.Deploy.CLI.Commands
             _interactiveService.WriteLine("Cloud Applications:");
             _interactiveService.WriteLine("-------------------");
 
-            var existingApplications = await _deployedApplicationQueryer.GetExistingDeployedApplications();
+            var deploymentTypes = new List<DeploymentTypes>(){ DeploymentTypes.CdkProject, DeploymentTypes.BeanstalkEnvironment };
+            var existingApplications = await _deployedApplicationQueryer.GetExistingDeployedApplications(deploymentTypes);
             foreach (var app in existingApplications)
             {
-                _interactiveService.WriteLine(app.Name);
+                _interactiveService.WriteLine(app.DisplayName);
             }
         }
     }

--- a/src/AWS.Deploy.CLI/ServerMode/SessionState.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/SessionState.cs
@@ -28,7 +28,7 @@ namespace AWS.Deploy.CLI.ServerMode
 
         public Recommendation? SelectedRecommendation { get; set; }
 
-        public CloudApplication ApplicationDetails { get; } = new CloudApplication(string.Empty, string.Empty);
+        public CloudApplication ApplicationDetails { get; } = new CloudApplication(string.Empty, string.Empty, CloudApplicationResourceType.None, string.Empty);
 
         public Task? DeploymentTask { get; set; }
 

--- a/src/AWS.Deploy.Common/CloudApplication.cs
+++ b/src/AWS.Deploy.Common/CloudApplication.cs
@@ -11,23 +11,28 @@ namespace AWS.Deploy.Common
     public class CloudApplication
     {
         /// <summary>
-        /// Name of the CloudApplication
-        /// used to create CloudFormation stack
+        /// Name of the CloudApplication resource
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// Name of CloudFormation stack
+        /// The unique Id to identify the CloudApplication.
+        /// The ID is set to the StackId if the CloudApplication is an existing Cloudformation stack.
+        /// The ID is set to the EnvironmentArn if the CloudApplication is an existing Elastic Beanstalk environment.
+        /// The ID is set to string.Empty for new CloudApplications.
         /// </summary>
-        /// <remarks>
-        /// <see cref="Name"/> and <see cref="StackName"/> are two different properties and just happens to be same value at this moment.
-        /// </remarks>
-        public string StackName => Name;
+        public string UniqueIdentifier { get; set; }
 
         /// <summary>
-        /// The id of the AWS .NET deployment tool recipe used to create the cloud application.
+        /// The id of the AWS .NET deployment tool recipe used to create or re-deploy the cloud application.
         /// </summary>
         public string RecipeId { get; set; }
+
+        /// <summary>
+        /// indicates the type of the AWS resource which serves as the deployment target.
+        /// Current supported values are None, CloudFormationStack and BeanstalkEnvironment.
+        /// </summary>
+        public CloudApplicationResourceType ResourceType { get; set; }
 
         /// <summary>
         /// Last updated time of CloudFormation stack
@@ -40,14 +45,21 @@ namespace AWS.Deploy.Common
         public bool UpdatedByCurrentUser { get; set; }
 
         /// <summary>
+        /// This name is shown to the user when the CloudApplication is presented as an existing re-deployment target.
+        /// </summary>
+        public string DisplayName => $"{Name} ({ResourceType})";
+
+        /// <summary>
         /// Display the name of the Cloud Application
         /// </summary>
         /// <returns></returns>
         public override string ToString() => Name;
 
-        public CloudApplication(string name, string recipeId, DateTime? lastUpdatedTime = null)
+        public CloudApplication(string name, string uniqueIdentifier, CloudApplicationResourceType resourceType, string recipeId, DateTime? lastUpdatedTime = null)
         {
             Name = name;
+            UniqueIdentifier = uniqueIdentifier;
+            ResourceType = resourceType;
             RecipeId = recipeId;
             LastUpdatedTime = lastUpdatedTime;
         }

--- a/src/AWS.Deploy.Common/CloudApplicationResourceType.cs
+++ b/src/AWS.Deploy.Common/CloudApplicationResourceType.cs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Common
+{
+    public enum CloudApplicationResourceType
+    {
+        None,
+        CloudFormationStack,
+        BeanstalkEnvironment
+    }
+}

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -23,7 +23,7 @@ namespace AWS.Deploy.Common
         ProjectPathNotFound = 10000100,
         ProjectParserNoSdkAttribute = 10000200,
         InvalidCliArguments = 10000300,
-        SilentArgumentNeedsStackNameArgument = 10000400,
+        SilentArgumentNeedsApplicationNameArgument = 10000400,
         SilentArgumentNeedsDeploymentRecipe = 10000500,
         DeploymentProjectPathNotFound = 10000600,
         RuleHasInvalidTestType = 10000700,
@@ -90,7 +90,8 @@ namespace AWS.Deploy.Common
         CompatibleRecommendationForRedeploymentNotFound = 10006800,
         InvalidSaveDirectoryForCdkProject = 10006900,
         FailedToFindDeploymentProjectRecipeId = 10007000,
-        UnexpectedError = 10007100
+        UnexpectedError = 10007100,
+        FailedToCreateDeploymentCommandInstance = 10007200
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/Recipes/DeploymentTypes.cs
+++ b/src/AWS.Deploy.Common/Recipes/DeploymentTypes.cs
@@ -1,10 +1,11 @@
-﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace AWS.Deploy.Common.Recipes
 {
     public enum DeploymentTypes
     {
-        CdkProject
+        CdkProject,
+        BeanstalkEnvironment
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -29,6 +29,11 @@ namespace AWS.Deploy.Common.Recipes
         public string Name { get; set; }
 
         /// <summary>
+        /// Indicates if this recipe should be presented as an option during new deployments.
+        /// </summary>
+        public bool DisableNewDeployments { get; set; }
+
+        /// <summary>
         /// Description of the recipe informing the user what this recipe does and why it is recommended.
         /// </summary>
         public string Description { get; set; }

--- a/src/AWS.Deploy.Common/UserDeploymentSettings.cs
+++ b/src/AWS.Deploy.Common/UserDeploymentSettings.cs
@@ -19,7 +19,7 @@ namespace AWS.Deploy.Common
 
         public string? AWSRegion { get; set; }
 
-        public string? StackName { get; set; }
+        public string? ApplicationName { get; set; }
 
         public string? RecipeId { get; set; }
 

--- a/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
+++ b/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
@@ -12,5 +12,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)CDK.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CLI.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CloudFormationIdentifier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RecipeIdentifier.cs" />
   </ItemGroup>
 </Project>

--- a/src/AWS.Deploy.Constants/CLI.cs
+++ b/src/AWS.Deploy.Constants/CLI.cs
@@ -9,9 +9,9 @@ namespace AWS.Deploy.Constants
         public const string CREATE_NEW_LABEL = "*** Create new ***";
         public const string DEFAULT_LABEL = "*** Default ***";
         public const string EMPTY_LABEL = "*** Empty ***";
-        public const string CREATE_NEW_STACK_LABEL = "*** Deploy to a new stack ***";
-        public const string PROMPT_NEW_STACK_NAME = "Enter the name of the new stack";
-        public const string PROMPT_CHOOSE_STACK_NAME = "Choose stack to deploy to";
+        public const string CREATE_NEW_STACK_LABEL = "*** Deploy to a new CloudFormation stack ***";
+        public const string PROMPT_NEW_STACK_NAME = "Enter the name of the new CloudFormationStack stack";
+        public const string PROMPT_CHOOSE_DEPLOYMENT_TARGET = "Choose deployment target";
 
         public const string CLI_APP_NAME = "AWS .NET Deployment Tool";
     }

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Constants
+{
+    internal static class RecipeIdentifier
+    {
+        public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";
+        public const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
+        public const string EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkEnvironment";
+    }
+}

--- a/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
+++ b/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
@@ -19,7 +19,7 @@ namespace AWS.Deploy.Orchestration
 
             // General Settings
             var appSettingsContainer = new RecipeProps<Dictionary<string, object>>(
-                cloudApplication.StackName,
+                cloudApplication.Name,
                 projectPath,
                 recommendation.Recipe.Id,
                 recommendation.Recipe.Version,

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -50,7 +50,8 @@ namespace AWS.Deploy.Orchestration.Data
         Task<Amazon.S3.Model.WebsiteConfiguration> GetS3BucketWebSiteConfiguration(string bucketName);
         Task<List<Cluster>> ListOfECSClusters();
         Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications();
-        Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName);
+        Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName = null);
+        Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn);
         Task<List<KeyPairInfo>> ListOfEC2KeyPairs();
         Task<string> CreateEC2KeyPair(string keyName, string saveLocation);
         Task<List<Role>> ListOfIAMRoles(string? servicePrincipal);
@@ -240,13 +241,10 @@ namespace AWS.Deploy.Orchestration.Data
             return applications.Applications;
         }
 
-        public async Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName)
+        public async Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName = null)
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
             var environments = new List<EnvironmentDescription>();
-
-            if (string.IsNullOrEmpty(applicationName))
-                return environments;
 
             var request = new DescribeEnvironmentsRequest
             {
@@ -263,6 +261,17 @@ namespace AWS.Deploy.Orchestration.Data
             } while (!string.IsNullOrEmpty(request.NextToken));
 
             return environments;
+        }
+
+        public async Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn)
+        {
+            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+            var response = await beanstalkClient.ListTagsForResourceAsync(new Amazon.ElasticBeanstalk.Model.ListTagsForResourceRequest
+            {
+                ResourceArn = resourceArn
+            });
+
+            return response.ResourceTags;
         }
 
         public async Task<List<KeyPairInfo>> ListOfEC2KeyPairs()

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -51,7 +51,7 @@ namespace AWS.Deploy.Orchestration
 
             var dockerExecutionDirectory = GetDockerExecutionDirectory(recommendation);
             var tagSuffix = DateTime.UtcNow.Ticks;
-            var imageTag = $"{cloudApplication.StackName.ToLower()}:{tagSuffix}";
+            var imageTag = $"{cloudApplication.Name.ToLower()}:{tagSuffix}";
             var dockerFile = GetDockerFilePath(recommendation);
             var buildArgs = GetDockerBuildArgs(recommendation);
 
@@ -79,7 +79,7 @@ namespace AWS.Deploy.Orchestration
             await InitiateDockerLogin();
 
             var tagSuffix = sourceTag.Split(":")[1];
-            var repository = await SetupECRRepository(cloudApplication.StackName.ToLower());
+            var repository = await SetupECRRepository(cloudApplication.Name.ToLower());
             var targetTag = $"{repository.RepositoryUri}:{tagSuffix}";
 
             await TagDockerImage(sourceTag, targetTag);

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.DisplayedResources;
+
+namespace AWS.Deploy.Orchestration.DeploymentCommands
+{
+    /// <summary>
+    /// This class is a Work In Progress.
+    /// </summary>
+    public class BeanstalkEnvironmentDeploymentCommand : IDeploymentCommand
+    {
+        public Task ExecuteAsync(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation recommendation) => throw new NotImplementedException();
+        public Task<List<DisplayedResourceItem>> GetDeploymentOutputsAsync(IDisplayedResourcesHandler displayedResourcesHandler, CloudApplication cloudApplication, Recommendation recommendation) => throw new NotImplementedException();
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestration.DisplayedResources;
+
+namespace AWS.Deploy.Orchestration.DeploymentCommands
+{
+    public class CdkDeploymentCommand : IDeploymentCommand
+    {
+        public async Task ExecuteAsync(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation recommendation)
+        {
+            if (orchestrator._interactiveService == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._interactiveService)} is null as part of the orchestartor object");
+            if (orchestrator._cdkManager == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._cdkManager)} is null as part of the orchestartor object");
+            if (orchestrator._cdkProjectHandler == null)
+                throw new InvalidOperationException($"{nameof(CdkProjectHandler)} is null as part of the orchestartor object");
+            if (orchestrator._localUserSettingsEngine == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._localUserSettingsEngine)} is null as part of the orchestartor object");
+            if (orchestrator._session == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._session)} is null as part of the orchestartor object");
+            if (orchestrator._cdkVersionDetector == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._cdkVersionDetector)} must not be null.");
+            if (orchestrator._directoryManager == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._directoryManager)} must not be null.");
+
+            orchestrator._interactiveService.LogMessageLine(string.Empty);
+            orchestrator._interactiveService.LogMessageLine($"Initiating deployment: {recommendation.Name}");
+
+            orchestrator._interactiveService.LogMessageLine("Configuring AWS Cloud Development Kit (CDK)...");
+            var cdkProject = await orchestrator._cdkProjectHandler.ConfigureCdkProject(orchestrator._session, cloudApplication, recommendation);
+
+            var projFiles = orchestrator._directoryManager.GetProjFiles(cdkProject);
+            var cdkVersion = orchestrator._cdkVersionDetector.Detect(projFiles);
+
+            await orchestrator._cdkManager.EnsureCompatibleCDKExists(Constants.CDK.DeployToolWorkspaceDirectoryRoot, cdkVersion);
+
+            try
+            {
+                await orchestrator._cdkProjectHandler.DeployCdkProject(orchestrator._session, cdkProject, recommendation);
+            }
+            finally
+            {
+                orchestrator._cdkProjectHandler.DeleteTemporaryCdkProject(orchestrator._session, cdkProject);
+            }
+
+            await orchestrator._localUserSettingsEngine.UpdateLastDeployedStack(cloudApplication.Name, orchestrator._session.ProjectDefinition.ProjectName, orchestrator._session.AWSAccountId, orchestrator._session.AWSRegion);
+        }
+
+        public async Task<List<DisplayedResourceItem>> GetDeploymentOutputsAsync(IDisplayedResourcesHandler displayedResourcesHandler, CloudApplication cloudApplication, Recommendation recommendation)
+        {
+            var displayedResources = new List<DisplayedResourceItem>();
+
+            if (recommendation.Recipe.DisplayedResources == null)
+                return displayedResources;
+
+            var resources = await displayedResourcesHandler.AwsResourceQueryer.DescribeCloudFormationResources(cloudApplication.Name);
+            foreach (var displayedResource in recommendation.Recipe.DisplayedResources)
+            {
+                var resource = resources.FirstOrDefault(x => x.LogicalResourceId.Equals(displayedResource.LogicalId));
+                if (resource == null)
+                    continue;
+
+                var data = new Dictionary<string, string>();
+                if (!string.IsNullOrEmpty(resource.ResourceType) && displayedResourcesHandler.DisplayedResourcesFactory.GetResource(resource.ResourceType) is var displayedResourceCommand && displayedResourceCommand != null)
+                {
+                    data = await displayedResourceCommand.Execute(resource.PhysicalResourceId);
+                }
+                displayedResources.Add(new DisplayedResourceItem(resource.PhysicalResourceId, displayedResource.Description, resource.ResourceType, data));
+            }
+
+            return displayedResources;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/DeploymentCommandFactory.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/DeploymentCommandFactory.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.Orchestration.DeploymentCommands
+{
+    public static class DeploymentCommandFactory
+    {
+        private static readonly Dictionary<DeploymentTypes, Type> _deploymentCommandTypeMapping = new()
+        {
+            { DeploymentTypes.CdkProject, typeof(CdkDeploymentCommand) },
+            { DeploymentTypes.BeanstalkEnvironment, typeof(BeanstalkEnvironmentDeploymentCommand) }
+        };
+
+        public static IDeploymentCommand BuildDeploymentCommand(DeploymentTypes deploymentType)
+        {
+            if (!_deploymentCommandTypeMapping.ContainsKey(deploymentType))
+            {
+                var message = $"Failed to create an instance of type {nameof(IDeploymentCommand)}. {deploymentType} does not exist as a key in {_deploymentCommandTypeMapping}.";
+                throw new FailedToCreateDeploymentCommandInstance(DeployToolErrorCode.FailedToCreateDeploymentCommandInstance, message);
+            }
+                
+            var deploymentCommandInstance = Activator.CreateInstance(_deploymentCommandTypeMapping[deploymentType]);
+            if (deploymentCommandInstance == null || deploymentCommandInstance is not IDeploymentCommand)
+            {
+                var message = $"Failed to create an instance of type {_deploymentCommandTypeMapping[deploymentType]}.";
+                throw new FailedToCreateDeploymentCommandInstance(DeployToolErrorCode.FailedToCreateDeploymentCommandInstance, message);
+            }
+
+            return (IDeploymentCommand)deploymentCommandInstance;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/DeploymentStatus.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/DeploymentStatus.cs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Orchestration.DeploymentCommands
+{
+    public enum DeploymentStatus { NotStarted = 1, Executing = 2, Error = 3, Success = 4 }
+}

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/IDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/IDeploymentCommand.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.DisplayedResources;
+
+namespace AWS.Deploy.Orchestration.DeploymentCommands
+{
+    public interface IDeploymentCommand
+    {
+        Task ExecuteAsync(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation recommendation);
+        Task<List<DisplayedResourceItem>> GetDeploymentOutputsAsync(IDisplayedResourcesHandler displayedResourcesHandler, CloudApplication cloudApplication, Recommendation recommendation);
+    }
+}

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -171,4 +171,9 @@ namespace AWS.Deploy.Orchestration
     {
         public DockerInfoException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+
+    public class FailedToCreateDeploymentCommandInstance : DeployToolException
+    {
+        public FailedToCreateDeploymentCommandInstance(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
@@ -70,7 +70,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             var suffix = 1;
             while (suffix < 100)
             {
-                if (existingApplications.All(x => x.StackName != recommendation) && IsValidName(recommendation))
+                if (existingApplications.All(x => x.Name != recommendation) && IsValidName(recommendation))
                     return recommendation;
 
                 recommendation = $"{recommendedPrefix}{suffix++}";

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
+using Amazon.ElasticBeanstalk;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Recipes.CDK.Common;
@@ -17,13 +19,12 @@ namespace AWS.Deploy.Orchestration.Utilities
     public interface IDeployedApplicationQueryer
     {
         /// <summary>
-        /// Get the list of existing deployed applications by describe the CloudFormation stacks and filtering the stacks to the
-        /// ones that have the AWS .NET deployment tool tag and description.
+        /// Get the list of existing deployed <see cref="CloudApplication"/> based on the deploymentTypes filter.
         /// </summary>
-        Task<List<CloudApplication>> GetExistingDeployedApplications();
+        Task<List<CloudApplication>> GetExistingDeployedApplications(List<DeploymentTypes> deploymentTypes);
 
         /// <summary>
-        /// Get the list of compatible applications based on the matching elements of the deployed stack and recommendation, such as Recipe Id.
+        /// Get the list of compatible applications by matching elements of the CloudApplication RecipeId and the recommendation RecipeId.
         /// </summary>
         Task<List<CloudApplication>> GetCompatibleApplications(List<Recommendation> recommendations, List<CloudApplication>? allDeployedApplications = null, OrchestratorSession? session = null);
 
@@ -49,45 +50,17 @@ namespace AWS.Deploy.Orchestration.Utilities
             _orchestratorInteractiveService = orchestratorInteractiveService;
         }
 
-        public async Task<List<CloudApplication>> GetExistingDeployedApplications()
+        public async Task<List<CloudApplication>> GetExistingDeployedApplications(List<DeploymentTypes> deploymentTypes)
         {
-            var stacks = await _awsResourceQueryer.GetCloudFormationStacks();
-            var apps = new List<CloudApplication>();
+            var existingApplications = new List<CloudApplication>();
 
-            foreach (var stack in stacks)
-            {
-                // Check to see if stack has AWS .NET deployment tool tag and the stack is not deleted or in the process of being deleted.
-                var deployTag = stack.Tags.FirstOrDefault(tags => string.Equals(tags.Key, Constants.CloudFormationIdentifier.STACK_TAG));
+            if (deploymentTypes.Contains(DeploymentTypes.CdkProject))
+                existingApplications.AddRange(await GetExistingCloudFormationStacks());
 
-                // Skip stacks that don't have AWS .NET deployment tool tag
-                if (deployTag == null ||
+            if (deploymentTypes.Contains(DeploymentTypes.BeanstalkEnvironment))
+                existingApplications.AddRange(await GetExistingBeanstalkEnvironments());
 
-                    // Skip stacks does not have AWS .NET deployment tool description prefix. (This is filter out stacks that have the tag propagated to it like the Beanstalk stack)
-                    (stack.Description == null || !stack.Description.StartsWith(Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX)) ||
-
-                    // Skip tags that are deleted or in the process of being deleted
-                    stack.StackStatus.ToString().StartsWith("DELETE"))
-                {
-                    continue;
-                }
-
-                // ROLLBACK_COMPLETE occurs when a stack creation fails and successfully rollbacks with cleaning partially created resources.
-                // In this state, only a delete operation can be performed. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html)
-                // We don't want to include ROLLBACK_COMPLETE because it never succeeded to deploy.
-                // However, a customer can give name of new application same as ROLLBACK_COMPLETE stack, which will trigger the re-deployment flow on the ROLLBACK_COMPLETE stack.
-                if (stack.StackStatus == StackStatus.ROLLBACK_COMPLETE)
-                {
-                    continue;
-                }
-
-                // If a list of compatible recommendations was given then skip existing applications that were used with a
-                // recipe that is not compatible.
-                var recipeId = deployTag.Value;
-
-                apps.Add(new CloudApplication(stack.StackName, recipeId, stack.LastUpdatedTime));
-            }
-
-            return apps;
+            return existingApplications;
         }
 
         /// <summary>
@@ -100,7 +73,7 @@ namespace AWS.Deploy.Orchestration.Utilities
         {
             var compatibleApplications = new List<CloudApplication>();
             if (allDeployedApplications == null)
-                allDeployedApplications = await GetExistingDeployedApplications();
+                allDeployedApplications = await GetExistingDeployedApplications(recommendations.Select(x => x.Recipe.DeploymentType).ToList());
 
             foreach (var application in allDeployedApplications)
             {
@@ -114,14 +87,14 @@ namespace AWS.Deploy.Orchestration.Utilities
             {
                 try
                 {
-                    await _localUserSettingsEngine.CleanOrphanStacks(allDeployedApplications.Select(x => x.StackName).ToList(), session.ProjectDefinition.ProjectName, session.AWSAccountId, session.AWSRegion);
+                    await _localUserSettingsEngine.CleanOrphanStacks(allDeployedApplications.Select(x => x.Name).ToList(), session.ProjectDefinition.ProjectName, session.AWSAccountId, session.AWSRegion);
                     var deploymentManifest = await _localUserSettingsEngine.GetLocalUserSettings();
                     var lastDeployedStack = deploymentManifest?.LastDeployedStacks?
                     .FirstOrDefault(x => x.Exists(session.AWSAccountId, session.AWSRegion, session.ProjectDefinition.ProjectName));
 
                     return compatibleApplications
                         .Select(x => {
-                            x.UpdatedByCurrentUser = lastDeployedStack?.Stacks?.Contains(x.StackName) ?? false;
+                            x.UpdatedByCurrentUser = lastDeployedStack?.Stacks?.Contains(x.Name) ?? false;
                             return x;
                             })
                         .OrderByDescending(x => x.UpdatedByCurrentUser)
@@ -157,6 +130,84 @@ namespace AWS.Deploy.Orchestration.Utilities
                 return string.Equals(recommendation.Recipe.Id, application.RecipeId, StringComparison.Ordinal) || string.Equals(recommendation.Recipe.BaseRecipeId, application.RecipeId, StringComparison.Ordinal);
             }
             return string.Equals(recommendation.Recipe.Id, application.RecipeId, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Fetches existing CloudFormation stacks created by the AWS .NET deployment tool
+        /// </summary>
+        /// <returns>A list of <see cref="CloudApplication"/></returns>
+        private async Task<List<CloudApplication>> GetExistingCloudFormationStacks()
+        {
+            var stacks = await _awsResourceQueryer.GetCloudFormationStacks();
+            var apps = new List<CloudApplication>();
+
+            foreach (var stack in stacks)
+            {
+                // Check to see if stack has AWS .NET deployment tool tag and the stack is not deleted or in the process of being deleted.
+                var deployTag = stack.Tags.FirstOrDefault(tags => string.Equals(tags.Key, Constants.CloudFormationIdentifier.STACK_TAG));
+
+                // Skip stacks that don't have AWS .NET deployment tool tag
+                if (deployTag == null ||
+
+                    // Skip stacks does not have AWS .NET deployment tool description prefix. (This is filter out stacks that have the tag propagated to it like the Beanstalk stack)
+                    (stack.Description == null || !stack.Description.StartsWith(Constants.CloudFormationIdentifier.STACK_DESCRIPTION_PREFIX)) ||
+
+                    // Skip tags that are deleted or in the process of being deleted
+                    stack.StackStatus.ToString().StartsWith("DELETE"))
+                {
+                    continue;
+                }
+
+                // ROLLBACK_COMPLETE occurs when a stack creation fails and successfully rollbacks with cleaning partially created resources.
+                // In this state, only a delete operation can be performed. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html)
+                // We don't want to include ROLLBACK_COMPLETE because it never succeeded to deploy.
+                // However, a customer can give name of new application same as ROLLBACK_COMPLETE stack, which will trigger the re-deployment flow on the ROLLBACK_COMPLETE stack.
+                if (stack.StackStatus == StackStatus.ROLLBACK_COMPLETE)
+                {
+                    continue;
+                }
+
+                // If a list of compatible recommendations was given then skip existing applications that were used with a
+                // recipe that is not compatible.
+                var recipeId = deployTag.Value;
+
+                apps.Add(new CloudApplication(stack.StackName, stack.StackId, CloudApplicationResourceType.CloudFormationStack, recipeId, stack.LastUpdatedTime));
+            }
+
+            return apps;
+        }
+
+        /// <summary>
+        /// Fetches existing Elastic Beanstalk environments that can serve as a deployment target.
+        /// These environments must have a valid dotnet specific platform arn.
+        /// Any environment that was created via the AWS .NET deployment tool as part of a CloudFormation stack is not included.
+        /// </summary>
+        /// <returns>A list of <see cref="CloudApplication"/></returns>
+        private async Task<List<CloudApplication>> GetExistingBeanstalkEnvironments()
+        {
+            var validEnvironments = new List<CloudApplication>();
+            var environments = await _awsResourceQueryer.ListOfElasticBeanstalkEnvironments();
+
+            if (!environments.Any())
+                return validEnvironments;
+
+            var dotnetPlatformArns = (await _awsResourceQueryer.GetElasticBeanstalkPlatformArns()).Select(x => x.PlatformArn).ToList();
+
+            // only select environments that have a dotnet specific platform ARN.
+            environments = environments.Where(x => x.Status == EnvironmentStatus.Ready && dotnetPlatformArns.Contains(x.PlatformArn)).ToList();
+
+            foreach (var env in environments)
+            {
+                var tags = await _awsResourceQueryer.ListElasticBeanstalkResourceTags(env.EnvironmentArn);
+
+                // skips all environments that were created via the deploy tool.
+                if (tags.Any(x => string.Equals(x.Key, Constants.CloudFormationIdentifier.STACK_TAG)))
+                    continue;
+
+                validEnvironments.Add(new CloudApplication(env.EnvironmentName, env.EnvironmentArn, CloudApplicationResourceType.BeanstalkEnvironment, Constants.RecipeIdentifier.EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID, env.DateUpdated));
+            }
+
+            return validEnvironments;
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -1,0 +1,88 @@
+{
+    "$schema": "./aws-deploy-recipe-schema.json",
+    "Id": "AspNetAppExistingBeanstalkEnvironment",
+    "Version": "0.1.0",
+    "Name": "ASP.NET Core App to Existing AWS Elastic Beanstalk Environment",
+    "DisableNewDeployments": true,
+    "DeploymentType": "BeanstalkEnvironment",
+    "DeploymentBundle": "DotnetPublishZipFile",
+    "Description": "This ASP.NET Core application will be built and deployed to existing AWS Elastic Beanstalk environment. Recommended if you do not want to deploy your application as a container image.",
+    "ShortDescription": "ASP.NET Core application deployed to AWS Elastic Beanstalk on Linux.",
+    "TargetService": "AWS Elastic Beanstalk",
+
+    "RecipePriority": 0,
+    "RecommendationRules": [
+        {
+            "Tests": [
+                {
+                    "Type": "MSProjectSdkAttribute",
+                    "Condition": {
+                        "Value": "Microsoft.NET.Sdk.Web"
+                    }
+                },
+                {
+                    "Type": "MSProperty",
+                    "Condition": {
+                        "PropertyName": "TargetFramework",
+                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0" ]
+                    }
+                }
+            ],
+            "Effect": {
+                "Pass": { "Include": true },
+                "Fail": {"Include": false}
+            }
+        }
+    ],
+
+    "OptionSettings": [
+        {
+            "Id": "EnhancedHealthReporting",
+            "Name": "Enhanced Health Reporting",
+            "Description": "Enhanced health reporting provides free real-time application and operating system monitoring of the instances and other resources in your environment.",
+            "Type": "String",
+            "DefaultValue": "enhanced",
+            "AllowedValues": [
+                "enhanced",
+                "basic"
+            ],
+            "ValueMapping": {
+                "enhanced": "Enhanced",
+                "basic": "Basic"
+            },
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
+            "Id": "XRayTracingSupportEnabled",
+            "Name": "Enable AWS X-Ray Tracing Support",
+            "Description": "AWS X-Ray is a service that collects data about requests that your application serves, and provides tools you can use to view, filter, and gain insights into that data to identify issues and opportunities for optimization. Do you want to enable AWS X-Ray tracing support?",
+            "Type": "Bool",
+            "DefaultValue": false,
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
+            "Id": "ReverseProxy",
+            "Name": "Reverse Proxy",
+            "Description": "By default Nginx is used as a reverse proxy in front of the .NET Core web server Kestrel. To use Kestrel as the front facing web server then select `none` as the reverse proxy.",
+            "Type": "String",
+            "DefaultValue": "nginx",
+            "AllowedValues": [
+                "nginx",
+                "none"
+            ],
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
+            "Id": "HealthCheckURL",
+            "Name": "Health Check URL",
+            "Description": "Customize the load balancer health check to ensure that your application, and not just the web server, is in a good state.",
+            "Type": "String",
+            "DefaultValue": "/",
+            "AdvancedSetting": false,
+            "Updatable": true
+        }
+    ]
+}

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -33,17 +33,28 @@
             "description": "The unique id for the recipe. This value should never been change once the recipe is released because it will be stored in user config files.",
             "minLength": 1
         },
+        "Version": {
+            "type": "string",
+            "title": "Version string for the recipe",
+            "description": "Version string for the recipe. Its value will be incremented when the recipe is updated.",
+            "minLength": 1
+        },
         "Name": {
             "type": "string",
             "title": "Name",
             "description": "The name that will be showed to the user when choosing which recipe to choose for deployment.",
             "minLength": 1
         },
+        "DisableNewDeployments": {
+            "type": "boolean",
+            "title": "DisableNewDeployments",
+            "description": "A boolean value that indicates if this recipe should be presented as an option during new deployments."
+        },
         "DeploymentType": {
             "type": "string",
             "title": "Deployment type",
             "description": "The technology used to deploy the project.",
-            "enum": [ "CdkProject" ]
+            "enum": [ "CdkProject",  "BeanstalkEnvironment"]
         },
         "DeploymentBundle": {
             "type": "string",

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
@@ -25,7 +25,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
         {
             Assert.Equal("default", _userDeploymentSettings.AWSProfile);
             Assert.Equal("us-west-2", _userDeploymentSettings.AWSRegion);
-            Assert.Equal("MyAppStack", _userDeploymentSettings.StackName);
+            Assert.Equal("MyAppStack", _userDeploymentSettings.ApplicationName);
             Assert.Equal("AspNetAppEcsFargate", _userDeploymentSettings.RecipeId);
 
             var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
@@ -25,7 +25,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
         {
             Assert.Equal("default", _userDeploymentSettings.AWSProfile);
             Assert.Equal("us-west-2", _userDeploymentSettings.AWSRegion);
-            Assert.Equal("MyAppStack", _userDeploymentSettings.StackName);
+            Assert.Equal("MyAppStack", _userDeploymentSettings.ApplicationName);
             Assert.Equal("AspNetAppElasticBeanstalkLinux", _userDeploymentSettings.RecipeId);
 
             var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkKeyValueDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/ElasticBeanStalkKeyValueDeploymentTest.cs
@@ -25,7 +25,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
         {
             Assert.Equal("default", _userDeploymentSettings.AWSProfile);
             Assert.Equal("us-west-2", _userDeploymentSettings.AWSRegion);
-            Assert.Equal("MyAppStack", _userDeploymentSettings.StackName);
+            Assert.Equal("MyAppStack", _userDeploymentSettings.ApplicationName);
             Assert.Equal("AspNetAppElasticBeanstalkLinux", _userDeploymentSettings.RecipeId);
 
             var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ECSFargateConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ECSFargateConfigFile.json
@@ -1,7 +1,7 @@
 {
     "AWSProfile": "default",
     "AWSRegion": "us-west-2",
-    "StackName": "MyAppStack",
+    "ApplicationName": "MyAppStack",
     "RecipeId": "AspNetAppEcsFargate",
     "OptionSettingsConfig":{
         "ECSCluster": 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkConfigFile.json
@@ -1,7 +1,7 @@
 {
     "AWSProfile": "default",
     "AWSRegion": "us-west-2",
-    "StackName": "MyAppStack",
+    "ApplicationName": "MyAppStack",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
     "OptionSettingsConfig": {
         "BeanstalkApplication": {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkKeyPairConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/ElasticBeanStalkKeyPairConfigFile.json
@@ -1,7 +1,7 @@
 {
     "AWSProfile": "default",
     "AWSRegion": "us-west-2",
-    "StackName": "MyAppStack",
+    "ApplicationName": "MyAppStack",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
     "OptionSettingsConfig": {
         "BeanstalkApplication": {

--- a/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BlazorWasmTests.cs
@@ -65,7 +65,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _interactiveService.StdInWriter.FlushAsync();
 
             // Deploy
-            var deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--application-name", _stackName, "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
@@ -95,7 +95,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Setup for redeployment turning on access logging via settings file.
@@ -103,7 +103,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _interactiveService.StdInWriter.FlushAsync();
 
             var applyLoggingSettingsFile = Path.Combine(Directory.GetParent(_testAppManager.GetProjectPath(Path.Combine(components))).FullName, "apply-settings.json");
-            deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--stack-name", _stackName, "--diagnostics", "--apply", applyLoggingSettingsFile };
+            deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--application-name", _stackName, "--diagnostics", "--apply", applyLoggingSettingsFile };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
@@ -67,7 +67,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 
             var userDeploymentSettings = UserDeploymentSettings.ReadSettings(configFilePath);
 
-            _stackName = userDeploymentSettings.StackName;
+            _stackName = userDeploymentSettings.ApplicationName;
             _clusterName = userDeploymentSettings.LeafOptionSettingItems["ECSCluster.NewClusterName"];
 
             var deployArgs = new[] { "deploy", "--project-path", projectPath, "--apply", configFilePath, "--silent", "--diagnostics" };
@@ -94,7 +94,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 
             var userDeploymentSettings = UserDeploymentSettings.ReadSettings(configFilePath);
 
-            _stackName = userDeploymentSettings.StackName;
+            _stackName = userDeploymentSettings.ApplicationName;
 
             var deployArgs = new[] { "deploy", "--project-path", projectPath, "--apply", configFilePath, "--silent", "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
@@ -84,7 +84,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -69,7 +69,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _interactiveService.StdInWriter.FlushAsync();
 
             // Deploy
-            var deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--application-name", _stackName, "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
@@ -94,7 +94,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -50,10 +50,11 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var recommendations = await orchestrator.GenerateDeploymentRecommendations();
 
             // ASSERT
-            recommendations.Count.ShouldEqual(3);
+            recommendations.Count.ShouldEqual(4);
             recommendations[0].Name.ShouldEqual("ASP.NET Core App to Amazon ECS using Fargate"); // default recipe
             recommendations[1].Name.ShouldEqual("ASP.NET Core App to AWS App Runner"); // default recipe
             recommendations[2].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Linux"); // default recipe
+            recommendations[3].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Environment"); // default recipe
         }
 
         [Fact]
@@ -85,12 +86,13 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var recommendations = await orchestrator.GenerateDeploymentRecommendations();
 
             // ASSERT - Recipes are ordered by priority
-            recommendations.Count.ShouldEqual(5);
+            recommendations.Count.ShouldEqual(6);
             recommendations[0].Name.ShouldEqual(customEcsRecipeName); // custom recipe
             recommendations[1].Name.ShouldEqual(customEbsRecipeName); // custom recipe
             recommendations[2].Name.ShouldEqual("ASP.NET Core App to Amazon ECS using Fargate"); // default recipe
             recommendations[3].Name.ShouldEqual("ASP.NET Core App to AWS App Runner"); // default recipe
             recommendations[4].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Linux"); // default recipe
+            recommendations[5].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Environment"); // default recipe
 
             // ASSERT - Recipe paths
             recommendations[0].Recipe.RecipePath.ShouldEqual(Path.Combine(saveDirectoryPathEcsProject, "ECS-CDK.recipe"));
@@ -133,12 +135,13 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var recommendations = await orchestrator.GenerateDeploymentRecommendations();
 
             // ASSERT - Recipes are ordered by priority
-            recommendations.Count.ShouldEqual(5);
+            recommendations.Count.ShouldEqual(6);
             recommendations[0].Name.ShouldEqual(customEbsRecipeName);
             recommendations[1].Name.ShouldEqual(customEcsRecipeName);
             recommendations[2].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Linux");
             recommendations[3].Name.ShouldEqual("ASP.NET Core App to Amazon ECS using Fargate");
             recommendations[4].Name.ShouldEqual("ASP.NET Core App to AWS App Runner");
+            recommendations[5].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Environment");
 
             // ASSERT - Recipe paths
             recommendations[0].Recipe.RecipePath.ShouldEqual(Path.Combine(saveDirectoryPathEbsProject, "EBS-CDK.recipe"));

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RedeploymentTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RedeploymentTests.cs
@@ -70,14 +70,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             await Utilities.CreateCDKDeploymentProjectWithRecipeName(projectPath, "Custom App Runner Recipe", "2", incompatibleDeploymentProjectPath, underSourceControl: false);
 
             // attempt re-deployment using incompatible CDK project
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--deployment-project", incompatibleDeploymentProjectPath, "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--deployment-project", incompatibleDeploymentProjectPath, "--application-name", _stackName, "--diagnostics" };
             var returnCode = await _app.Run(deployArgs);
             Assert.Equal(CommandReturnCodes.USER_ERROR, returnCode);
 
             // attempt re-deployment using compatible CDK project
             await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default option settings
             await _interactiveService.StdInWriter.FlushAsync();
-            deployArgs = new[] { "deploy", "--project-path", projectPath, "--deployment-project", compatibleDeploymentProjectPath, "--stack-name", _stackName, "--diagnostics" };
+            deployArgs = new[] { "deploy", "--project-path", projectPath, "--deployment-project", compatibleDeploymentProjectPath, "--application-name", _stackName, "--diagnostics" };
             returnCode = await _app.Run(deployArgs);
             Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
             Assert.Equal(StackStatus.UPDATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
@@ -96,7 +96,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             await _interactiveService.StdInWriter.FlushAsync();
 
             // Deploy
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
             var returnCode = await _app.Run(deployArgs);
             Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
 
@@ -121,7 +121,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             Assert.Equal(CommandReturnCodes.SUCCESS, returnCode);
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
         }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -54,5 +54,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
+        public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -62,7 +62,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
             // Deploy
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
@@ -87,7 +87,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
@@ -67,7 +67,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
             // Deploy
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
@@ -94,7 +94,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for re-deployment
@@ -102,7 +102,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             await _interactiveService.StdInWriter.FlushAsync();
 
             // Perform re-deployment
-            deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
+            deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
             Assert.Equal(StackStatus.UPDATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
             Assert.Equal("ACTIVE", cluster.Status);
@@ -131,7 +131,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
             // Deploy
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--stack-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
@@ -153,7 +153,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs));;
 
             // Verify stack exists in list of deployments
-            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+            var listDeployStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listDeployStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
-            var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty);
+            var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             var result = await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation);
 
             var dockerFile = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(recommendation.ProjectPath)), "Dockerfile");
@@ -82,7 +82,7 @@ namespace AWS.Deploy.CLI.UnitTests
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = projectPath;
 
-            var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty);
+            var cloudApplication = new CloudApplication("ConsoleAppTask", string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             var result = await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation);
 
             var dockerFile = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(recommendation.ProjectPath)), "Dockerfile");
@@ -100,10 +100,10 @@ namespace AWS.Deploy.CLI.UnitTests
             var project = await _projectDefinitionParser.Parse(projectPath);
             var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
 
-            var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty);
+            var cloudApplication = new CloudApplication("ConsoleAppTask", string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             await _deploymentBundleHandler.PushDockerImageToECR(cloudApplication, recommendation, "ConsoleAppTask:latest");
 
-            Assert.Equal(cloudApplication.StackName.ToLower(), recommendation.DeploymentBundle.ECRRepositoryName);
+            Assert.Equal(cloudApplication.Name.ToLower(), recommendation.DeploymentBundle.ECRRepositoryName);
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var recommendations = await engine.ComputeRecommendations();
             var recommendation = recommendations.FirstOrDefault(x => x.Recipe.DeploymentBundle.Equals(DeploymentBundleTypes.Container));
 
-            var cloudApplication = new CloudApplication("WebAppWithSolutionParentLevel", String.Empty);
+            var cloudApplication = new CloudApplication("WebAppWithSolutionParentLevel", string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             var result = await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation);
 
             Assert.Equal(Directory.GetParent(SystemIOUtilities.ResolvePath(projectPath)).FullName, recommendation.DeploymentBundle.DockerExecutionDirectory);
@@ -195,7 +195,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var recommendations = await engine.ComputeRecommendations();
             var recommendation = recommendations.FirstOrDefault(x => x.Recipe.DeploymentBundle.Equals(DeploymentBundleTypes.Container));
 
-            var cloudApplication = new CloudApplication("WebAppNoSolution", String.Empty);
+            var cloudApplication = new CloudApplication("WebAppNoSolution", string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             var result = await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation);
 
             Assert.Equal(Path.GetFullPath(SystemIOUtilities.ResolvePath(projectPath)), recommendation.DeploymentBundle.DockerExecutionDirectory);

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -79,5 +79,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
+        public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeploymentCommandFactoryTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeploymentCommandFactoryTests.cs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestration.DeploymentCommands;
+using Xunit;
+
+namespace AWS.Deploy.Orchestration.UnitTests
+{
+    public class DeploymentCommandFactoryTests
+    {
+        [Theory]
+        [InlineData(DeploymentTypes.CdkProject, typeof(CdkDeploymentCommand))]
+        [InlineData(DeploymentTypes.BeanstalkEnvironment, typeof(BeanstalkEnvironmentDeploymentCommand))]
+        public void BuildsValidDeploymentCommand(DeploymentTypes deploymentType, Type expectedDeploymentCommandType)
+        {
+            var command = DeploymentCommandFactory.BuildDeploymentCommand(deploymentType);
+            Assert.True(command.GetType() == expectedDeploymentCommandType);
+        }
+    }
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
@@ -33,7 +33,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
         public DisplayedResourcesHandlerTests()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
-            _cloudApplication = new CloudApplication("StackName", "RecipeId");
+            _cloudApplication = new CloudApplication("StackName", "UniqueId", CloudApplicationResourceType.CloudFormationStack, "RecipeId");
             _displayedResourcesFactory = new DisplayedResourceCommandFactory(_mockAWSResourceQueryer.Object);
             _stackResource = new StackResource();
             _stackResources = new List<StackResource>() { _stackResource };

--- a/test/AWS.Deploy.Orchestration.UnitTests/Utilities/CloudApplicationNameGeneratorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/Utilities/CloudApplicationNameGeneratorTests.cs
@@ -96,7 +96,7 @@ namespace AWS.Deploy.Orchestration.UnitTests.Utilities
 
             var existingApplication = new List<CloudApplication>
             {
-                new CloudApplication(projectFile, string.Empty)
+                new CloudApplication(projectFile, string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty)
             };
 
             // ACT

--- a/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
+++ b/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
@@ -1,5 +1,5 @@
 {
-    "StackName": "ElasticBeanStalk{Suffix}",
+    "ApplicationName": "ElasticBeanStalk{Suffix}",
     "RecipeId": "AspNetAppElasticBeanstalkLinux",
     "OptionSettingsConfig": {
         "BeanstalkApplication": {

--- a/testapps/WebAppWithDockerFile/ECSFargateConfigFile.json
+++ b/testapps/WebAppWithDockerFile/ECSFargateConfigFile.json
@@ -1,5 +1,5 @@
 {
-    "StackName": "EcsFargate{Suffix}",
+    "ApplicationName": "EcsFargate{Suffix}",
     "RecipeId": "AspNetAppEcsFargate",
     "OptionSettingsConfig":{
         "ECSCluster":


### PR DESCRIPTION
**Note** - The CI pipeline is not automatically run when trying to merge a PR into a staging branch. I manually triggered the `aws-dotnet-deploy-ci` CodeBuild job and it ran successfully (build 204, 213, 219).

*Issue #, if available:*
DOTNET-5510

*Description of changes:*

* Replaced the `--stack-name` CLI argument to `--application-name` since our deployment targets are no longer restricted to CloudFormation stacks.
* Amended property names, user prompts, error messages and comments to reflect that our deployment targets are no longer restricted to CloudFormation stacks.
* Moved existing and added new constants to the `AWS.Deploy.Constants` shared project.
* Made the following changes to the `CloudApplication` class
   * Removed the `StackName` property as not all `CloudApplication` objects will be CloudFormation stacks
   * Added a new `UniqueIdentifier` property that can either be CloudFormation StackIDs or Elastic Beanstalk Environment ARNs.  For new deployments this property is set to `string.Empty`
   * Added a new `ResourceType` property that indicates the type of the AWS resource which serves as the deployment target. Current supported values are `CloudFormationStack`, `BeanstalkEnvironment` and `None`
   * Added a new `DisplayName` property which is shown to the user when the `CloudApplication` is presented as an existing re-deployment target.
* Extended the `DeploymentTypes` enum to to include `BeanstalkEnvironment`
* Added a boolean property `DisableNewDeployments` to `RecipeDefinition` class. If set to true then this recipe will not be displayed as a recommendation for **new deployments**
* The call to `_deployedApplicationQueryer.GetExistingDeployedApplications` now includes compatible Elastic Beanstalk environments
  * These environments are vetted to ensure that they were not created by our deploy tool and that they contain a dotnet compatible platform ARN.
* Created the `IDeploymentCommand` interface which serves as the blueprint for all current and future deployment commands.
* Created the `DeploymentCommandFactory`. It inspects the `DeploymentType` of the recipe and creates an instance of the appropriate deployment command
* Moved all the logic for a **CDK based deployment** to `CdkDeploymentCommand`. This class implements the `IDeploymentCommand`  interface.
   * In a follow up PR the logic to deploy to an existing Elastic Beanstalk environment will be supported by `BeanstalkEnvironmentDeploymentCommand`
* Added a new recipe to support deployments to existing Elastic Beanstalk environment. This recipe has its `DisableNewDeployments` property set to true


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
