### PR TITLE
feat: capture standard error in server mode session

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.ServerMode.Client/CommandLineWrapper.cs
@@ -6,7 +6,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
+using AWS.Deploy.ServerMode.Client.Utilities;
 
 namespace AWS.Deploy.ServerMode.Client
 {
@@ -19,9 +21,12 @@ namespace AWS.Deploy.ServerMode.Client
             _diagnosticLoggingEnabled = diagnosticLoggingEnabled;
         }
 
-        public virtual async Task<int> Run(string command, params string[] stdIn)
+        public virtual async Task<RunResult> Run(string command, params string[] stdIn)
         {
             var arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"/c {command}" : $"-c \"{command}\"";
+
+            var strOutput = new CappedStringBuilder(100);
+            var strError = new CappedStringBuilder(50);
 
             var processStartInfo = new ProcessStartInfo
             {
@@ -29,6 +34,8 @@ namespace AWS.Deploy.ServerMode.Client
                 Arguments = arguments,
                 UseShellExecute = false, // UseShellExecute must be false in allow redirection of StdIn.
                 RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
                 CreateNoWindow = !_diagnosticLoggingEnabled, // It allows displaying stdout and stderr on the screen.
             };
 
@@ -43,9 +50,28 @@ namespace AWS.Deploy.ServerMode.Client
                 await process.StandardInput.WriteLineAsync(line).ConfigureAwait(false);
             }
 
+            process.OutputDataReceived += (sender, e) =>
+            {
+                strOutput.AppendLine(e.Data);
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                strError.AppendLine(e.Data);
+            };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
             process.WaitForExit(-1);
 
-            return await Task.FromResult(process.ExitCode).ConfigureAwait(false);
+            var result = new RunResult
+            {
+                ExitCode = process.ExitCode,
+                StandardError = strError.ToString(),
+                StandardOut = strOutput.GetLastLines(5),
+            };
+
+            return await Task.FromResult(result).ConfigureAwait(false);
         }
 
         private string GetSystemShell()
@@ -69,5 +95,29 @@ namespace AWS.Deploy.ServerMode.Client
             value = Environment.GetEnvironmentVariable(variable);
             return !string.IsNullOrEmpty(value);
         }
+    }
+
+    public class RunResult
+    {
+        /// <summary>
+        /// Indicates if this command was run successfully.  This checks that
+        /// <see cref="StandardError"/> is empty.
+        /// </summary>
+        public bool Success => string.IsNullOrWhiteSpace(StandardError);
+
+        /// <summary>
+        /// Fully read <see cref="Process.StandardOutput"/>
+        /// </summary>
+        public string StandardOut { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Fully read <see cref="Process.StandardError"/>
+        /// </summary>
+        public string StandardError { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Fully read <see cref="Process.ExitCode"/>
+        /// </summary>
+        public int ExitCode { get; set; }
     }
 }

--- a/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
+++ b/src/AWS.Deploy.ServerMode.Client/ServerModeSession.cs
@@ -164,9 +164,12 @@ namespace AWS.Deploy.ServerMode.Client
 
                 // For -100 errors, we want to check all the ports in the configured port range
                 // If the error code other than -100, this is an unexpected exit code.
-                if (startServerTask.Result != TCP_PORT_ERROR)
+                if (startServerTask.Result.ExitCode != TCP_PORT_ERROR)
                 {
-                    throw new InternalServerModeException($"\"{command}\" failed for unknown reason.");
+                    throw new InternalServerModeException(
+                        string.IsNullOrEmpty(startServerTask.Result.StandardError) ?
+                        $"\"{command}\" failed for unknown reason." :
+                        startServerTask.Result.StandardError);
                 }
             }
 

