### PR TITLE
feat: Support Elastic Beanstalk backwards compatibility via server-mode

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -299,7 +299,7 @@ namespace AWS.Deploy.CLI.Commands
             if (deployedApplication.ResourceType == CloudApplicationResourceType.CloudFormationStack)
                 previousSettings = (await _templateMetadataReader.LoadCloudApplicationMetadata(deployedApplication.Name)).Settings;
             else
-                previousSettings = (await _deployedApplicationQueryer.GetPreviousSettings(deployedApplication));
+                previousSettings = await _deployedApplicationQueryer.GetPreviousSettings(deployedApplication);
 
             selectedRecommendation = selectedRecommendation.ApplyPreviousSettings(previousSettings);
 

--- a/src/AWS.Deploy.CLI/ServerMode/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Exceptions.cs
@@ -29,4 +29,12 @@ namespace AWS.Deploy.CLI.ServerMode
     {
         public InvalidEncryptionKeyInfoException(string message, Exception? innerException = null) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if could not find deployment targets mapping.
+    /// </summary>
+    public class FailedToFindDeploymentTargetsMappingException : Exception
+    {
+        public FailedToFindDeploymentTargetsMappingException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Models/DeploymentTypes.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/DeploymentTypes.cs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    public enum DeploymentTypes
+    {
+        CloudFormationStack,
+        BeanstalkEnvironment
+    }
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Models/ExistingDeploymentSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/ExistingDeploymentSummary.cs
@@ -5,11 +5,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AWS.Deploy.Common;
 
 namespace AWS.Deploy.CLI.ServerMode.Models
 {
     public class ExistingDeploymentSummary
     {
+        private readonly Dictionary<CloudApplicationResourceType, DeploymentTypes> _deploymentTargetsMapping = new()
+        {
+            { CloudApplicationResourceType.CloudFormationStack, DeploymentTypes.CloudFormationStack },
+            { CloudApplicationResourceType.BeanstalkEnvironment, DeploymentTypes.BeanstalkEnvironment }
+        };
+
         public string Name { get; set; }
 
         public string RecipeId { get; set; }
@@ -26,6 +33,10 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public bool UpdatedByCurrentUser { get; set; }
 
+        public DeploymentTypes DeploymentType { get; set; }
+
+        public string ExistingDeploymentId { get; set; }
+
         public ExistingDeploymentSummary(
             string name,
             string recipeId,
@@ -34,7 +45,9 @@ namespace AWS.Deploy.CLI.ServerMode.Models
             string description,
             string targetService,
             DateTime? lastUpdatedTime,
-            bool updatedByCurrentUser
+            bool updatedByCurrentUser,
+            CloudApplicationResourceType resourceType,
+            string uniqueIdentifier
         )
         {
             Name = name;
@@ -45,6 +58,15 @@ namespace AWS.Deploy.CLI.ServerMode.Models
             TargetService = targetService;
             LastUpdatedTime = lastUpdatedTime;
             UpdatedByCurrentUser = updatedByCurrentUser;
+            ExistingDeploymentId = uniqueIdentifier;
+
+            if (!_deploymentTargetsMapping.ContainsKey(resourceType))
+            {
+                var message = $"Failed to find a deployment target mapping for {nameof(CloudApplicationResourceType)} {resourceType}.";
+                throw new FailedToFindDeploymentTargetsMappingException(message);
+            }
+
+            DeploymentType = _deploymentTargetsMapping[resourceType];  
         }
     }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Models/RecommendationSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/RecommendationSummary.cs
@@ -9,18 +9,26 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 {
     public class RecommendationSummary
     {
+        private readonly Dictionary<Common.Recipes.DeploymentTypes, DeploymentTypes> _deploymentTargetsMapping = new()
+        {
+            { Common.Recipes.DeploymentTypes.CdkProject, DeploymentTypes.CloudFormationStack },
+            { Common.Recipes.DeploymentTypes.BeanstalkEnvironment, DeploymentTypes.BeanstalkEnvironment }
+        };
+
         public string RecipeId { get; set; }
         public string Name { get; set; }
         public string ShortDescription { get; set; }
         public string Description { get; set; }
         public string TargetService { get; set; }
+        public DeploymentTypes DeploymentType { get; set; }
 
         public RecommendationSummary(
             string recipeId,
             string name,
             string shortDescription,
             string description,
-            string targetService
+            string targetService,
+            Common.Recipes.DeploymentTypes deploymentType
         )
         {
             RecipeId = recipeId;
@@ -28,6 +36,14 @@ namespace AWS.Deploy.CLI.ServerMode.Models
             ShortDescription = shortDescription;
             Description = description;
             TargetService = targetService;
+
+            if (!_deploymentTargetsMapping.ContainsKey(deploymentType))
+            {
+                var message = $"Failed to find a deployment target mapping for {nameof(Common.Recipes.DeploymentTypes)} {deploymentType}.";
+                throw new FailedToFindDeploymentTargetsMappingException(message);
+            }
+
+            DeploymentType = _deploymentTargetsMapping[deploymentType];
         }
     }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Models/SetDeploymentTargetInput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/SetDeploymentTargetInput.cs
@@ -13,6 +13,6 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public string? NewDeploymentRecipeId { get; set; }
 
-        public string? ExistingDeploymentName { get; set; }
+        public string? ExistingDeploymentId { get; set; }
     }
 }

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1477,6 +1477,17 @@ namespace AWS.Deploy.ServerMode.Client
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
+    public enum DeploymentTypes
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"CloudFormationStack")]
+        CloudFormationStack = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"BeanstalkEnvironment")]
+        BeanstalkEnvironment = 1,
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v12.0.0.0)")]
     public partial class DeployToolExceptionSummary 
     {
         [Newtonsoft.Json.JsonProperty("errorCode", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -1536,6 +1547,13 @@ namespace AWS.Deploy.ServerMode.Client
     
         [Newtonsoft.Json.JsonProperty("updatedByCurrentUser", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool UpdatedByCurrentUser { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("deploymentType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public DeploymentTypes DeploymentType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("existingDeploymentId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ExistingDeploymentId { get; set; }
     
     
     }
@@ -1715,6 +1733,10 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("targetService", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string TargetService { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("deploymentType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public DeploymentTypes DeploymentType { get; set; }
+    
     
     }
     
@@ -1727,8 +1749,8 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("newDeploymentRecipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string NewDeploymentRecipeId { get; set; }
     
-        [Newtonsoft.Json.JsonProperty("existingDeploymentName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string ExistingDeploymentName { get; set; }
+        [Newtonsoft.Json.JsonProperty("existingDeploymentId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ExistingDeploymentId { get; set; }
     
     
     }

--- a/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
@@ -126,5 +126,41 @@ namespace AWS.Deploy.CLI.UnitTests
             var resultRecipe = Assert.IsType<RecipeSummary>(result.Value);
             Assert.Equal(recipe.Id, resultRecipe.Id);
         }
+
+        [Theory]
+        [InlineData(CloudApplicationResourceType.CloudFormationStack, DeploymentTypes.CloudFormationStack)]
+        [InlineData(CloudApplicationResourceType.BeanstalkEnvironment, DeploymentTypes.BeanstalkEnvironment)]
+        public void ExistingDeploymentSummary_ContainsCorrectDeploymentType(CloudApplicationResourceType resourceType, DeploymentTypes expectedDeploymentType)
+        {
+            var existingDeploymentSummary = new ExistingDeploymentSummary(
+                "name",
+                "recipeId",
+                "recipeName",
+                "shortDescription",
+                "description",
+                "targetService",
+                System.DateTime.Now,
+                true,
+                resourceType,
+                "uniqueId");
+
+            Assert.Equal(expectedDeploymentType, existingDeploymentSummary.DeploymentType);
+        }
+
+        [Theory]
+        [InlineData(Deploy.Common.Recipes.DeploymentTypes.CdkProject, DeploymentTypes.CloudFormationStack)]
+        [InlineData(Deploy.Common.Recipes.DeploymentTypes.BeanstalkEnvironment, DeploymentTypes.BeanstalkEnvironment)]
+        public void RecommendationSummary_ContainsCorrectDeploymentType(Deploy.Common.Recipes.DeploymentTypes deploymentType, DeploymentTypes expectedDeploymentType)
+        {
+            var recommendationSummary = new RecommendationSummary(
+                "recipeId",
+                "name",
+                "shortDescription",
+                "description",
+                "targetService",
+                deploymentType);
+
+            Assert.Equal(expectedDeploymentType, recommendationSummary.DeploymentType);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5510

*Description of changes:*
This PR supports the server-mode workflow to deploy to an existing Elastic Beanstalk environment.
Verified that this PR works as intended by deployment to an existing Beanstalk Environment via server-mode.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
