### PR TITLE
fix: deployment project fails if .aws-dotnet-deploy directory does no…

### DIFF
--- a/src/AWS.Deploy.Orchestration/CDK/CDKInstaller.cs
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKInstaller.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Utilities;
 
 namespace AWS.Deploy.Orchestration.CDK
@@ -35,15 +36,20 @@ namespace AWS.Deploy.Orchestration.CDK
     public class CDKInstaller : ICDKInstaller
     {
         private readonly ICommandLineWrapper _commandLineWrapper;
+        private readonly IDirectoryManager _directoryManager;
 
-        public CDKInstaller(ICommandLineWrapper commandLineWrapper)
+        public CDKInstaller(ICommandLineWrapper commandLineWrapper, IDirectoryManager directoryManager)
         {
             _commandLineWrapper = commandLineWrapper;
+            _directoryManager = directoryManager;
         }
 
         public async Task<TryGetResult<Version>> GetVersion(string workingDirectory)
         {
             const string command = "npx --no-install cdk --version";
+
+            if (!_directoryManager.Exists(workingDirectory))
+                _directoryManager.CreateDirectory(workingDirectory);
 
             TryRunResult result;
 

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKInstallerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKInstallerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Utilities;
 using Xunit;
@@ -13,12 +14,14 @@ namespace AWS.Deploy.Orchestration.UnitTests.CDK
     {
         private readonly TestCommandLineWrapper _commandLineWrapper;
         private readonly CDKInstaller _cdkInstaller;
+        private readonly IDirectoryManager _directoryManager;
         private const string _workingDirectory = @"c:\fake\path";
 
         public CDKInstallerTests()
         {
             _commandLineWrapper = new TestCommandLineWrapper();
-            _cdkInstaller = new CDKInstaller(_commandLineWrapper);
+            _directoryManager = new TestDirectoryManager();
+            _cdkInstaller = new CDKInstaller(_commandLineWrapper, _directoryManager);
         }
 
         [Fact]


### PR DESCRIPTION
*Issue #, if available:*
Closes #420 

*Description of changes:*
When using a deployment project, we don't create the temp folder .aws-dotnet-deploy. I added a create directory before using that folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
