### PR TITLE
feat: Support Elastic Beanstalk backwards compatibility via the CLI

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -23,6 +23,7 @@ using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Orchestration.LocalUserSettings;
+using AWS.Deploy.Orchestration.ServiceHandlers;
 
 namespace AWS.Deploy.CLI.Commands
 {
@@ -69,6 +70,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ICustomRecipeLocator _customRecipeLocator;
         private readonly ILocalUserSettingsEngine _localUserSettingsEngine;
         private readonly ICDKVersionDetector _cdkVersionDetector;
+        private readonly IAWSServiceHandler _awsServiceHandler;
 
         public CommandFactory(
             IToolInteractiveService toolInteractiveService,
@@ -93,7 +95,8 @@ namespace AWS.Deploy.CLI.Commands
             IDeploymentManifestEngine deploymentManifestEngine,
             ICustomRecipeLocator customRecipeLocator,
             ILocalUserSettingsEngine localUserSettingsEngine,
-            ICDKVersionDetector cdkVersionDetector)
+            ICDKVersionDetector cdkVersionDetector,
+            IAWSServiceHandler awsServiceHandler)
         {
             _toolInteractiveService = toolInteractiveService;
             _orchestratorInteractiveService = orchestratorInteractiveService;
@@ -118,6 +121,7 @@ namespace AWS.Deploy.CLI.Commands
             _customRecipeLocator = customRecipeLocator;
             _localUserSettingsEngine = localUserSettingsEngine;
             _cdkVersionDetector = cdkVersionDetector;
+            _awsServiceHandler = awsServiceHandler;
         }
 
         public Command BuildRootCommand()
@@ -216,7 +220,8 @@ namespace AWS.Deploy.CLI.Commands
                         _systemCapabilityEvaluator,
                         session,
                         _directoryManager,
-                        _fileManager);
+                        _fileManager,
+                        _awsServiceHandler);
 
                     var deploymentProjectPath = input.DeploymentProject ?? string.Empty;
                     if (!string.IsNullOrEmpty(deploymentProjectPath))

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -13,6 +13,7 @@ using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Orchestration.LocalUserSettings;
+using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Orchestration.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -58,6 +59,9 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ILocalUserSettingsEngine), typeof(LocalUserSettingsEngine), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICommandFactory), typeof(CommandFactory), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICDKVersionDetector), typeof(CDKVersionDetector), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IAWSServiceHandler), typeof(AWSServiceHandler), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IS3Handler), typeof(AWSS3Handler), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IElasticBeanstalkHandler), typeof(AWSElasticBeanstalkHandler), lifetime));
 
             var packageJsonTemplate = typeof(PackageJsonGenerator).Assembly.ReadEmbeddedFile(PackageJsonGenerator.TemplateIdentifier);
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IPackageJsonGenerator), (serviceProvider) => new PackageJsonGenerator(packageJsonTemplate), lifetime));

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -32,6 +32,7 @@ using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.CLI.Commands;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.ServiceHandlers;
 
 namespace AWS.Deploy.CLI.ServerMode.Controllers
 {
@@ -612,7 +613,9 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                                         serviceProvider.GetRequiredService<IFileManager>()),
                                     serviceProvider.GetRequiredService<ICustomRecipeLocator>(),
                                     new List<string> { RecipeLocator.FindRecipeDefinitionsPath() },
-                                    serviceProvider.GetRequiredService<IDirectoryManager>()
+                                    serviceProvider.GetRequiredService<IFileManager>(),
+                                    serviceProvider.GetRequiredService<IDirectoryManager>(),
+                                    serviceProvider.GetRequiredService<IAWSServiceHandler>()
                                 );
         }
     }

