### PR TITLE
feat: Add support for worker project types

### DIFF
--- a/.github/workflows/BuildandTest.yml
+++ b/.github/workflows/BuildandTest.yml
@@ -19,6 +19,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Setup .NET Core 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30309.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{11C7056E-93C1-408B-BD87-5270595BBE0E}"
 EndProject
@@ -64,7 +64,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.ServerMode.Clien
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AWS.Deploy.Constants", "src\AWS.Deploy.Constants\AWS.Deploy.Constants.shproj", "{F2266C44-C8C5-45AD-AA9B-44F8825BDF63}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Deploy.ServerMode.Client.UnitTests", "test\AWS.Deploy.ServerMode.Client.UnitTests\AWS.Deploy.ServerMode.Client.UnitTests.csproj", "{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.ServerMode.Client.UnitTests", "test\AWS.Deploy.ServerMode.Client.UnitTests\AWS.Deploy.ServerMode.Client.UnitTests.csproj", "{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerServiceExample", "testapps\WorkerServiceExample\WorkerServiceExample.csproj", "{7C330493-9BF7-4DB6-815B-807C08500AC6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -167,6 +169,10 @@ Global
 		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -196,6 +202,7 @@ Global
 		{C533AA26-797A-4A41-BA28-2364B66DAA5F} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{F2266C44-C8C5-45AD-AA9B-44F8825BDF63} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
+		{7C330493-9BF7-4DB6-815B-807C08500AC6} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -129,7 +129,17 @@ namespace AWS.Deploy.DockerEngine
         {
             var content = ProjectUtilities.ReadDockerFileConfig();
             var definitions = JsonConvert.DeserializeObject<List<ImageDefinition>>(content);
-            var mappings = definitions.FirstOrDefault(x => x.SdkType.Equals(_project.SdkType));
+
+            var sdkType = _project.SdkType;
+
+            // For the Microsoft.NET.Sdk.Workersdk type we want to use the same container as Microsoft.NET.Sdk since a project
+            // using Microsoft.NET.Sdk.Worker is still just a regular console application.
+            if (string.Equals(sdkType, "Microsoft.NET.Sdk.Worker", StringComparison.OrdinalIgnoreCase))
+            {
+                sdkType = "Microsoft.NET.Sdk";
+            }
+
+            var mappings = definitions.FirstOrDefault(x => x.SdkType.Equals(sdkType));
             if (mappings == null)
                 throw new UnsupportedProjectException(DeployToolErrorCode.NoValidDockerMappingForSdkType, $"The project with SDK Type {_project.SdkType} is not supported.");
 

--- a/src/AWS.Deploy.Orchestration/RecommendationEngine/MSProjectSdkAttributeTest.cs
+++ b/src/AWS.Deploy.Orchestration/RecommendationEngine/MSProjectSdkAttributeTest.cs
@@ -15,7 +15,16 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
 
         public override Task<bool> Execute(RecommendationTestInput input)
         {
-            var result = string.Equals(input.ProjectDefinition.SdkType, input.Test.Condition.Value, StringComparison.InvariantCultureIgnoreCase);
+            bool result = false;
+            if(!string.IsNullOrEmpty(input.Test.Condition.Value))
+            {
+                result = string.Equals(input.ProjectDefinition.SdkType, input.Test.Condition.Value, StringComparison.InvariantCultureIgnoreCase);
+            }
+            else if(input.Test.Condition.AllowedValues?.Count > 0)
+            {
+                result = input.Test.Condition.AllowedValues.Contains(input.ProjectDefinition.SdkType);
+            }
+
             return Task.FromResult(result);
         }
     }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -26,8 +26,24 @@
         }
     ],
 
-    "RecipePriority": 110,
+    "RecipePriority": -1,
     "RecommendationRules": [
+
+        {
+            "Tests": [
+                {
+                    "Type": "MSProperty",
+                    "Condition": {
+                        "PropertyName": "TargetFramework",
+                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                    }
+                }
+            ],
+            "Effect": {
+                "Fail": { "Include": false }
+            }
+        },
+
         {
             "Tests": [
                 {
@@ -39,20 +55,39 @@
                 {
                     "Type": "MSProperty",
                     "Condition": {
-                        "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
-                    }
-                },
-                {
-                    "Type": "MSProperty",
-                    "Condition": {
                         "PropertyName": "OutputType",
                         "AllowedValues": [ "Exe" ]
                     }
                 }
             ],
             "Effect": {
-                "Pass": { "Include": true }
+                "Pass": {
+                    "PriorityAdjustment": 111,
+                    "Include": true
+                },
+                "Fail": {
+                    "Include": true
+                }
+            }
+        },
+
+        {
+            "Tests": [
+                {
+                    "Type": "MSProjectSdkAttribute",
+                    "Condition": {
+                        "Value": "Microsoft.NET.Sdk.Worker"
+                    }
+                }
+            ],
+            "Effect": {
+                "Pass": {
+                    "PriorityAdjustment": 111,
+                    "Include": true
+                },
+                "Fail": {
+                    "Include": true
+                }
             }
         },
 

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -23,6 +23,7 @@ namespace AWS.Deploy.CLI.UnitTests
         [InlineData("WebAppProjectDependencies", "WebAppProjectDependencies")]
         [InlineData("WebAppDifferentTargetFramework", "")]
         [InlineData("ConsoleSdkType", "")]
+        [InlineData("WorkerServiceExample", "")]
         public async Task DockerGenerate(string topLevelFolder, string projectName)
         {
             var projectPath = ResolvePath(Path.Combine(topLevelFolder, projectName));

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -113,6 +113,19 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.NotNull(blazorRecommendation);
         }
 
+        [Fact]
+        public async Task WorkerServiceTest()
+        {
+            var engine = await BuildRecommendationEngine("WorkerServiceExample");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            Assert.Single(recommendations);
+            recommendations
+                .Any(r => r.Recipe.Id == Constants.CONSOLE_APP_FARGATE_SERVICE_RECIPE_ID)
+                .ShouldBeTrue("Failed to receive Recommendation: " + Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+        }
+
 
         [Fact]
         public async Task ValueMappingWithDefaultValue()

--- a/testapps/WorkerServiceExample/Program.cs
+++ b/testapps/WorkerServiceExample/Program.cs
@@ -1,0 +1,10 @@
+using WorkerServiceExample;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/testapps/WorkerServiceExample/Worker.cs
+++ b/testapps/WorkerServiceExample/Worker.cs
@@ -1,0 +1,21 @@
+namespace WorkerServiceExample
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+
+        public Worker(ILogger<Worker> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                await Task.Delay(1000, stoppingToken);
+            }
+        }
+    }
+}

--- a/testapps/WorkerServiceExample/WorkerServiceExample.csproj
+++ b/testapps/WorkerServiceExample/WorkerServiceExample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-WorkerServiceExample-D6E7C6FE-A250-4405-9027-C7CB7BC4D11B</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+  </ItemGroup>
+</Project>

--- a/testapps/WorkerServiceExample/WorkerServiceExample.sln
+++ b/testapps/WorkerServiceExample/WorkerServiceExample.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkerServiceExample", "WorkerServiceExample.csproj", "{FE09FB9D-E411-470C-9AD7-65E2ED12B151}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7668EAFA-DFA2-47D0-A1A4-998CAD29BCDB}
+	EndGlobalSection
+EndGlobal

