### PR TITLE
feat: add check for opt-in regions

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -187,7 +187,7 @@ namespace AWS.Deploy.CLI.Commands
                     _commandLineWrapper.RegisterAWSContext(awsCredentials, awsRegion);
                     _awsClientFactory.RegisterAWSContext(awsCredentials, awsRegion);
 
-                    var callerIdentity = await _awsResourceQueryer.GetCallerIdentity();
+                    var callerIdentity = await _awsResourceQueryer.GetCallerIdentity(awsRegion);
 
                     var session = new OrchestratorSession(
                         projectDefinition,
@@ -299,7 +299,7 @@ namespace AWS.Deploy.CLI.Commands
                     {
                         var projectDefinition = await _projectParserUtility.Parse(input.ProjectPath ?? string.Empty);
 
-                        var callerIdentity = await _awsResourceQueryer.GetCallerIdentity();
+                        var callerIdentity = await _awsResourceQueryer.GetCallerIdentity(awsRegion);
 
                         session = new OrchestratorSession(
                             projectDefinition,
@@ -369,6 +369,8 @@ namespace AWS.Deploy.CLI.Commands
                         awsOptions.Credentials = awsCredentials;
                         awsOptions.Region = RegionEndpoint.GetBySystemName(awsRegion);
                     });
+
+                    await _awsResourceQueryer.GetCallerIdentity(awsRegion);
 
                     var listDeploymentsCommand = new ListDeploymentsCommand(_toolInteractiveService, _deployedApplicationQueryer);
 

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -79,7 +79,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 output.SessionId,
                 input.ProjectPath,
                 input.AWSRegion,
-                (await awsResourceQueryer.GetCallerIdentity()).Account,
+                (await awsResourceQueryer.GetCallerIdentity(input.AWSRegion)).Account,
                 await _projectParserUtility.Parse(input.ProjectPath)
                 );
 

--- a/src/AWS.Deploy.Common/DefaultAWSClientFactory.cs
+++ b/src/AWS.Deploy.Common/DefaultAWSClientFactory.cs
@@ -17,11 +17,14 @@ namespace AWS.Deploy.Common
             _awsOptionsAction = awsOptionsAction;
         }
 
-        public T GetAWSClient<T>() where T : IAmazonService
+        public T GetAWSClient<T>(string? awsRegion = null) where T : IAmazonService
         {
             var awsOptions = new AWSOptions();
 
             _awsOptionsAction?.Invoke(awsOptions);
+
+            if (!string.IsNullOrEmpty(awsRegion))
+                awsOptions.Region = RegionEndpoint.GetBySystemName(awsRegion);
 
             return awsOptions.CreateServiceClient<T>();
         }

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -98,7 +98,9 @@ namespace AWS.Deploy.Common
         FailedS3Upload = 10007600,
         FailedToCreateElasticBeanstalkApplicationVersion = 10007700,
         FailedToUpdateElasticBeanstalkEnvironment = 10007800,
-        FailedToCreateElasticBeanstalkStorageLocation = 10007900
+        FailedToCreateElasticBeanstalkStorageLocation = 10007900,
+        UnableToAccessAWSRegion = 10008000,
+        OptInRegionDisabled = 10008100,
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/IAWSClientFactory.cs
+++ b/src/AWS.Deploy.Common/IAWSClientFactory.cs
@@ -9,7 +9,7 @@ namespace AWS.Deploy.Common
 {
     public interface IAWSClientFactory
     {
-        T GetAWSClient<T>() where T : IAmazonService;
+        T GetAWSClient<T>(string? awsRegion = null) where T : IAmazonService;
         void ConfigureAWSOptions(Action<AWSOptions> awsOptionsAction);
     }
 }