--- a/src/AWS.Deploy.Common/CloudApplication.cs
+++ b/src/AWS.Deploy.Common/CloudApplication.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 
 namespace AWS.Deploy.Common
 {
@@ -10,6 +11,13 @@ namespace AWS.Deploy.Common
     /// </summary>
     public class CloudApplication
     {
+        private readonly Dictionary<CloudApplicationResourceType, string> _resourceTypeMapping =
+            new()
+            {
+                { CloudApplicationResourceType.CloudFormationStack, "CloudFormation Stack" },
+                { CloudApplicationResourceType.BeanstalkEnvironment, "Elastic Beanstalk Environment" }
+            };
+
         /// <summary>
         /// Name of the CloudApplication resource
         /// </summary>
@@ -18,7 +26,7 @@ namespace AWS.Deploy.Common
         /// <summary>
         /// The unique Id to identify the CloudApplication.
         /// The ID is set to the StackId if the CloudApplication is an existing Cloudformation stack.
-        /// The ID is set to the EnvironmentArn if the CloudApplication is an existing Elastic Beanstalk environment.
+        /// The ID is set to the EnvironmentId if the CloudApplication is an existing Elastic Beanstalk environment.
         /// The ID is set to string.Empty for new CloudApplications.
         /// </summary>
         public string UniqueIdentifier { get; set; }
@@ -47,12 +55,11 @@ namespace AWS.Deploy.Common
         /// <summary>
         /// This name is shown to the user when the CloudApplication is presented as an existing re-deployment target.
         /// </summary>
-        public string DisplayName => $"{Name} ({ResourceType})";
+        public string DisplayName => $"{Name} ({_resourceTypeMapping[ResourceType]})";
 
         /// <summary>
         /// Display the name of the Cloud Application
         /// </summary>
-        /// <returns></returns>
         public override string ToString() => Name;
 
         public CloudApplication(string name, string uniqueIdentifier, CloudApplicationResourceType resourceType, string recipeId, DateTime? lastUpdatedTime = null)

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -91,7 +91,12 @@ namespace AWS.Deploy.Common
         InvalidSaveDirectoryForCdkProject = 10006900,
         FailedToFindDeploymentProjectRecipeId = 10007000,
         UnexpectedError = 10007100,
-        FailedToCreateDeploymentCommandInstance = 10007200
+        FailedToCreateDeploymentCommandInstance = 10007200,
+        FailedToFindElasticBeanstalkApplication = 10007300,
+        FailedS3Upload = 10007400,
+        FailedToCreateElasticBeanstalkApplicationVersion = 10007500,
+        FailedToUpdateElasticBeanstalkEnvironment = 10007600,
+        FailedToCreateElasticBeanstalkStorageLocation = 10007700,
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/IO/FileManager.cs
+++ b/src/AWS.Deploy.Common/IO/FileManager.cs
@@ -15,6 +15,9 @@ namespace AWS.Deploy.Common.IO
         Task<string> ReadAllTextAsync(string path);
         Task<string[]> ReadAllLinesAsync(string path);
         Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken = default);
+        FileStream OpenRead(string filePath);
+        string GetExtension(string filePath);
+        long GetSizeInBytes(string filePath);
     }
 
     /// <summary>
@@ -30,6 +33,12 @@ namespace AWS.Deploy.Common.IO
 
         public Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken) =>
             File.WriteAllTextAsync(filePath, contents, cancellationToken);
