### PR TITLE
feat: Add support for --silent flag in the delete-deployment command

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -40,7 +40,7 @@ namespace AWS.Deploy.CLI.Commands
         private static readonly Option<string> _optionApplicationName = new("--application-name", "Name of the cloud application. If you choose to deploy via CloudFormation, this name will be used to identify the CloudFormation stack.");
         private static readonly Option<bool> _optionDiagnosticLogging = new(new[] { "-d", "--diagnostics" }, "Enable diagnostic output.");
         private static readonly Option<string> _optionApply = new("--apply", "Path to the deployment settings file to be applied.");
-        private static readonly Option<bool> _optionDisableInteractive = new(new[] { "-s", "--silent" }, "Disable interactivity to deploy without any prompts for user input.");
+        private static readonly Option<bool> _optionDisableInteractive = new(new[] { "-s", "--silent" }, "Disable interactivity to execute commands without any prompts for user input.");
         private static readonly Option<string> _optionOutputDirectory = new(new[] { "-o", "--output" }, "Directory path in which the CDK deployment project will be saved.");
         private static readonly Option<string> _optionProjectDisplayName = new(new[] { "--project-display-name" }, "The name of the deployment project that will be displayed in the list of available deployment options.");
         private static readonly Option<string> _optionDeploymentProject = new(new[] { "--deployment-project" }, "The absolute or relative path of the CDK project that will be used for deployment");
@@ -268,6 +268,7 @@ namespace AWS.Deploy.CLI.Commands
                 deleteCommand.Add(_optionRegion);
                 deleteCommand.Add(_optionProjectPath);
                 deleteCommand.Add(_optionDiagnosticLogging);
+                deleteCommand.Add(_optionDisableInteractive);
                 deleteCommand.AddArgument(new Argument("deployment-name"));
             }
 
@@ -276,6 +277,7 @@ namespace AWS.Deploy.CLI.Commands
                 try
                 {
                     _toolInteractiveService.Diagnostics = input.Diagnostics;
+                    _toolInteractiveService.DisableInteractive = input.Silent;
 
                     var awsCredentials = await _awsUtilities.ResolveAWSCredentials(input.Profile);
                     var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region);

--- a/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/DeleteCommandHandlerInput.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/DeleteCommandHandlerInput.cs
@@ -15,5 +15,6 @@ namespace AWS.Deploy.CLI.Commands.CommandHandlerInput
         public string? ProjectPath { get; set; }
         public string? DeploymentName { get; set; }
         public bool Diagnostics { get; set; }
+        public bool Silent { get; set; }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeleteDeploymentCommand.cs
@@ -57,7 +57,10 @@ namespace AWS.Deploy.CLI.Commands
                 return;
             }
 
-            var confirmDelete = _consoleUtilities.AskYesNoQuestion($"Are you sure you want to delete {stackName}?", YesNo.No);
+            var confirmDelete =  _interactiveService.DisableInteractive
+                ? YesNo.Yes
+                : _consoleUtilities.AskYesNoQuestion($"Are you sure you want to delete {stackName}?", YesNo.No);
+
             if (confirmDelete == YesNo.No)
             {
                 return;

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -91,9 +91,8 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.Contains(listStdOut, (deployment) => _stackName.Equals(deployment));
 
             // Arrange input for delete
-            await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
-            await _interactiveService.StdInWriter.FlushAsync();
-            var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics" };
+            // Use --silent flag to delete without user prompts
+            var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics", "--silent" };
 
             // Delete
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deleteArgs));;


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws/aws-dotnet-deploy/issues/404
* DOTNET-5646

*Description of changes:*
This PR adds the support `--silent` flag to the `delete-deployment` command to enable deletions without any user prompts.
**Command Syntax** : `dotnet aws delete-deployment <CloudApplicationName> --silent`

Updated `WebAppNoDockerFileTests` to use the `--silent` flag during stack deletion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
