### PR TITLE
feat: Make ECR repository name configurable in container based deployments

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -59,6 +59,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.SNSTopicArn, new SNSTopicArnsCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.S3BucketName, new S3BucketNameCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.InstanceType, new InstanceTypeCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ECRRepository,  new ECRRepositoryCommand(awsResourceQueryer, consoleUtilities)}
             };
         }
 

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -101,6 +101,7 @@ namespace AWS.Deploy.Common
         FailedToCreateElasticBeanstalkStorageLocation = 10007900,
         UnableToAccessAWSRegion = 10008000,
         OptInRegionDisabled = 10008100,
+        ECRRepositoryPromptForNameReturnedNull = 10008200
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -30,6 +30,7 @@ namespace AWS.Deploy.Common.Recipes
         ExistingIAMRole,
         ExistingECSCluster,
         ExistingVpc,
-        ExistingBeanstalkApplication
+        ExistingBeanstalkApplication,
+        ECRRepository
     };
 }

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -45,7 +45,7 @@ namespace AWS.Deploy.Common
             DeploymentBundle = new DeploymentBundle();
             DeploymentBundleSettings = deploymentBundleSettings;
 
-            CollectRecommendationReplacementTokens(Recipe.OptionSettings);
+            CollectRecommendationReplacementTokens(GetConfigurableOptionSettingItems().ToList());
 
             foreach (var replacement in additionalReplacements)
             {

--- a/src/AWS.Deploy.Constants/CLI.cs
+++ b/src/AWS.Deploy.Constants/CLI.cs
@@ -18,8 +18,5 @@ namespace AWS.Deploy.Constants
         public const string PROMPT_CHOOSE_DEPLOYMENT_TARGET = "Choose deployment target";
 
         public const string CLI_APP_NAME = "AWS .NET Deployment Tool";
-
-        public const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
-        public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";
     }
 }

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -6,8 +6,12 @@ namespace AWS.Deploy.Constants
 {
     internal static class RecipeIdentifier
     {
+        // Recipe IDs
+        public const string EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkEnvironment";
+
+        // Replacement Tokens
         public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";
         public const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
-        public const string EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkEnvironment";
+        public const string REPLACE_TOKEN_ECR_REPOSITORY_NAME = "{DefaultECRRepositoryName}";
     }
 }

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.Orchestration.Data
         Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns();
         Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn();
         Task<List<AuthorizationData>> GetECRAuthorizationToken();
-        Task<List<Repository>> GetECRRepositories(List<string> repositoryNames);
+        Task<List<Repository>> GetECRRepositories(List<string>? repositoryNames = null);
         Task<Repository> CreateECRRepository(string repositoryName);
         Task<List<Stack>> GetCloudFormationStacks();
         Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion);
@@ -407,7 +407,7 @@ namespace AWS.Deploy.Orchestration.Data
             return response.AuthorizationData;
         }
 
-        public async Task<List<Repository>> GetECRRepositories(List<string> repositoryNames)
+        public async Task<List<Repository>> GetECRRepositories(List<string>? repositoryNames = null)
         {
             var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>();
 

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -19,7 +19,7 @@ namespace AWS.Deploy.Orchestration
     {
         Task<string> BuildDockerImage(CloudApplication cloudApplication, Recommendation recommendation);
         Task<string> CreateDotnetPublishZip(Recommendation recommendation);
-        Task PushDockerImageToECR(CloudApplication cloudApplication, Recommendation recommendation, string sourceTag);
+        Task PushDockerImageToECR(Recommendation recommendation, string repositoryName, string sourceTag);
     }
 
     public class DeploymentBundleHandler : IDeploymentBundleHandler
@@ -71,7 +71,7 @@ namespace AWS.Deploy.Orchestration
             return imageTag;
         }
 
-        public async Task PushDockerImageToECR(CloudApplication cloudApplication, Recommendation recommendation, string sourceTag)
+        public async Task PushDockerImageToECR(Recommendation recommendation, string repositoryName, string sourceTag)
         {
             _interactiveService.LogMessageLine(string.Empty);
             _interactiveService.LogMessageLine("Pushing the docker image to ECR repository...");
@@ -79,7 +79,7 @@ namespace AWS.Deploy.Orchestration
             await InitiateDockerLogin();
 
             var tagSuffix = sourceTag.Split(":")[1];
-            var repository = await SetupECRRepository(cloudApplication.Name.ToLower());
+            var repository = await SetupECRRepository(repositoryName);
             var targetTag = $"{repository.RepositoryUri}:{tagSuffix}";
 
             await TagDockerImage(sourceTag, targetTag);

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -20,6 +20,25 @@
             "DefaultValue": "",
             "AdvancedSetting": true,
             "Updatable": true
+        },
+        {
+            "Id": "ECRRepositoryName",
+            "Name": "ECS Repository Name",
+            "Description": "Specifies the ECR repository where the docker images will be stored",
+            "Type": "String",
+            "TypeHint": "ECRRepository",
+            "DefaultValue": "{DefaultECRRepositoryName}",
+            "AdvancedSetting": false,
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "Regex",
+                    "Configuration" : {
+                        "Regex": "^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+                        "ValidationFailedMessage": "Invalid ECR repository Name. The ECR repository name can only contain lowercase letters, numbers, hyphens(-), dots(.), underscores(_) and forward slashes (/). For more information visit https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html#cfn-ecr-repository-repositoryname"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -124,6 +124,19 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             Validate(optionSettingItem, value, isValid);
         }
 
+        [Theory]
+        [InlineData("myrepo123", true)]
+        [InlineData("myrepo123.a/b", true)]
+        [InlineData("MyRepo", false)] // cannot contain uppercase letters
+        [InlineData("myrepo123@", false)] // cannot contain @
+        [InlineData("myrepo123.a//b", false)] // cannot contain consecutive slashes.
+        public void ECRRepositoryNameValidationTest(string value, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$"));
+            Validate(optionSettingItem, value, isValid);
+        }
+
         private OptionSettingItemValidatorConfig GetRegexValidatorConfig(string regex)
         {
             var regexValidatorConfig = new OptionSettingItemValidatorConfig

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -99,11 +99,11 @@ namespace AWS.Deploy.CLI.UnitTests
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
             var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
+            var repositoryName = "repository";
 
-            var cloudApplication = new CloudApplication("ConsoleAppTask", string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
-            await _deploymentBundleHandler.PushDockerImageToECR(cloudApplication, recommendation, "ConsoleAppTask:latest");
+            await _deploymentBundleHandler.PushDockerImageToECR(recommendation, repositoryName, "ConsoleAppTask:latest");
 
-            Assert.Equal(cloudApplication.Name.ToLower(), recommendation.DeploymentBundle.ECRRepositoryName);
+            Assert.Equal(repositoryName, recommendation.DeploymentBundle.ECRRepositoryName);
         }
 
         [Fact]


### PR DESCRIPTION
*Description of changes:*
This PR makes the ECR repository name configurable in container based deployment recipes. It does so by making the ECR repository name a part of the deployment bundle settings. This option setting is backed by the `ECRRepositoryCommand` type hint that gives users the ability to create a new repository or select  an existing one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