--- a/src/AWS.Deploy.ServerMode.Client/Utilities/CappedStringBuilder.cs
+++ b/src/AWS.Deploy.ServerMode.Client/Utilities/CappedStringBuilder.cs
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AWS.Deploy.ServerMode.Client.Utilities
+{
+    public class CappedStringBuilder
+    {
+        public int LineLimit { get; }
+        public int LineCount {
+            get
+            {
+                return _lines?.Count ?? 0;
+            }
+        }
+
+        private readonly Queue<string> _lines;
+
+        public CappedStringBuilder(int lineLimit)
+        {
+            _lines = new Queue<string>(lineLimit);
+            LineLimit = lineLimit;
+        }
+
+        public void AppendLine(string value)
+        {
+            if (LineCount >= LineLimit)
+            {
+                _lines.Dequeue();
+            }
+
+            _lines.Enqueue(value);
+        }
+
+        public string GetLastLines(int lineCount)
+        {
+            return _lines.Reverse().Take(lineCount).Reverse().Aggregate((x, y) => x + Environment.NewLine + y);
+        }
+
+        public override string ToString()
+        {
+            return _lines.Aggregate((x, y) => x + Environment.NewLine + y);
+        }
+    }
+}

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/CappedStringBuilderTests.cs
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/CappedStringBuilderTests.cs
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using AWS.Deploy.ServerMode.Client.Utilities;
+using Xunit;
+
+namespace AWS.Deploy.ServerMode.Client.UnitTests
+{
+    public class CappedStringBuilderTests
+    {
+        private readonly CappedStringBuilder _cappedStringBuilder;
+
+        public CappedStringBuilderTests()
+        {
+            _cappedStringBuilder = new CappedStringBuilder(5);
+        }
+
+        [Fact]
+        public void AppendLineTest()
+        {
+            _cappedStringBuilder.AppendLine("test1");
+            _cappedStringBuilder.AppendLine("test2");
+            _cappedStringBuilder.AppendLine("test3");
+
+            Assert.Equal(3, _cappedStringBuilder.LineCount);
+            Assert.Equal($"test1{Environment.NewLine}test2{Environment.NewLine}test3", _cappedStringBuilder.ToString());
+        }
+
+        [Fact]
+        public void GetLastLinesTest()
+        {
+            _cappedStringBuilder.AppendLine("test1");
+            _cappedStringBuilder.AppendLine("test2");
+
+            Assert.Equal(2, _cappedStringBuilder.LineCount);
+            Assert.Equal("test2", _cappedStringBuilder.GetLastLines(1));
+            Assert.Equal($"test1{Environment.NewLine}test2", _cappedStringBuilder.GetLastLines(2));
+        }
+    }
+}

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/ServerModeSessionTests.cs
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/ServerModeSessionTests.cs
@@ -27,7 +27,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task Start()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
 
             // Act
@@ -44,7 +45,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task Start_PortUnavailable()
         {
             // Arrange
-            MockCommandLineWrapperRun(-100);
+            var runResult = new RunResult { ExitCode = -100 };
+            MockCommandLineWrapperRun(runResult);
             MockHttpGet(HttpStatusCode.NotFound, TimeSpan.FromSeconds(5));
 
             // Act & Assert
@@ -58,7 +60,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task Start_HttpGetThrows()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGetThrows();
 
             // Act & Assert
@@ -72,7 +75,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task Start_HttpGetForbidden()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.Forbidden);
 
             // Act & Assert
@@ -96,7 +100,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task IsAlive_GetAsyncThrows()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
             await _serverModeSession.Start(CancellationToken.None);
 
@@ -113,7 +118,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task IsAlive_HttpResponseSuccess()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
             await _serverModeSession.Start(CancellationToken.None);
 
@@ -128,7 +134,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task IsAlive_HttpResponseFailure()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
             await _serverModeSession.Start(CancellationToken.None);
 
@@ -145,7 +152,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task TryGetRestAPIClient()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
             await _serverModeSession.Start(CancellationToken.None);
 
@@ -161,7 +169,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public void TryGetRestAPIClient_WithoutStart()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
 
             // Act
@@ -176,7 +185,8 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
         public async Task TryGetDeploymentCommunicationClient()
         {
             // Arrange
-            MockCommandLineWrapperRun(0, TimeSpan.FromSeconds(100));
+            var runResult = new RunResult { ExitCode = 0 };
+            MockCommandLineWrapperRun(runResult, TimeSpan.FromSeconds(100));
             MockHttpGet(HttpStatusCode.OK);
             await _serverModeSession.Start(CancellationToken.None);
 
@@ -228,15 +238,15 @@ namespace AWS.Deploy.ServerMode.Client.UnitTests
                     ItExpr.IsAny<CancellationToken>())
                 .Throws(new Exception());
 
-        private void MockCommandLineWrapperRun(int statusCode) =>
+        private void MockCommandLineWrapperRun(RunResult runResult) =>
             _commandLineWrapper
                 .Setup(wrapper => wrapper.Run(It.IsAny<string>(), It.IsAny<string[]>()))
-                .ReturnsAsync(statusCode);
+                .ReturnsAsync(runResult);
 
-        private void MockCommandLineWrapperRun(int statusCode, TimeSpan delay) =>
+        private void MockCommandLineWrapperRun(RunResult runResult, TimeSpan delay) =>
             _commandLineWrapper
                 .Setup(wrapper => wrapper.Run(It.IsAny<string>(), It.IsAny<string[]>()))
-                .ReturnsAsync(statusCode, delay);
+                .ReturnsAsync(runResult, delay);
 
         private Task<AWSCredentials> CredentialGenerator() => throw new NotImplementedException();
     }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5204

*Description of changes:*
Redirected standard error in server mode session to capture any error thrown in startup.
In the case where the deploy tool is not installed, server mode session throws an error but does not return the message indicating that the deploy tool is not installed. This change makes it so that errors are returned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