--- a/src/AWS.Deploy.Constants/CLI.cs
+++ b/src/AWS.Deploy.Constants/CLI.cs
@@ -6,6 +6,10 @@ namespace AWS.Deploy.Constants
 {
     internal static class CLI
     {
+        // Represents the default STS AWS region that is used for the purposes of
+        // retrieving the caller identity and determining if a user is in an opt-in region.
+        public const string DEFAULT_STS_AWS_REGION = "us-east-1";
+
         public const string CREATE_NEW_LABEL = "*** Create new ***";
         public const string DEFAULT_LABEL = "*** Default ***";
         public const string EMPTY_LABEL = "*** Empty ***";

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -204,4 +204,12 @@ namespace AWS.Deploy.Orchestration
     {
         public ElasticBeanstalkException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+    
+    /// <summary>
+    /// Throw if unable to access the specified AWS Region.
+    /// </summary>
+    public class UnableToAccessAWSRegionException : DeployToolException
+    {
+        public UnableToAccessAWSRegionException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -14,6 +14,7 @@ using Amazon.ECS.Model;
 using Amazon.ElasticBeanstalk.Model;
 using Amazon.ElasticLoadBalancingV2;
 using Amazon.IdentityManagement.Model;
+using Amazon.Runtime;
 using Amazon.SecurityToken.Model;
 using AWS.Deploy.Orchestration.Data;
 
@@ -33,7 +34,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentId) => throw new NotImplementedException();
         public Task<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticLoadBalancingV2.Model.Listener>> DescribeElasticLoadBalancerListeners(string loadBalancerArn) => throw new NotImplementedException();
-        public Task<GetCallerIdentityResponse> GetCallerIdentity() => throw new NotImplementedException();
         public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
         public Task<List<AuthorizationData>> GetECRAuthorizationToken() => throw new NotImplementedException();
         public Task<List<Repository>> GetECRRepositories(List<string> repositoryNames) => throw new NotImplementedException();
@@ -57,5 +57,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
         public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();
+        public Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/TestAWSClientFactory.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TestAWSClientFactory.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.CLI.UnitTests
             _clients = clientMocks ?? new IAmazonService[0];
         }
 
-        public T GetAWSClient<T>() where T : IAmazonService
+        public T GetAWSClient<T>(string? awsRegion = null) where T : IAmazonService
         {
             var match = _clients.OfType<T>().FirstOrDefault();
 

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
@@ -44,7 +44,7 @@ namespace AWS.Deploy.CLI.UnitTests
                     .Returns(ddbPaginators.Object);
 
             var awsClientFactory = new Mock<IAWSClientFactory>();
-            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonDynamoDB>())
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonDynamoDB>(It.IsAny<string>()))
                     .Returns(ddbClient.Object);
 
             var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
@@ -74,7 +74,7 @@ namespace AWS.Deploy.CLI.UnitTests
                     .Returns(sqsPaginators.Object);
 
             var awsClientFactory = new Mock<IAWSClientFactory>();
-            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonSQS>())
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonSQS>(It.IsAny<string>()))
                     .Returns(sqsClient.Object);
 
             var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
@@ -104,7 +104,7 @@ namespace AWS.Deploy.CLI.UnitTests
                     .Returns(snsPaginators.Object);
 
             var awsClientFactory = new Mock<IAWSClientFactory>();
-            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonSimpleNotificationService>())
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonSimpleNotificationService>(It.IsAny<string>()))
                     .Returns(snsClient.Object);
 
             var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);
@@ -126,7 +126,7 @@ namespace AWS.Deploy.CLI.UnitTests
                     .Returns(Task.FromResult(new ListBucketsResponse { Buckets = new List<S3Bucket> { new S3Bucket {BucketName = "Bucket1" }, new S3Bucket { BucketName = "Bucket2" } } }));
 
             var awsClientFactory = new Mock<IAWSClientFactory>();
-            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonS3>())
+            awsClientFactory.Setup(x => x.GetAWSClient<IAmazonS3>(It.IsAny<string>()))
                     .Returns(s3Client.Object);
 
             var awsResourceQueryer = new AWSResourceQueryer(awsClientFactory.Object);

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -12,6 +12,7 @@ using Amazon.ECR.Model;
 using Amazon.ElasticBeanstalk.Model;
 using Amazon.ElasticLoadBalancingV2;
 using Amazon.IdentityManagement.Model;
+using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SecurityToken.Model;
 using AWS.Deploy.Orchestration;
