### PR TITLE
feat: Improve telemetry by capturing CDK deployment failure message

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.3.12" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.7.14" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.35" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.2" />

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -90,7 +90,8 @@ namespace AWS.Deploy.Common
         CompatibleRecommendationForRedeploymentNotFound = 10006800,
         InvalidSaveDirectoryForCdkProject = 10006900,
         FailedToFindDeploymentProjectRecipeId = 10007000,
-        UnexpectedError = 10007100
+        UnexpectedError = 10007100,
+        FailedToCreateCdkStack = 10007200
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.45" />
     <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" Version="3.7.0.48" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.3.12" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.7.14" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.1.17" />
     <PackageReference Include="AWSSDK.AppRunner" Version="3.7.0.24" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Amazon.CloudFormation;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.CDK;
+using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.Recipes.CDK.Common;
 
@@ -15,7 +18,7 @@ namespace AWS.Deploy.Orchestration
     {
         Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
         string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
-        Task DeployCdkProject(OrchestratorSession session, string cdkProjectPath, Recommendation recommendation);
+        Task DeployCdkProject(OrchestratorSession session, CloudApplication cloudApplication, string cdkProjectPath, Recommendation recommendation);
         void DeleteTemporaryCdkProject(OrchestratorSession session, string cdkProjectPath);
     }
 
@@ -25,11 +28,16 @@ namespace AWS.Deploy.Orchestration
         private readonly ICommandLineWrapper _commandLineWrapper;
         private readonly CdkAppSettingsSerializer _appSettingsBuilder;
         private readonly IDirectoryManager _directoryManager;
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
 
-        public CdkProjectHandler(IOrchestratorInteractiveService interactiveService, ICommandLineWrapper commandLineWrapper)
+        public CdkProjectHandler(
+            IOrchestratorInteractiveService interactiveService,
+            ICommandLineWrapper commandLineWrapper,
+            IAWSResourceQueryer awsResourceQueryer)
         {
             _interactiveService = interactiveService;
             _commandLineWrapper = commandLineWrapper;
+            _awsResourceQueryer = awsResourceQueryer;
             _appSettingsBuilder = new CdkAppSettingsSerializer();
             _directoryManager = new DirectoryManager();
         }
@@ -61,7 +69,7 @@ namespace AWS.Deploy.Orchestration
             return cdkProjectPath;
         }
 
-        public async Task DeployCdkProject(OrchestratorSession session, string cdkProjectPath, Recommendation recommendation)
+        public async Task DeployCdkProject(OrchestratorSession session, CloudApplication cloudApplication, string cdkProjectPath, Recommendation recommendation)
         {
             var recipeInfo = $"{recommendation.Recipe.Id}_{recommendation.Recipe.Version}";
             var environmentVariables = new Dictionary<string, string>
@@ -77,6 +85,7 @@ namespace AWS.Deploy.Orchestration
 
             var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
 
+            var deploymentStartDate = DateTime.Now;
             // Handover to CDK command line tool
             // Use a CDK Context parameter to specify the settings file that has been serialized.
             var cdkDeploy = await _commandLineWrapper.TryRunWithResult( $"npx cdk deploy --require-approval never -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
@@ -86,8 +95,34 @@ namespace AWS.Deploy.Orchestration
                 redirectIO: true,
                 streamOutputToInteractiveService: true);
 
+            await CheckCdkDeploymentFailure(cloudApplication, deploymentStartDate);
+
             if (cdkDeploy.ExitCode != 0)
                 throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToDeployCdkApplication, "We had an issue deploying your application to AWS. Check the deployment output for more details.");
+        }
+
+        private async Task CheckCdkDeploymentFailure(CloudApplication cloudApplication, DateTime deploymentStartDate)
+        {
+            try
+            {
+                var stackEvents = await _awsResourceQueryer.GetCloudFormationStackEvents(cloudApplication.StackName);
+                
+                var failedEvents = stackEvents
+                    .Where(x => x.Timestamp >= deploymentStartDate)
+                    .Where(x =>
+                        x.ResourceStatus.Equals(ResourceStatus.CREATE_FAILED) ||
+                        x.ResourceStatus.Equals(ResourceStatus.UPDATE_FAILED)
+                    );
+                if (failedEvents.Any())
+                {
+                    var errors = string.Join(". ", failedEvents.Reverse().Select(x => x.ResourceStatusReason));
+                    throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToDeployCdkApplication, errors);
+                }
+            }
+            catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ValidationError") && exception.Message.Equals($"Stack [{cloudApplication.StackName}] does not exist"))
+            {
+                throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToCreateCdkStack, "A CloudFormation stack was not created. Check the deployment output for more details.");
+            }
         }
 
         public string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -39,6 +39,7 @@ namespace AWS.Deploy.Orchestration.Data
 {
     public interface IAWSResourceQueryer
     {
+        Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName);
         Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes();
         Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
         Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
@@ -77,6 +78,22 @@ namespace AWS.Deploy.Orchestration.Data
         public AWSResourceQueryer(IAWSClientFactory awsClientFactory)
         {
             _awsClientFactory = awsClientFactory;
+        }
+
+        public async Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName)
+        {
+            var cfClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
+            var stackEvents = new List<StackEvent>();
+            var listInstanceTypesPaginator = cfClient.Paginators.DescribeStackEvents(new DescribeStackEventsRequest {
+                StackName = stackName
+            });
+
+            await foreach (var response in listInstanceTypesPaginator.Responses)
+            {
+                stackEvents.AddRange(response.StackEvents);
+            }
+
+            return stackEvents;
         }
 
         public async Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes()

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -166,7 +166,7 @@ namespace AWS.Deploy.Orchestration
 
                     try
                     {
-                        await _cdkProjectHandler.DeployCdkProject(_session, cdkProject, recommendation);
+                        await _cdkProjectHandler.DeployCdkProject(_session, cloudApplication, cdkProject, recommendation);
                     }
                     finally
                     {

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -54,5 +54,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
+        public Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -79,5 +79,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
+        public Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5575

*Description of changes:*
Based on the metrics gathered around the deploy tool usage, customers are experiencing deployment failures when they get to the `cdk deploy` stage. This part aims to break down the CDK deploy failures to have a better understanding of the customer's issues with the deploy tool.
This PR adds the ability to query CloudFormation to get the events of the deployment for a given stack. After we finish deploying to cdk (whether success or failure), we check the CloudFormation events for `CREATE_FAILED` or `UPDATE_FAILED` events. If they exist, we throw an exception with the error message of those events.
There is another part to this story where `cdk deploy` fails before creating a stack where we have to scrape the output text to understand the failures. That will be tackled as part of another PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