+
+        public FileStream OpenRead(string filePath) => File.OpenRead(filePath);
+
+        public string GetExtension(string filePath) => Path.GetExtension(filePath);
+
+        public long GetSizeInBytes(string filePath) => new FileInfo(filePath).Length;
 
         private bool IsFileValid(string filePath)
         {

--- a/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
+++ b/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CDK.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CLI.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CloudFormationIdentifier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ElasticBeanstalk.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RecipeIdentifier.cs" />
   </ItemGroup>
 </Project>

--- a/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
+++ b/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Constants
+{
+    internal static class ElasticBeanstalk
+    {
+        public const string EnhancedHealthReportingOptionId = "EnhancedHealthReporting";
+        public const string EnhancedHealthReportingOptionNameSpace = "aws:elasticbeanstalk:healthreporting:system";
+        public const string EnhancedHealthReportingOptionName = "SystemType";
+
+        public const string XRayTracingOptionId = "XRayTracingSupportEnabled";
+        public const string XRayTracingOptionNameSpace = "aws:elasticbeanstalk:xray";
+        public const string XRayTracingOptionName = "XRayEnabled";
+
+        public const string ProxyOptionId = "ReverseProxy";
+        public const string ProxyOptionNameSpace = "aws:elasticbeanstalk:environment:proxy";
+        public const string ProxyOptionName = "ProxyServer";
+
+        public const string HealthCheckURLOptionId = "HealthCheckURL";
+        public const string HealthCheckURLOptionNameSpace = "aws:elasticbeanstalk:application";
+        public const string HealthCheckURLOptionName = "Application Healthcheck URL";
+
+        /// <summary>
+        /// This list stores a named tuple of OptionSettingId, OptionSettingNameSpace and OptionSettingName.
+        /// <para>OptionSettingId refers to the Id property for an option setting item in the recipe file.</para>
+        /// <para>OptionSettingNameSpace and OptionSettingName provide a way to configure the environments metadata and update its behaviour.</para>
+        /// <para>A comprehensive list of all configurable settings can be found <see href="https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/beanstalk-environment-configuration-advanced.html">here</see></para>
+        /// </summary>
+        public static List<(string OptionSettingId, string OptionSettingNameSpace, string OptionSettingName)> OptionSettingQueryList = new()
+        {
+            new (EnhancedHealthReportingOptionId, EnhancedHealthReportingOptionNameSpace, EnhancedHealthReportingOptionName),
+            new (XRayTracingOptionId, XRayTracingOptionNameSpace, XRayTracingOptionName),
+            new (ProxyOptionId, ProxyOptionNameSpace, ProxyOptionName),
+            new (HealthCheckURLOptionId, HealthCheckURLOptionNameSpace, HealthCheckURLOptionName)
+        };
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
@@ -3,19 +3,68 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Orchestration.DisplayedResources;
 
 namespace AWS.Deploy.Orchestration.DeploymentCommands
 {
-    /// <summary>
-    /// This class is a Work In Progress.
-    /// </summary>
     public class BeanstalkEnvironmentDeploymentCommand : IDeploymentCommand
     {
-        public Task ExecuteAsync(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation recommendation) => throw new NotImplementedException();
-        public Task<List<DisplayedResourceItem>> GetDeploymentOutputsAsync(IDisplayedResourcesHandler displayedResourcesHandler, CloudApplication cloudApplication, Recommendation recommendation) => throw new NotImplementedException();
+        public async Task ExecuteAsync(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation recommendation)
+        {
+            if (orchestrator._interactiveService == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._interactiveService)} is null as part of the orchestartor object");
+            if (orchestrator._awsResourceQueryer == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._awsResourceQueryer)} is null as part of the orchestartor object");
+            if (orchestrator._awsServiceHandler == null)
+                throw new InvalidOperationException($"{nameof(orchestrator._awsServiceHandler)} is null as part of the orchestartor object");
+
+            var deploymentPackage = recommendation.DeploymentBundle.DotnetPublishZipPath;
+            var environmentName = cloudApplication.Name;
+            var applicationName = (await orchestrator._awsResourceQueryer.ListOfElasticBeanstalkEnvironments())
+                .Where(x => string.Equals(x.EnvironmentId, cloudApplication.UniqueIdentifier))
+                .FirstOrDefault()?
+                .ApplicationName;
+
+            var s3Handler = orchestrator._awsServiceHandler.S3Handler;
+            var elasticBeanstalkHandler = orchestrator._awsServiceHandler.ElasticBeanstalkHandler;
+
+            if (string.IsNullOrEmpty(applicationName))
+            {
+                var message = $"Could not find any Elastic Beanstalk application that contains the following environment: {environmentName}";
+                throw new AWSResourceNotFoundException(DeployToolErrorCode.FailedToFindElasticBeanstalkApplication, message);
+            }
+
+            orchestrator._interactiveService.LogMessageLine($"Initiating deployment to {cloudApplication.DisplayName}...");
+
+            var versionLabel = $"v-{DateTime.Now.Ticks}";
+            var s3location = await elasticBeanstalkHandler.CreateApplicationStorageLocationAsync(applicationName, versionLabel, deploymentPackage);
+            await s3Handler.UploadToS3Async(s3location.S3Bucket, s3location.S3Key, deploymentPackage);
+            await elasticBeanstalkHandler.CreateApplicationVersionAsync(applicationName, versionLabel, s3location);
+            var environmentConfigurationSettings = elasticBeanstalkHandler.GetEnvironmentConfigurationSettings(recommendation);
+
+            var success = await elasticBeanstalkHandler.UpdateEnvironmentAsync(applicationName, environmentName, versionLabel, environmentConfigurationSettings);
+
+            if (success)
+            {
+                orchestrator._interactiveService.LogMessageLine($"The Elastic Beanstalk Environment {environmentName} has been successfully updated to the application version {versionLabel}" + Environment.NewLine);
+            } 
+            else
+            {
+                throw new ElasticBeanstalkException(DeployToolErrorCode.FailedToUpdateElasticBeanstalkEnvironment, "Failed to update the Elastic Beanstalk environment");
+            }
+        }
+        public async Task<List<DisplayedResourceItem>> GetDeploymentOutputsAsync(IDisplayedResourcesHandler displayedResourcesHandler, CloudApplication cloudApplication, Recommendation recommendation)
+        {
+            var displayedResources = new List<DisplayedResourceItem>();
+            var environment = await displayedResourcesHandler.AwsResourceQueryer.DescribeElasticBeanstalkEnvironment(cloudApplication.Name);
+            var data = new Dictionary<string, string>() {{ "Endpoint", $"http://{environment.CNAME}/" }};
+            var resourceDescription = "An AWS Elastic Beanstalk environment is a collection of AWS resources running an application version.";
+            var resourceType = "Elastic Beanstalk Environment";
+            displayedResources.Add(new DisplayedResourceItem(environment.EnvironmentName, resourceDescription, resourceType, data));
+            return displayedResources;
+        }
     }
 }

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/DeploymentCommandFactory.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/DeploymentCommandFactory.cs
@@ -22,14 +22,14 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
             if (!_deploymentCommandTypeMapping.ContainsKey(deploymentType))
             {
                 var message = $"Failed to create an instance of type {nameof(IDeploymentCommand)}. {deploymentType} does not exist as a key in {_deploymentCommandTypeMapping}.";
-                throw new FailedToCreateDeploymentCommandInstance(DeployToolErrorCode.FailedToCreateDeploymentCommandInstance, message);
+                throw new FailedToCreateDeploymentCommandInstanceException(DeployToolErrorCode.FailedToCreateDeploymentCommandInstance, message);
             }
                 
             var deploymentCommandInstance = Activator.CreateInstance(_deploymentCommandTypeMapping[deploymentType]);
             if (deploymentCommandInstance == null || deploymentCommandInstance is not IDeploymentCommand)
             {
                 var message = $"Failed to create an instance of type {_deploymentCommandTypeMapping[deploymentType]}.";
-                throw new FailedToCreateDeploymentCommandInstance(DeployToolErrorCode.FailedToCreateDeploymentCommandInstance, message);
+                throw new FailedToCreateDeploymentCommandInstanceException(DeployToolErrorCode.FailedToCreateDeploymentCommandInstance, message);
             }
 
             return (IDeploymentCommand)deploymentCommandInstance;

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -1,6 +1,7 @@
 
 using System;
 using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.DeploymentCommands;
 
 namespace AWS.Deploy.Orchestration
 {
@@ -172,8 +173,27 @@ namespace AWS.Deploy.Orchestration
         public DockerInfoException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
-    public class FailedToCreateDeploymentCommandInstance : DeployToolException
+    /// <summary>
+    /// Throw if could not create an instance of <see cref="IDeploymentCommand"/>
+    /// </summary>
+    public class FailedToCreateDeploymentCommandInstanceException : DeployToolException
     {
-        public FailedToCreateDeploymentCommandInstance(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+        public FailedToCreateDeploymentCommandInstanceException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Throw if an error occured while calling a S3 API.
+    /// </summary>
+    public class S3Exception : DeployToolException
+    {
+        public S3Exception(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Throw if an error occured while calling an Elastic Beanstalk API.
+    /// </summary>
+    public class ElasticBeanstalkException : DeployToolException
+    {
+        public ElasticBeanstalkException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 }

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -14,6 +14,8 @@ using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.DeploymentCommands;
 using AWS.Deploy.Orchestration.LocalUserSettings;
+using AWS.Deploy.Orchestration.ServiceHandlers;
+using AWS.Deploy.Orchestration.Utilities;
 
 namespace AWS.Deploy.Orchestration
 {
@@ -33,9 +35,11 @@ namespace AWS.Deploy.Orchestration
         internal readonly ILocalUserSettingsEngine? _localUserSettingsEngine;
         internal readonly IDockerEngine? _dockerEngine;
         internal readonly IList<string>? _recipeDefinitionPaths;
+        internal readonly IFileManager? _fileManager;
         internal readonly IDirectoryManager? _directoryManager;
         internal readonly ICustomRecipeLocator? _customRecipeLocator;
         internal readonly OrchestratorSession? _session;
+        internal readonly IAWSServiceHandler? _awsServiceHandler;
 
         public Orchestrator(
             OrchestratorSession session,
@@ -49,7 +53,9 @@ namespace AWS.Deploy.Orchestration
             IDockerEngine dockerEngine,
             ICustomRecipeLocator customRecipeLocator,
             IList<string> recipeDefinitionPaths,
-            IDirectoryManager directoryManager)
+            IFileManager fileManager,
+            IDirectoryManager directoryManager,
+            IAWSServiceHandler awsServiceHandler)
         {
             _session = session;
             _interactiveService = interactiveService;
@@ -62,7 +68,9 @@ namespace AWS.Deploy.Orchestration
             _customRecipeLocator = customRecipeLocator;
             _recipeDefinitionPaths = recipeDefinitionPaths;
             _localUserSettingsEngine = localUserSettingsEngine;
+            _fileManager = fileManager;
             _directoryManager = directoryManager;
+            _awsServiceHandler = awsServiceHandler;
         }
 
         public Orchestrator(OrchestratorSession session, IList<string> recipeDefinitionPaths)

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
@@ -1,0 +1,201 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.ElasticBeanstalk;
+using Amazon.ElasticBeanstalk.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.Orchestration.ServiceHandlers
+{
+    public interface IElasticBeanstalkHandler
+    {
+        Task<S3Location> CreateApplicationStorageLocationAsync(string applicationName, string versionLabel, string deploymentPackage);
+        Task<CreateApplicationVersionResponse> CreateApplicationVersionAsync(string applicationName, string versionLabel, S3Location sourceBundle);
+        Task<bool> UpdateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, List<ConfigurationOptionSetting> optionSettings);
+        List<ConfigurationOptionSetting> GetEnvironmentConfigurationSettings(Recommendation recommendation);
+    }
+
+    public class AWSElasticBeanstalkHandler : IElasticBeanstalkHandler
+    {
+        private readonly IAWSClientFactory _awsClientFactory;
+        private readonly IOrchestratorInteractiveService _interactiveService;
+        private readonly IFileManager _fileManager;
+
+        public AWSElasticBeanstalkHandler(IAWSClientFactory awsClientFactory, IOrchestratorInteractiveService interactiveService, IFileManager fileManager)
+        {
+            _awsClientFactory = awsClientFactory;
+            _interactiveService = interactiveService;
+            _fileManager = fileManager;
+        }
+
+        public async Task<S3Location> CreateApplicationStorageLocationAsync(string applicationName, string versionLabel, string deploymentPackage)
+        {
+            string bucketName;
+            try
+            {
+                var ebClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+                bucketName = (await ebClient.CreateStorageLocationAsync()).S3Bucket;
+            }
+            catch (Exception e)
+            {
+                throw new ElasticBeanstalkException(DeployToolErrorCode.FailedToCreateElasticBeanstalkStorageLocation, "An error occured while creating the Elastic Beanstalk storage location", e);
+            }
+
+            var key = string.Format("{0}/AWSDeploymentArchive_{0}_{1}{2}",
+                                        applicationName.Replace(' ', '-'),
+                                        versionLabel.Replace(' ', '-'),
+                                        _fileManager.GetExtension(deploymentPackage));
+
+            return new S3Location { S3Bucket = bucketName, S3Key = key };
+        }
+
+        public async Task<CreateApplicationVersionResponse> CreateApplicationVersionAsync(string applicationName, string versionLabel, S3Location sourceBundle)
+        {
+            _interactiveService.LogMessageLine("Creating new application version: " + versionLabel);
+
+            try
+            {
+                var ebClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+                var response = await ebClient.CreateApplicationVersionAsync(new CreateApplicationVersionRequest
+                {
+                    ApplicationName = applicationName,
+                    VersionLabel = versionLabel,
+                    SourceBundle = sourceBundle
+                });
+                return response;
+            }
+            catch (Exception e)
+            {
+                throw new ElasticBeanstalkException(DeployToolErrorCode.FailedToCreateElasticBeanstalkApplicationVersion, "An error occured while creating the Elastic Beanstalk application version", e);
+            }
+        }
+
+        public List<ConfigurationOptionSetting> GetEnvironmentConfigurationSettings(Recommendation recommendation)
+        {
+            var additionalSettings = new List<ConfigurationOptionSetting>();
+
+            foreach (var tuple in Constants.ElasticBeanstalk.OptionSettingQueryList)
+            {
+                var optionSetting = recommendation.GetOptionSetting(tuple.OptionSettingId);
+
+                if (!optionSetting.Updatable)
+                    continue;
+
+                var optionSettingValue = optionSetting.GetValue<string>(new Dictionary<string, string>());
+
+                additionalSettings.Add(new ConfigurationOptionSetting
+                {
+                    Namespace = tuple.OptionSettingNameSpace,
+                    OptionName = tuple.OptionSettingName,
+                    Value = optionSettingValue
+                });
+            }
+
+            return additionalSettings;
+        }
+
+        public async Task<bool> UpdateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, List<ConfigurationOptionSetting> optionSettings)
+        {
+            _interactiveService.LogMessageLine("Getting latest environment event date before update");
+
+            var startingEventDate = await GetLatestEventDateAsync(applicationName, environmentName);
+
+            _interactiveService.LogMessageLine($"Updating environment {environmentName} to new application version {versionLabel}");
+
+            var updateRequest = new UpdateEnvironmentRequest
+            {
+                ApplicationName = applicationName,
+                EnvironmentName = environmentName,
+                VersionLabel = versionLabel,
+                OptionSettings = optionSettings
+            };
+
+            try
+            {
+                var ebClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+                var updateEnvironmentResponse = await ebClient.UpdateEnvironmentAsync(updateRequest);
+                return await WaitForEnvironmentUpdateCompletion(applicationName, environmentName, startingEventDate);
+            }
+            catch (Exception e)
+            {
+                throw new ElasticBeanstalkException(DeployToolErrorCode.FailedToUpdateElasticBeanstalkEnvironment, "An error occured while updating the Elastic Beanstalk environment", e);
+            }
+        }
+
+        private async Task<DateTime> GetLatestEventDateAsync(string applicationName, string environmentName)
+        {
+            var request = new DescribeEventsRequest
+            {
+                ApplicationName = applicationName,
+                EnvironmentName = environmentName
+            };
+
+            var ebClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+            var response = await ebClient.DescribeEventsAsync(request);
+            if (response.Events.Count == 0)
+                return DateTime.Now;
+
+            return response.Events.First().EventDate;
+        }
+
+        private async Task<bool> WaitForEnvironmentUpdateCompletion(string applicationName, string environmentName, DateTime startingEventDate)
+        {
+            _interactiveService.LogMessageLine("Waiting for environment update to complete");
+
+            var success = true;
+            var environment = new EnvironmentDescription();
+            var lastPrintedEventDate = startingEventDate;
+            var requestEvents = new DescribeEventsRequest
+            {
+                ApplicationName = applicationName,
+                EnvironmentName = environmentName
+            };
+            var requestEnvironment = new DescribeEnvironmentsRequest
+            {
+                ApplicationName = applicationName,
+                EnvironmentNames = new List<string> { environmentName }
+            };
+            var ebClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+
+            do
+            {
+                Thread.Sleep(5000);
+
+                var responseEnvironments = await ebClient.DescribeEnvironmentsAsync(requestEnvironment);
+                if (responseEnvironments.Environments.Count == 0)
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.BeanstalkEnvironmentDoesNotExist, $"Failed to find environment {environmentName} belonging to application {applicationName}");
+
+                environment = responseEnvironments.Environments[0];
+
+                requestEvents.StartTimeUtc = lastPrintedEventDate;
+                var responseEvents = await ebClient.DescribeEventsAsync(requestEvents);
+                if (responseEvents.Events.Any())
+                {
+                    for (var i = responseEvents.Events.Count - 1; i >= 0; i--)
+                    {
+                        var evnt = responseEvents.Events[i];
+                        if (evnt.EventDate <= lastPrintedEventDate)
+                            continue;
+
+                        _interactiveService.LogMessageLine(evnt.EventDate.ToLocalTime() + "    " + evnt.Severity + "    " + evnt.Message);
+                        if (evnt.Severity == EventSeverity.ERROR || evnt.Severity == EventSeverity.FATAL)
+                        {
+                            success = false;
+                        }
+                    }
+
+                    lastPrintedEventDate = responseEvents.Events[0].EventDate;
+                }
+
+            } while (environment.Status == EnvironmentStatus.Launching || environment.Status == EnvironmentStatus.Updating);
+
+            return success;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSS3Handler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSS3Handler.cs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Transfer;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.Orchestration.ServiceHandlers
+{
+    public interface IS3Handler
+    {
+        Task UploadToS3Async(string bucket, string key, string filePath);
+    }
+
+    public class AWSS3Handler : IS3Handler
+    {
+        private readonly IAWSClientFactory _awsClientFactory;
+        private readonly IOrchestratorInteractiveService _interactiveService;
+        private readonly IFileManager _fileManager;
+
+        private const int UPLOAD_PROGRESS_INCREMENT = 10;
+
+        public AWSS3Handler(IAWSClientFactory awsClientFactory, IOrchestratorInteractiveService interactiveService, IFileManager fileManager)
+        {
+            _awsClientFactory = awsClientFactory;
+            _interactiveService = interactiveService;
+            _fileManager = fileManager;
+        }
+
+        public async Task UploadToS3Async(string bucket, string key, string filePath)
+        {
+            using (var stream = _fileManager.OpenRead(filePath))
+            {
+                _interactiveService.LogMessageLine($"Uploading to S3. (Bucket: {bucket} Key: {key} Size: {_fileManager.GetSizeInBytes(filePath)} bytes)");
+
+                var request = new TransferUtilityUploadRequest()
+                {
+                    BucketName = bucket,
+                    Key = key,
+                    InputStream = stream
+                };
+
+                request.UploadProgressEvent += CreateTransferUtilityProgressHandler();
+
+                try
+                {
+                    var s3Client = _awsClientFactory.GetAWSClient<IAmazonS3>();
+                    await new TransferUtility(s3Client).UploadAsync(request);
+                }
+                catch (Exception e)
+                {
+                    throw new S3Exception(DeployToolErrorCode.FailedS3Upload, $"Error uploading to {key} in bucket {bucket}", innerException: e);
+                }
+            }
+        }
+
+        private EventHandler<UploadProgressArgs> CreateTransferUtilityProgressHandler()
+        {
+            var percentToUpdateOn = UPLOAD_PROGRESS_INCREMENT;
+            EventHandler<UploadProgressArgs> handler = ((s, e) =>
+            {
+                if (e.PercentDone != percentToUpdateOn && e.PercentDone <= percentToUpdateOn) return;
+
+                var increment = e.PercentDone % UPLOAD_PROGRESS_INCREMENT;
+                if (increment == 0)
+                    increment = UPLOAD_PROGRESS_INCREMENT;
+                percentToUpdateOn = e.PercentDone + increment;
+                _interactiveService.LogMessageLine($"... Progress: {e.PercentDone}%");
+            });
+
+            return handler;
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSServiceHandler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSServiceHandler.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Orchestration.ServiceHandlers
+{
+    public interface IAWSServiceHandler
+    {
+        IS3Handler S3Handler { get; }
+        IElasticBeanstalkHandler ElasticBeanstalkHandler { get; }
+    }
+
+    public class AWSServiceHandler : IAWSServiceHandler
+    {
+        public IS3Handler S3Handler { get; }
+        public IElasticBeanstalkHandler ElasticBeanstalkHandler { get; }
+
+        public AWSServiceHandler(IS3Handler s3Handler, IElasticBeanstalkHandler elasticBeanstalkHandler)
+        {
+            S3Handler = s3Handler;
+            ElasticBeanstalkHandler = elasticBeanstalkHandler;
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestFileManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestFileManager.cs
@@ -36,6 +36,10 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
             InMemoryStore[filePath] = contents;
             return Task.CompletedTask;
         }
+
+        public FileStream OpenRead(string filePath) => throw new NotImplementedException();
+        public string GetExtension(string filePath) => throw new NotImplementedException();
+        public long GetSizeInBytes(string filePath) => throw new NotImplementedException();
     }
 
     public static class TestFileManagerExtensions

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -23,6 +23,8 @@ using Newtonsoft.Json;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.Orchestration.LocalUserSettings;
+using AWS.Deploy.Orchestration.Utilities;
+using AWS.Deploy.Orchestration.ServiceHandlers;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 {
@@ -224,7 +226,9 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
                 new Mock<IDockerEngine>().Object,
                 customRecipeLocator,
                 new List<string> { RecipeLocator.FindRecipeDefinitionsPath() },
-                directoryManager);
+                fileManager,
+                directoryManager,
+                new Mock<IAWSServiceHandler>().Object);
         }
 
         private async Task<string> GetCustomRecipeId(string recipeFilePath)

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -55,5 +55,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
         public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
+        public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -80,5 +80,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
         public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
+        public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.ElasticBeanstalk.Model;
+using Amazon.Runtime;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration.ServiceHandlers;
+using AWS.Deploy.Orchestration.UnitTests.Utilities;
+using AWS.Deploy.Recipes;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.Orchestration.UnitTests
+{
+    public class ElasticBeanstalkHandlerTests
+    {
+        [Fact]
+        public async Task GetAdditionSettingsTest_DefaultValues()
+        {
+            // ARRANGE
+            var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id.Equals(Constants.RecipeIdentifier.EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID));
+
+            var elasticBeanstalkHandler = new AWSElasticBeanstalkHandler(new Mock<IAWSClientFactory>().Object,
+                new Mock<IOrchestratorInteractiveService>().Object,
+                new Mock<IFileManager>().Object);
+
+            // ACT
+            var optionSettings = elasticBeanstalkHandler.GetEnvironmentConfigurationSettings(recommendation);
+
+            // ASSERT
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.EnhancedHealthReportingOptionName,
+                Namespace = Constants.ElasticBeanstalk.EnhancedHealthReportingOptionNameSpace,
+                Value = "enhanced"
+            }, x));
+
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.HealthCheckURLOptionName,
+                Namespace = Constants.ElasticBeanstalk.HealthCheckURLOptionNameSpace,
+                Value = "/"
+            }, x));
+
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.ProxyOptionName,
+                Namespace = Constants.ElasticBeanstalk.ProxyOptionNameSpace,
+                Value = "nginx"
+            }, x));
+
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.XRayTracingOptionName,
+                Namespace = Constants.ElasticBeanstalk.XRayTracingOptionNameSpace,
+                Value = "false"
+            }, x));
+        }
+
+        [Fact]
+        public async Task GetAdditionSettingsTest_CustomValues()
+        {
+            // ARRANGE
+            var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id.Equals(Constants.RecipeIdentifier.EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID));
+
+            var elasticBeanstalkHandler = new AWSElasticBeanstalkHandler(new Mock<IAWSClientFactory>().Object,
+                new Mock<IOrchestratorInteractiveService>().Object,
+                new Mock<IFileManager>().Object);
+
+            recommendation.GetOptionSetting(Constants.ElasticBeanstalk.EnhancedHealthReportingOptionId).SetValueOverride("basic");
+            recommendation.GetOptionSetting(Constants.ElasticBeanstalk.HealthCheckURLOptionId).SetValueOverride("/url");
+            recommendation.GetOptionSetting(Constants.ElasticBeanstalk.ProxyOptionId).SetValueOverride("none");
+            recommendation.GetOptionSetting(Constants.ElasticBeanstalk.XRayTracingOptionId).SetValueOverride("true");
+
+            // ACT
+            var optionSettings = elasticBeanstalkHandler.GetEnvironmentConfigurationSettings(recommendation);
+
+            // ASSERT
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.EnhancedHealthReportingOptionName,
+                Namespace = Constants.ElasticBeanstalk.EnhancedHealthReportingOptionNameSpace,
+                Value = "basic"
+            }, x));
+
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.HealthCheckURLOptionName,
+                Namespace = Constants.ElasticBeanstalk.HealthCheckURLOptionNameSpace,
+                Value = "/url"
+            }, x));
+
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.ProxyOptionName,
+                Namespace = Constants.ElasticBeanstalk.ProxyOptionNameSpace,
+                Value = "none"
+            }, x));
+
+            Assert.Contains(optionSettings, x => IsEqual(new ConfigurationOptionSetting
+            {
+                OptionName = Constants.ElasticBeanstalk.XRayTracingOptionName,
+                Namespace = Constants.ElasticBeanstalk.XRayTracingOptionNameSpace,
+                Value = "true"
+            }, x));
+        }
+
+        private async Task<RecommendationEngine.RecommendationEngine> BuildRecommendationEngine(string testProjectName)
+        {
+            var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
+
+            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var awsCredentials = new Mock<AWSCredentials>();
+            var session = new OrchestratorSession(
+                await parser.Parse(fullPath),
+                awsCredentials.Object,
+                "us-west-2",
+                "123456789012")
+            {
+                AWSProfileName = "default"
+            };
+
+            return new RecommendationEngine.RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() }, session);
+        }
+
+        private bool IsEqual(ConfigurationOptionSetting expected, ConfigurationOptionSetting actual)
+        {
+            return string.Equals(expected.OptionName, actual.OptionName)
+                && string.Equals(expected.Namespace, actual.Namespace)
+                && string.Equals(expected.Value, actual.Value);
+        }
+    }
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
@@ -36,6 +36,10 @@ namespace AWS.Deploy.Orchestration.UnitTests
             InMemoryStore[filePath] = contents;
             return Task.CompletedTask;
         }
+
+        public FileStream OpenRead(string filePath) => throw new NotImplementedException();
+        public string GetExtension(string filePath) => throw new NotImplementedException();
+        public long GetSizeInBytes(string filePath) => throw new NotImplementedException();
     }
 
     public static class TestFileManagerExtensions


### PR DESCRIPTION
**Note** - The CI pipeline is not automatically run when trying to merge a PR into a staging branch. I manually triggered the aws-dotnet-deploy-ci CodeBuild job and it ran successfully (build 223 and 227).

*Issue #, if available:*
DOTNET-5510

*Description of changes:*
This PR supports the CLI workflow to deploy to an existing Elastic Beanstalk environment. **It does not update server mode**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