--- a/testapps/WorkerServiceExample/appsettings.Development.json
+++ b/testapps/WorkerServiceExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/testapps/WorkerServiceExample/appsettings.json
+++ b/testapps/WorkerServiceExample/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/testapps/docker/WorkerServiceExample/Program.cs
+++ b/testapps/docker/WorkerServiceExample/Program.cs
@@ -1,0 +1,10 @@
+using WorkerServiceExample;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/testapps/docker/WorkerServiceExample/ReferenceDockerfile
+++ b/testapps/docker/WorkerServiceExample/ReferenceDockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["WorkerServiceExample.csproj", ""]
+RUN dotnet restore "WorkerServiceExample.csproj"
+COPY . .
+WORKDIR "/src/"
+RUN dotnet build "WorkerServiceExample.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WorkerServiceExample.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WorkerServiceExample.dll"]

--- a/testapps/docker/WorkerServiceExample/Worker.cs
+++ b/testapps/docker/WorkerServiceExample/Worker.cs
@@ -1,0 +1,21 @@
+namespace WorkerServiceExample
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+
+        public Worker(ILogger<Worker> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                await Task.Delay(1000, stoppingToken);
+            }
+        }
+    }
+}

--- a/testapps/docker/WorkerServiceExample/WorkerServiceExample.csproj
+++ b/testapps/docker/WorkerServiceExample/WorkerServiceExample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-WorkerServiceExample-D6E7C6FE-A250-4405-9027-C7CB7BC4D11B</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+  </ItemGroup>
+</Project>

--- a/testapps/docker/WorkerServiceExample/WorkerServiceExample.sln
+++ b/testapps/docker/WorkerServiceExample/WorkerServiceExample.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkerServiceExample", "WorkerServiceExample.csproj", "{FE09FB9D-E411-470C-9AD7-65E2ED12B151}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE09FB9D-E411-470C-9AD7-65E2ED12B151}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7668EAFA-DFA2-47D0-A1A4-998CAD29BCDB}
+	EndGlobalSection
+EndGlobal

--- a/testapps/docker/WorkerServiceExample/appsettings.Development.json
+++ b/testapps/docker/WorkerServiceExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/testapps/docker/WorkerServiceExample/appsettings.json
+++ b/testapps/docker/WorkerServiceExample/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*
Add support for Worker project types being deploy as a ECS Fargate service. To distinguish a worker project type the csproj `Sdk` attribute is set to `Microsoft.NET.Sdk.Worker`. 

The new sdk typed caused a challenge with our existing rules for the recipe because we look for `Microsoft.NET.Sdk` and if the `OutputType` property is set to `Exe`. With `Microsoft.NET.Sdk.Worker` there is no `OutputType` property because it is inherited from the SDK. The rules got rewritten to have the initial priority be negative meaning exclude and then only include the recipe if either the rule for `Microsoft.NET.Sdk` and `Exe` was true or if `Microsoft.NET.Sdk.Worker` was true by setting the priority to a positive number.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
