### PR TITLE
feat: Add List type and VPC Connector setting to App Runner

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.DockerEngine;
@@ -430,6 +431,9 @@ namespace AWS.Deploy.CLI.Commands
                                 existingValue[optionSettingKey] = optionSettingValue;
                                 settingValue = existingValue;
                                 break;
+                            case OptionSettingValueType.List:
+                                settingValue = JsonConvert.DeserializeObject<SortedSet<string>>(optionSettingValue) ?? new SortedSet<string>();
+                                break;
                             default:
                                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, $"Invalid value {optionSettingValue} for option setting item {optionSettingJsonPath}");
                         }
@@ -842,6 +846,12 @@ namespace AWS.Deploy.CLI.Commands
                         case OptionSettingValueType.KeyValue:
                             settingValue = _consoleUtilities.AskUserForKeyValue(!string.IsNullOrEmpty(currentValue.ToString()) ? (Dictionary<string, string>) currentValue : new Dictionary<string, string>());
                             break;
+                        case OptionSettingValueType.List:
+                            var valueList = new SortedSet<string>();
+                            if (!string.IsNullOrEmpty(currentValue.ToString()))
+                                valueList = ((SortedSet<string>) currentValue).DeepCopy();
+                            settingValue = _consoleUtilities.AskUserForList(valueList);
+                            break;
                         case OptionSettingValueType.Object:
                             foreach (var childSetting in setting.ChildOptionSettings)
                             {
@@ -863,8 +873,7 @@ namespace AWS.Deploy.CLI.Commands
                 }
                 catch (ValidationFailedException ex)
                 {
-                    _toolInteractiveService.WriteErrorLine(
-                        $"Value [{settingValue}] is not valid: {ex.Message}");
+                    _toolInteractiveService.WriteErrorLine(ex.Message);
 
                     await ConfigureDeploymentFromCli(recommendation, setting);
                 }
@@ -881,6 +890,7 @@ namespace AWS.Deploy.CLI.Commands
             object? displayValue = null;
             Dictionary<string, string>? keyValuePair = null;
             Dictionary<string, object>? objectValues = null;
+            SortedSet<string>? listValues = null;
             if (typeHintResponseType != null)
             {
                 var methodInfo = typeof(Recommendation)
@@ -895,7 +905,8 @@ namespace AWS.Deploy.CLI.Commands
                 var value = recommendation.GetOptionSettingValue(optionSetting);
                 objectValues = value as Dictionary<string, object>;
                 keyValuePair = value as Dictionary<string, string>;
-                displayValue = objectValues == null && keyValuePair == null ? value : string.Empty;
+                listValues = value as SortedSet<string>;
+                displayValue = objectValues == null && keyValuePair == null && listValues == null ? value : string.Empty;
             }
 
             if (mode == DisplayOptionSettingsMode.Editable)
@@ -912,6 +923,14 @@ namespace AWS.Deploy.CLI.Commands
                 foreach (var (key, value) in keyValuePair)
                 {
                     _toolInteractiveService.WriteLine($"\t{key}: {value}");
+                }
+            }
+
+            if (listValues != null)
+            {
+                foreach (var value in listValues)
+                {
+                    _toolInteractiveService.WriteLine($"\t{value}");
                 }
             }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcConnectorCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcConnectorCommand.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.AppRunner.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class ExistingVpcConnectorCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public ExistingVpcConnectorCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        private async Task<List<VpcConnector>> GetData()
