### PR TITLE
feat: Improve the CLI UX to support multiple deployment targets

### DIFF
--- a/src/AWS.Deploy.Constants/CLI.cs
+++ b/src/AWS.Deploy.Constants/CLI.cs
@@ -10,11 +10,16 @@ namespace AWS.Deploy.Constants
         // retrieving the caller identity and determining if a user is in an opt-in region.
         public const string DEFAULT_STS_AWS_REGION = "us-east-1";
 
+        // labels
         public const string CREATE_NEW_LABEL = "*** Create new ***";
         public const string DEFAULT_LABEL = "*** Default ***";
         public const string EMPTY_LABEL = "*** Empty ***";
         public const string CREATE_NEW_STACK_LABEL = "*** Deploy to a new CloudFormation stack ***";
+        public const string CREATE_NEW_APPLICATION_LABEL = "*** Deploy to a new Cloud Application ***";
+
+        // input prompts
         public const string PROMPT_NEW_STACK_NAME = "Enter the name of the new CloudFormationStack stack";
+        public const string PROMPT_NEW_ECR_REPOSITORY_NAME = "Enter the name of the new ECR repository";
         public const string PROMPT_CHOOSE_DEPLOYMENT_TARGET = "Choose deployment target";
 
         public const string CLI_APP_NAME = "AWS .NET Deployment Tool";


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5711

*Description of changes:*
This PR improves the CLI UX to support multiple deployment targets. It adds the ability to generate the input prompts for `CloudApplication` name by inspecting the deployment type of the recipe at run time.

**This PR establishes the following UX** _(Switch to a non-dark mode on the browser to view the flowchart clearly)_


![deploy-tool-ux](https://user-images.githubusercontent.com/36622308/155426470-7cbabb71-902b-4450-a7b2-ce89b7b79d25.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
