### PR TITLE
fix: KeyValue types not working with server mode

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -118,6 +118,11 @@ namespace AWS.Deploy.Common.Recipes
             {
                 _valueOverride = valueOverride;
             }
+            else if (Type.Equals(OptionSettingValueType.KeyValue))
+            {
+                var deserialized = JsonConvert.DeserializeObject<Dictionary<string, string>>(valueOverride?.ToString() ?? "");
+                _valueOverride = deserialized;
+            }
             else if (valueOverride is string valueOverrideString)
             {
                 if (bool.TryParse(valueOverrideString, out var valueOverrideBool))

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -91,7 +91,6 @@ namespace AWS.Deploy.Common
         /// Throws exception if there is no <see cref="OptionSettingItem" /> that matches <paramref name="jsonPath"/> />
         /// In case an option setting of type <see cref="OptionSettingValueType.KeyValue"/> is encountered,
         /// that <paramref name="jsonPath"/> can have the key value pair name as the leaf node with the option setting Id as the node before that.
-        /// In case there are multiple nodes after a <see cref="OptionSettingValueType.KeyValue"/>, then that indicates an invalid <paramref name="jsonPath"/>
         /// </summary>
         /// <param name="jsonPath">
         /// Dot (.) separated key values string pointing to an option setting.
@@ -118,11 +117,7 @@ namespace AWS.Deploy.Common
                 }
                 if (optionSetting.Type.Equals(OptionSettingValueType.KeyValue))
                 {
-                    if (i + 2 == ids.Length)
-                        return optionSetting;
-                    else
-                        throw new OptionSettingItemDoesNotExistException(DeployToolErrorCode.OptionSettingItemDoesNotExistInRecipe, $"The Option Setting Item {jsonPath} does not exist as part of the" +
-                    $" {Recipe.Name} recipe");
+                    return optionSetting;
                 }
             }
 

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -264,6 +264,34 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.Equal("CustomAppStack-dev", beanstalkRecommendation.GetOptionSettingValue<string>(beanstalEnvNameSetting));
         }
 
+        [Fact]
+        public async Task GetKeyValueOptionSettingServerMode()
+        {
+            var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var beanstalkRecommendation = recommendations.FirstOrDefault(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            var envVarsSetting = beanstalkRecommendation.GetOptionSetting("ElasticBeanstalkEnvironmentVariables");
+
+            Assert.Equal(OptionSettingValueType.KeyValue, envVarsSetting.Type);
+        }
+
+        [Fact]
+        public async Task GetKeyValueOptionSettingConfigFile()
+        {
+            var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var beanstalkRecommendation = recommendations.FirstOrDefault(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            var envVarsSetting = beanstalkRecommendation.GetOptionSetting("ElasticBeanstalkEnvironmentVariables.Key");
+
+            Assert.Equal(OptionSettingValueType.KeyValue, envVarsSetting.Type);
+        }
+
         [Theory]
         [MemberData(nameof(ShouldIncludeTestCases))]
         public void ShouldIncludeTests(RuleEffect effect, bool testPass, bool expectedResult)


### PR DESCRIPTION
*Issue #, if available:*
IDE-6536

*Description of changes:*
Trying to set ElasticBeanstalkEnvironmentVariables which is of type KeyValue via server mode fails. The way we are we are handling the KeyValue type set via config files is not working with server mode. removing the code specific to config files works for both features.
In addition, when setting the KeyValue type, the values are not sticking because they are being handle as string instead of Dictionary. Additional handling was added to cover this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