+        {
+            return await _awsResourceQueryer.DescribeAppRunnerVpcConnectors();
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var vpcConnectors = await GetData();
+            return vpcConnectors.Select(vpcConnector => new TypeHintResource(vpcConnector.VpcConnectorArn, vpcConnector.VpcConnectorName)).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var vpcConnectors = await GetData();
+            var currentVpcConnector = recommendation.GetOptionSettingValue<string>(optionSetting);
+
+            var userInputConfiguration = new UserInputConfiguration<VpcConnector>(
+                vpcConnector => vpcConnector.VpcConnectorName,
+                vpcConnector => vpcConnector.VpcConnectorArn.Equals(currentVpcConnector),
+                currentVpcConnector)
+            {
+                CanBeEmpty = true,
+                CreateNew = false
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(vpcConnectors, "Select VPC Connector:", userInputConfiguration);
+
+            return userResponse.SelectedOption?.VpcConnectorArn ?? string.Empty;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -59,7 +59,8 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.SNSTopicArn, new SNSTopicArnsCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.S3BucketName, new S3BucketNameCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.InstanceType, new InstanceTypeCommand(awsResourceQueryer, consoleUtilities) },
-                { OptionSettingTypeHint.ECRRepository,  new ECRRepositoryCommand(awsResourceQueryer, consoleUtilities, toolInteractiveService) }
+                { OptionSettingTypeHint.ECRRepository,  new ECRRepositoryCommand(awsResourceQueryer, consoleUtilities, toolInteractiveService) },
+                { OptionSettingTypeHint.ExistingVpcConnector,  new ExistingVpcConnectorCommand(awsResourceQueryer, consoleUtilities) }
             };
         }
 

--- a/src/AWS.Deploy.Common/Extensions/GenericExtensions.cs
+++ b/src/AWS.Deploy.Common/Extensions/GenericExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using Newtonsoft.Json;
 
 namespace AWS.Deploy.Common.Extensions
@@ -11,6 +12,24 @@ namespace AWS.Deploy.Common.Extensions
         {
             var serializedObject = JsonConvert.SerializeObject(obj);
             return JsonConvert.DeserializeObject<T>(serializedObject);
+        }
+
+        public static bool TryDeserialize<T>(this object obj, out T? inputList)
+        {
+            try
+            {
+                inputList = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(obj));
+
+                if (inputList == null)
+                    return false;
+
+                return true;
+            }
+            catch (Exception)
+            {
+                inputList = default(T);
+                return false;
+            }
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -114,13 +114,18 @@ namespace AWS.Deploy.Common.Recipes
                 !AllowedValues.Contains(valueOverride.ToString() ?? ""))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, $"Invalid value for option setting item '{Name}'");
 
-            if (valueOverride is bool || valueOverride is int || valueOverride is long || valueOverride is double || valueOverride is Dictionary<string, string>)
+            if (valueOverride is bool || valueOverride is int || valueOverride is long || valueOverride is double || valueOverride is Dictionary<string, string> || valueOverride is SortedSet<string>)
             {
                 _valueOverride = valueOverride;
             }
             else if (Type.Equals(OptionSettingValueType.KeyValue))
             {
                 var deserialized = JsonConvert.DeserializeObject<Dictionary<string, string>>(valueOverride?.ToString() ?? "");
+                _valueOverride = deserialized;
+            }
+            else if (Type.Equals(OptionSettingValueType.List))
+            {
+                var deserialized = JsonConvert.DeserializeObject<SortedSet<string>>(valueOverride?.ToString() ?? "");
                 _valueOverride = deserialized;
             }
             else if (valueOverride is string valueOverrideString)

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -31,6 +31,7 @@ namespace AWS.Deploy.Common.Recipes
         ExistingECSCluster,
         ExistingVpc,
         ExistingBeanstalkApplication,
-        ECRRepository
+        ECRRepository,
+        ExistingVpcConnector
     };
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingValueType.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingValueType.cs
@@ -10,6 +10,7 @@ namespace AWS.Deploy.Common.Recipes
         Double,
         Bool,
         KeyValue,