@@ -26,7 +27,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
         public Task<Repository> CreateECRRepository(string repositoryName) => throw new NotImplementedException();
         public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
-        public Task<GetCallerIdentityResponse> GetCallerIdentity() => throw new NotImplementedException();
 
         public Task<List<AuthorizationData>> GetECRAuthorizationToken()
         {
@@ -82,5 +82,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
         public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();
+        public Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWSResourceQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWSResourceQueryerTests.cs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.Data;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.Orchestration.UnitTests
+{
+    public class AWSResourceQueryerTests
+    {
+        private readonly Mock<IAWSClientFactory> _mockAWSClientFactory;
+        private readonly Mock<IAmazonSecurityTokenService> _mockSTSClient;
+        private readonly Mock<IAmazonSecurityTokenService> _mockSTSClientDefaultRegion;
+
+        public AWSResourceQueryerTests()
+        {
+            _mockAWSClientFactory = new Mock<IAWSClientFactory>();
+            _mockSTSClient = new Mock<IAmazonSecurityTokenService>();
+            _mockSTSClientDefaultRegion = new Mock<IAmazonSecurityTokenService>();
+        }
+
+        [Fact]
+        public async Task GetCallerIdentity_HasRegionAccess()
+        {
+            var awsResourceQueryer = new AWSResourceQueryer(_mockAWSClientFactory.Object);
+            var stsResponse = new GetCallerIdentityResponse();
+
+            _mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonSecurityTokenService>("ap-southeast-3")).Returns(_mockSTSClient.Object);
+            _mockSTSClient.Setup(x => x.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(stsResponse);
+
+            await awsResourceQueryer.GetCallerIdentity("ap-southeast-3");
+        }
+
+        [Fact]
+        public async Task GetCallerIdentity_OptInRegion()
+        {
+            var awsResourceQueryer = new AWSResourceQueryer(_mockAWSClientFactory.Object);
+            var stsResponse = new GetCallerIdentityResponse();
+
+            _mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonSecurityTokenService>("ap-southeast-3")).Returns(_mockSTSClient.Object);
+            _mockSTSClient.Setup(x => x.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>())).Throws(new Exception("Invalid token"));
+
+            _mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonSecurityTokenService>("us-east-1")).Returns(_mockSTSClientDefaultRegion.Object);
+            _mockSTSClientDefaultRegion.Setup(x => x.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(stsResponse);
+
+            var exceptionThrown = await Assert.ThrowsAsync<UnableToAccessAWSRegionException>(() => awsResourceQueryer.GetCallerIdentity("ap-southeast-3"));
+            Assert.Equal(DeployToolErrorCode.OptInRegionDisabled, exceptionThrown.ErrorCode);
+        }
+
+        [Fact]
+        public async Task GetCallerIdentity_BadConnection()
+        {
+            var awsResourceQueryer = new AWSResourceQueryer(_mockAWSClientFactory.Object);
+            var stsResponse = new GetCallerIdentityResponse();
+
+            _mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonSecurityTokenService>("ap-southeast-3")).Returns(_mockSTSClient.Object);
+            _mockSTSClient.Setup(x => x.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>())).Throws(new Exception("Invalid token"));
+
+            _mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonSecurityTokenService>("us-east-1")).Returns(_mockSTSClientDefaultRegion.Object);
+            _mockSTSClientDefaultRegion.Setup(x => x.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>())).Throws(new Exception("Invalid token"));
+
+            var exceptionThrown = await Assert.ThrowsAsync<UnableToAccessAWSRegionException>(() => awsResourceQueryer.GetCallerIdentity("ap-southeast-3"));
+            Assert.Equal(DeployToolErrorCode.UnableToAccessAWSRegion, exceptionThrown.ErrorCode);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5640

*Description of changes:*
Update existing GetCallerIdentity call at Command startup which checks if a region is reachable. If it is not, we retrieve the region partition. If it is in the commercial partition, we do another GetCallerIdentity call to us-east-1(default region). If that succeeds, we conclude that the user is in an opt-in region and needs to enable it.

![image](https://user-images.githubusercontent.com/53088140/151865766-c80508b2-87fe-4d72-837e-dd294fe86e7a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
