### PR TITLE
fix: Fix redeployment failure while using ConsoleAppEcsFargateService recipe

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Configurations/AutoScalingConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Configurations/AutoScalingConfiguration.cs
@@ -15,11 +15,13 @@ namespace ConsoleAppEcsFargateService.Configurations
 {
     public partial class AutoScalingConfiguration
     {
+        const int defaultCooldown = 300;
+
         public bool Enabled { get; set; }
 
-        public int MinCapacity { get; set; }
+        public int MinCapacity { get; set; } = 1;
 
-        public int MaxCapacity { get; set; }
+        public int MaxCapacity { get; set; } = 3;
 
         public enum ScalingTypeEnum { Cpu, Memory }
 
@@ -27,19 +29,19 @@ namespace ConsoleAppEcsFargateService.Configurations
 
 
 
-        public double CpuTypeTargetUtilizationPercent { get; set; }
+        public double CpuTypeTargetUtilizationPercent { get; set; } = 70;
 
-        public int CpuTypeScaleInCooldownSeconds { get; set; }
+        public int CpuTypeScaleInCooldownSeconds { get; set; } = defaultCooldown;
 
-        public int CpuTypeScaleOutCooldownSeconds { get; set; }
+        public int CpuTypeScaleOutCooldownSeconds { get; set; } = defaultCooldown;
 
 
 
-        public int MemoryTypeTargetUtilizationPercent { get; set; }
+        public int MemoryTypeTargetUtilizationPercent { get; set; } = 70;
 
-        public int MemoryTypeScaleInCooldownSeconds { get; set; }
+        public int MemoryTypeScaleInCooldownSeconds { get; set; } = defaultCooldown;
 
-        public int MemoryTypeScaleOutCooldownSeconds { get; set; }
+        public int MemoryTypeScaleOutCooldownSeconds { get; set; } = defaultCooldown;
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -97,6 +97,15 @@ namespace AWS.Deploy.CLI.IntegrationTests
             var listStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
             Assert.Contains(listStdOut, (deployment) => _stackName.Equals(deployment));
 
+            // Arrange input for re-deployment
+            await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default option settings
+            await _interactiveService.StdInWriter.FlushAsync();
+
+            // Perform re-deployment
+            deployArgs = new[] { "deploy", "--project-path", _testAppManager.GetProjectPath(Path.Combine(components)), "--application-name", _stackName, "--diagnostics" };
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
+            Assert.Equal(StackStatus.UPDATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
             // Arrange input for delete
             await _interactiveService.StdInWriter.WriteAsync("y"); // Confirm delete
             await _interactiveService.StdInWriter.FlushAsync();


### PR DESCRIPTION
*Description of changes:*
The deploy tool fails to perform a redeployment using the `ConsoleAppEcsFargateService` recipe. This is because the child option settings inside the `AutoScalingConfiguration` do not have a default value in the CDK Templates. As a result, these option settings are set to `0` while apply the previous deployment settings ultimately causing the `range` validators to fail.

This PR fixes the above issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