-        Object
+        Object,
+        List
     };
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using AWS.Deploy.Common.Extensions;
 
 namespace AWS.Deploy.Common.Recipes.Validation
 {
@@ -24,6 +26,26 @@ namespace AWS.Deploy.Common.Recipes.Validation
             var regex = new Regex(Regex);
 
             var message = ValidationFailedMessage.Replace("{{Regex}}", Regex);
+
+
+            if (input?.TryDeserialize<SortedSet<string>>(out var inputList) ?? false)
+            {
+                foreach (var item in inputList!)
+                {
+                    var valid = regex.IsMatch(item) || (AllowEmptyString && string.IsNullOrEmpty(item));
+                    if (!valid)
+                        return new ValidationResult
+                        {
+                            IsValid = false,
+                            ValidationFailedMessage = message
+                        };
+                }
+                return new ValidationResult
+                {
+                    IsValid = true,
+                    ValidationFailedMessage = message
+                };
+            }
 
             return new ValidationResult
             {

--- a/src/AWS.Deploy.Common/UserDeploymentSettings.cs
+++ b/src/AWS.Deploy.Common/UserDeploymentSettings.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -53,6 +54,13 @@ namespace AWS.Deploy.Common
         /// <param name="node">The current node that is being processed.</param>
         private void TraverseRootToLeaf(JToken node)
         {
+            if (!string.IsNullOrEmpty(node.Path) && node.Type.ToString().Equals("Array"))
+            {
+                var list = node.Values<string>().Select(x => x.ToString()).ToList();
+                LeafOptionSettingItems.Add(node.Path, JsonConvert.SerializeObject(list));
+                return;
+            }
+
             if (!node.HasValues)
             {
                 // The only way to reach a leaf node of type object is if the object is empty.

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.7.14" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.1.17" />
-    <PackageReference Include="AWSSDK.AppRunner" Version="3.7.0.24" />
+    <PackageReference Include="AWSSDK.AppRunner" Version="3.7.3.11" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="5.0.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="5.0.1" />

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon;
+using Amazon.AppRunner.Model;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using Amazon.CloudFront;
@@ -73,6 +74,7 @@ namespace AWS.Deploy.Orchestration.Data
         Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets();
         Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentName);
         Task<Repository> DescribeECRRepository(string respositoryName);
+        Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors();
     }
 
     public class AWSResourceQueryer : IAWSResourceQueryer
@@ -112,6 +114,13 @@ namespace AWS.Deploy.Orchestration.Data
             }
 
             return instanceTypes;
+        }
+
+        public async Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors()
+        {
+            var appRunnerClient = _awsClientFactory.GetAWSClient<Amazon.AppRunner.IAmazonAppRunner>();
+            var connections = await appRunnerClient.ListVpcConnectorsAsync(new Amazon.AppRunner.Model.ListVpcConnectorsRequest());
+            return connections.VpcConnectors;
         }
 
         public async Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn)

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/Configuration.cs
@@ -17,6 +17,11 @@ namespace AspNetAppAppRunner.Configurations
         public IAMRoleConfiguration ApplicationIAMRole { get; set; }
 
         /// <summary>
+        /// App Runner requires this resource when you want to associate your App Runner service to a custom Amazon Virtual Private Cloud (Amazon VPC).
+        /// </summary>
+        public VPCConnectorConfiguration VPCConnector { get; set; }
+
+        /// <summary>
         /// The Identity and Access Management (IAM) role that provides the AWS App Runner service access to pull the container image from ECR.
         /// </summary>
         public IAMRoleConfiguration ServiceAccessIAMRole { get; set; }
