### PR TITLE
fix: beanstalk error at startup when in non-default regions

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -26,8 +26,6 @@ namespace AWS.Deploy.CLI.Commands
 {
     public class DeployCommand
     {
-        public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";
-
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
         private readonly ICdkProjectHandler _cdkProjectHandler;
@@ -197,8 +195,7 @@ namespace AWS.Deploy.CLI.Commands
                 }
             }
 
-            // Apply the user entered stack name to the recommendation so that any default settings based on stack name are applied.
-            selectedRecommendation.AddReplacementToken(REPLACE_TOKEN_STACK_NAME, cloudApplicationName);
+            await orchestrator.ApplyAllReplacementTokens(selectedRecommendation, cloudApplicationName);
 
             var cloudApplication = new CloudApplication(cloudApplicationName, selectedRecommendation.Recipe.Id);
 

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -344,6 +344,9 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 return NotFound($"Session ID {sessionId} not found.");
             }
 
+            var serviceProvider = CreateSessionServiceProvider(state);
+            var orchestrator = CreateOrchestrator(state, serviceProvider);
+
             if(!string.IsNullOrEmpty(input.NewDeploymentRecipeId) &&
                !string.IsNullOrEmpty(input.NewDeploymentName))
             {
@@ -355,11 +358,10 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
                 state.ApplicationDetails.Name = input.NewDeploymentName;
                 state.ApplicationDetails.RecipeId = input.NewDeploymentRecipeId;
-                state.SelectedRecommendation.AddReplacementToken(DeployCommand.REPLACE_TOKEN_STACK_NAME, input.NewDeploymentName);
+                await orchestrator.ApplyAllReplacementTokens(state.SelectedRecommendation, input.NewDeploymentName);
             }
             else if(!string.IsNullOrEmpty(input.ExistingDeploymentName))
             {
-                var serviceProvider = CreateSessionServiceProvider(state);
                 var templateMetadataReader = serviceProvider.GetRequiredService<ITemplateMetadataReader>();
 
                 var existingDeployment = state.ExistingDeployments?.FirstOrDefault(x => string.Equals(input.ExistingDeploymentName, x.Name));
@@ -379,7 +381,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
                 state.ApplicationDetails.Name = input.ExistingDeploymentName;
                 state.ApplicationDetails.RecipeId = existingDeployment.RecipeId;
-                state.SelectedRecommendation.AddReplacementToken(DeployCommand.REPLACE_TOKEN_STACK_NAME, input.ExistingDeploymentName);
+                await orchestrator.ApplyAllReplacementTokens(state.SelectedRecommendation, input.ExistingDeploymentName);
             }
 
             return Ok();

--- a/src/AWS.Deploy.CLI/ServerMode/Startup.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Startup.cs
@@ -84,6 +84,8 @@ namespace AWS.Deploy.CLI.ServerMode
 
             app.UseSwagger();
 
+            app.ConfigureExceptionHandler();
+
             app.UseRouting();
 
             app.UseAuthentication();

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -91,7 +91,8 @@ namespace AWS.Deploy.Common
         InvalidSaveDirectoryForCdkProject = 10006900,
         FailedToFindDeploymentProjectRecipeId = 10007000,
         UnexpectedError = 10007100,
-        FailedToCreateCdkStack = 10007200
+        FailedToCreateCdkStack = 10007200,
+        FailedToFindElasticBeanstalkSolutionStack = 10007300
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Constants/CLI.cs
+++ b/src/AWS.Deploy.Constants/CLI.cs
@@ -14,5 +14,8 @@ namespace AWS.Deploy.Constants
         public const string PROMPT_CHOOSE_STACK_NAME = "Choose stack to deploy to";
 
         public const string CLI_APP_NAME = "AWS .NET Deployment Tool";
+
+        public const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
+        public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";
     }
 }

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -381,7 +381,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (!platforms.Any())
             {
-                throw new AmazonElasticBeanstalkException(".NET Core Solution Stack doesn't exist.");
+                throw new FailedToFindElasticBeanstalkSolutionStackException(DeployToolErrorCode.FailedToFindElasticBeanstalkSolutionStack, "Cannot use Elastic Beanstalk deployments because we cannot find a .NET Core Solution Stack to use. One possible reason could be that Elastic Beanstalk is not enabled in your region if you are using a non-default region.");
             }
 
             return platforms.First();

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -171,4 +171,12 @@ namespace AWS.Deploy.Orchestration
     {
         public DockerInfoException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if unable to find an Elastic Beanstalk .NET solution stack.
+    /// </summary>
+    public class FailedToFindElasticBeanstalkSolutionStackException : DeployToolException
+    {
+        public FailedToFindElasticBeanstalkSolutionStackException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5654

*Description of changes:*
* When recommendations are instantiated, all the recipe default values are check to create an inventory of the replacements needed.
* After a user selects the recommendation, a call is made to the orchestrator to do the token replacements if the recommendation has the replacement token in its inventory.
* When a user selects a beanstalk recommendation, if they are in a region that does not support beanstalk, the .net stack platform call will return empty which will throw an expected deploy tool exception instead of a generic one. The error message has been improved.
* In server mode, exceptions thrown in APIs now correctly return the error messages and error codes to the caller instead of having an empty body.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