@@ -93,6 +98,7 @@ namespace AspNetAppAppRunner.Configurations
 
         public Configuration(
             IAMRoleConfiguration applicationIAMRole,
+            VPCConnectorConfiguration vpcConnector,
             IAMRoleConfiguration serviceAccessIAMRole,
             string serviceName,
             int? port,
@@ -101,6 +107,7 @@ namespace AspNetAppAppRunner.Configurations
             string memory)
         {
             ApplicationIAMRole = applicationIAMRole;
+            VPCConnector = vpcConnector;
             ServiceAccessIAMRole = serviceAccessIAMRole;
             ServiceName = serviceName;
             Port = port ?? 80;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a generated file from the original deployment recipe. It contains properties for
+// all of the settings defined in the recipe file. It is recommended to not modify this file in order
+// to allow easy updates to the file when the original recipe that this project was created from has updates.
+// This class is marked as a partial class. If you add new settings to the recipe file, those settings should be
+// added to partial versions of this class outside of the Generated folder for example in the Configuration folder.
+
+using System.Collections.Generic;
+
+namespace AspNetAppAppRunner.Configurations
+{
+    public partial class VPCConnectorConfiguration
+    {
+        /// <summary>
+        /// If set, creates a new VPC Connector to connect to the AppRunner service.
+        /// </summary>
+        public bool CreateNew { get; set; }
+
+        /// <summary>
+        /// The VPC Connector to use for the App Runner service.
+        /// </summary>
+        public string? VpcConnectorId { get; set; }
+
+        /// <summary>
+        /// A list of IDs of subnets that App Runner should use when it associates your service with a custom Amazon VPC.
+        /// Specify IDs of subnets of a single Amazon VPC. App Runner determines the Amazon VPC from the subnets you specify.
+        /// </summary>
+        public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();
+
+        /// <summary>
+        /// A list of IDs of security groups that App Runner should use for access to AWS resources under the specified subnets.
+        /// If not specified, App Runner uses the default security group of the Amazon VPC.
+        /// The default security group allows all outbound traffic.
+        /// </summary>
+        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
+    }
+}

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -363,6 +363,89 @@
                     }
                 }
             ]
+        },
+        {
+            "Id": "VPCConnector",
+            "Name": "VPC Connector",
+            "Description": "App Runner requires this resource when you want to associate your App Runner service to a custom Amazon Virtual Private Cloud (Amazon VPC).",
+            "Type": "Object",
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New VPC Connector",
+                    "Description": "Do you want to create a new VPC Connector?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": false,
+                    "Updatable": true
+                },
+                {
+                    "Id": "VpcConnectorId",
+                    "Name": "Existing VPC Connector ID",
+                    "Description": "The ID of the existing VPC Connector to use.",
+                    "Type": "String",
+                    "TypeHint": "ExistingVpcConnector",
+                    "DefaultValue": null,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "VPCConnector.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                },
+                {
+                    "Id": "Subnets",
+                    "Name": "Subnets",
+                    "Description": "A list of IDs of subnets that App Runner should use when it associates your service with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC. App Runner determines the Amazon VPC from the subnets you specify.",
+                    "Type": "List",
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^subnet-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid Subnet ID. The Subnet ID must start with the \"subnet-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example subnet-abc88de9 is a valid Subnet ID."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPCConnector.CreateNew",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
+                    "Id": "SecurityGroups",
+                    "Name": "SecurityGroups",
+                    "Description": "A list of IDs of security groups that App Runner should use for access to AWS resources under the specified subnets. If not specified, App Runner uses the default security group of the Amazon VPC. The default security group allows all outbound traffic.",
+                    "Type": "List",
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^sg-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPCConnector.CreateNew",
+                            "Value": true
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -436,7 +436,7 @@
                     "title": "Type",
                     "description": "The data type of the setting.",
                     "minLength": 1,
-                    "enum": [ "String", "Int", "Bool", "Object" ]
+                    "enum": [ "String", "Int", "Bool", "Object", "KeyValue", "List" ]
                 },
                 "TypeHint": {
                     "type": "string",

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/AppRunnerDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/AppRunnerDeploymentTest.cs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using AWS.Deploy.Common;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
+{
+    public class AppRunnerDeploymentTest
+    {
+        private readonly UserDeploymentSettings _userDeploymentSettings;
+        public AppRunnerDeploymentTest()
+        {
+            var filePath = Path.Combine("ConfigFileDeployment", "TestFiles", "UnitTestFiles", "AppRunnerConfigFile.json");
+            var userDeploymentSettings = UserDeploymentSettings.ReadSettings(filePath);
+            _userDeploymentSettings = userDeploymentSettings;
+        }
+
+        [Fact]
+        public void VerifyJsonParsing()
+        {
+            Assert.Equal("default", _userDeploymentSettings.AWSProfile);
+            Assert.Equal("us-west-2", _userDeploymentSettings.AWSRegion);
+            Assert.Equal("MyAppStack", _userDeploymentSettings.ApplicationName);
+            Assert.Equal("AspNetAppAppRunner", _userDeploymentSettings.RecipeId);
+
+            var optionSettingDictionary = _userDeploymentSettings.LeafOptionSettingItems;
+            Assert.Equal("True", optionSettingDictionary["VPCConnector.CreateNew"]);
+
+            var subnetsString = optionSettingDictionary["VPCConnector.Subnets"];
+            var subnets = JsonConvert.DeserializeObject<SortedSet<string>>(subnetsString);
+            Assert.Single(subnets);
+            Assert.Contains("subnet-1234abcd", subnets);
+
+            var securityGroupsString = optionSettingDictionary["VPCConnector.SecurityGroups"];
+            var securityGroups = JsonConvert.DeserializeObject<SortedSet<string>>(securityGroupsString);
+            Assert.Single(securityGroups);
+            Assert.Contains("sg-1234abcd", securityGroups);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/AppRunnerConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/UnitTestFiles/AppRunnerConfigFile.json
@@ -1,0 +1,14 @@
+{
+    "AWSProfile": "default",
+    "AWSRegion": "us-west-2",
+    "ApplicationName": "MyAppStack",
+    "RecipeId": "AspNetAppAppRunner",
+    "OptionSettingsConfig":{
+        "VPCConnector":
+        {
+            "CreateNew": true,
+            "Subnets": [ "subnet-1234abcd" ],
+            "SecurityGroups": [ "sg-1234abcd" ]
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Amazon.AppRunner.Model;
 using Amazon.CloudFormation.Model;
 using Amazon.CloudFront.Model;
 using Amazon.CloudWatchEvents.Model;
@@ -59,5 +60,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();
         public Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion) => throw new NotImplementedException();
         public Task<Repository> DescribeECRRepository(string respositoryName) => throw new NotImplementedException();
+        public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Constants.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Constants.cs
@@ -7,6 +7,7 @@ namespace AWS.Deploy.CLI.UnitTests
     {
         public const string ASPNET_CORE_ASPNET_CORE_FARGATE_RECIPE_ID = "AspNetAppEcsFargate";
         public const string ASPNET_CORE_BEANSTALK_RECIPE_ID = "AspNetAppElasticBeanstalkLinux";
+        public const string ASPNET_CORE_APPRUNNER_ID = "AspNetAppAppRunner";
 
         public const string CONSOLE_APP_FARGATE_SERVICE_RECIPE_ID = "ConsoleAppEcsFargateService";
         public const string CONSOLE_APP_FARGATE_SCHEDULE_TASK_RECIPE_ID = "ConsoleAppEcsFargateScheduleTask";

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Amazon.AppRunner.Model;
 using Amazon.CloudFormation.Model;
 using Amazon.CloudFront.Model;
 using Amazon.CloudWatchEvents.Model;
@@ -84,5 +85,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();
         public Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion) => throw new NotImplementedException();
         public Task<Repository> DescribeECRRepository(string respositoryName) => throw new NotImplementedException();
+        public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5710

*Description of changes:*
* Add a List type as a supported option for Option Setting Items
* Added VPC Configuration Option Setting Item to App runner recipe, which allows you to specify a list of subnets and security groups that will allow App Runner to determine the proper VPC to use.

https://user-images.githubusercontent.com/53088140/158249532-0d9aa166-540b-463b-aad8-7aa39b36a392.mov


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
