### PR TITLE
fix: Remove duplicate URLs from system capability messages.

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -241,7 +241,7 @@ namespace AWS.Deploy.CLI.Commands
             var missingCapabilitiesMessage = "";
             foreach (var capability in systemCapabilities)
             {
-                missingCapabilitiesMessage = $"{missingCapabilitiesMessage}{capability.GetMessage()}{Environment.NewLine}";
+                missingCapabilitiesMessage = $"{missingCapabilitiesMessage}{Environment.NewLine}{capability.GetMessage()}{Environment.NewLine}";
             }
 
             if (systemCapabilities.Any())

--- a/src/AWS.Deploy.Orchestration/SystemCapabilities.cs
+++ b/src/AWS.Deploy.Orchestration/SystemCapabilities.cs
@@ -48,7 +48,12 @@ namespace AWS.Deploy.Orchestration
         public string GetMessage()
         {
             if (!string.IsNullOrEmpty(Message))
-                return Message;
+            {
+                if (!string.IsNullOrEmpty(InstallationUrl))
+                    return $"{Message} {InstallationUrl}";
+                else
+                    return Message;
+            }
 
             var availabilityMessage = Available ? "and available" : "but not available";
             var installationMessage = Installed ? $"installed {availabilityMessage}" : "not installed";

--- a/src/AWS.Deploy.Orchestration/SystemCapabilityEvaluator.cs
+++ b/src/AWS.Deploy.Orchestration/SystemCapabilityEvaluator.cs
@@ -92,14 +92,14 @@ namespace AWS.Deploy.Orchestration
                 {
                     capabilities.Add(new SystemCapability("NodeJS", false, false) {
                         InstallationUrl = "https://nodejs.org/en/download/",
-                        Message = "The selected deployment uses the AWS CDK, which requires Node.js. The latest LTS version of Node.js is recommended and can be installed from https://nodejs.org/en/download/. Specifically, AWS CDK requires 10.13.0+ to work properly."
+                        Message = $"The selected deployment uses the AWS CDK, which requires Node.js. AWS CDK requires {MinimumNodeJSVersion} of Node.js or later, and the latest LTS version is recommended."
                     });
                 }
                 else if (systemCapabilities.NodeJsVersion < MinimumNodeJSVersion)
                 {
                     capabilities.Add(new SystemCapability("NodeJS", false, false) {
                         InstallationUrl = "https://nodejs.org/en/download/",
-                        Message = $"The selected deployment uses the AWS CDK, which requires version of Node.js higher than your current installation ({systemCapabilities.NodeJsVersion}). The latest LTS version of Node.js is recommended and can be installed from https://nodejs.org/en/download/. Specifically, AWS CDK requires 10.3+ to work properly."
+                        Message = $"The selected deployment uses the AWS CDK, which requires a version of Node.js higher than your current installation ({systemCapabilities.NodeJsVersion}). AWS CDK requires {MinimumNodeJSVersion} of Node.js or later, and the latest LTS version is recommended."
                     });
                 }
             }
@@ -111,7 +111,7 @@ namespace AWS.Deploy.Orchestration
                     capabilities.Add(new SystemCapability("Docker", false, false)
                     {
                         InstallationUrl = "https://docs.docker.com/engine/install/",
-                        Message = "The selected deployment option requires Docker, which was not detected. Please install and start the appropriate version of Docker for your OS: https://docs.docker.com/engine/install/"
+                        Message = "The selected deployment option requires Docker, which was not detected. Please install and start the appropriate version of Docker for your OS."
                     });
                 }
                 else if (!systemCapabilities.DockerInfo.DockerContainerType.Equals("linux", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5623

*Description of changes:*
Removes the download URL from system capability messages. The URL is provided separately in the `InstallationUrl` property, which the CLI or Visual Studio can choose how to display separately.

Before, from the CLI when missing both Node.js and Docker:
```
Name the Cloud Application to deploy your project to
--------------------------------------------------------------------------------
Enter the name of the new CloudFormationStack stack (default ASPNetWebApp1):


The selected deployment uses the AWS CDK, which requires Node.js. The latest LTS version of Node.js is recommended and can be installed from https://nodejs.org/en/download/. Specifically, AWS CDK requires 10.13.0+ to work properly.
The selected deployment option requires Docker, which was not detected. Please install and start the appropriate version of Docker for your OS: https://docs.docker.com/engine/install/
```

After, from the CLI when missing both Node.js and Docker:
```
Name the Cloud Application to deploy your project to
--------------------------------------------------------------------------------
Enter the name of the new CloudFormationStack stack (default ASPNetWebApp1):


The selected deployment uses the AWS CDK, which requires Node.js. AWS CDK requires 10.13.0 of Node.js or later, and the latest LTS version is recommended. https://nodejs.org/en/download/

The selected deployment option requires Docker, which was not detected. Please install and start the appropriate version of Docker for your OS. https://docs.docker.com/engine/install/
```

After, from the CLI when missing Docker and have a older version of Node:
```
Name the Cloud Application to deploy your project to
--------------------------------------------------------------------------------
Enter the name of the new CloudFormationStack stack (default ASPNetWebApp1):



The selected deployment uses the AWS CDK, which requires a version of Node.js higher than your current installation (8.12.0). AWS CDK requires 10.13.0 of Node.js or later, and the latest LTS version is recommended. https://nodejs.org/en/download/

The selected deployment option requires Docker, which was not detected. Please install and start the appropriate version of Docker for your OS. https://docs.docker.com/engine/install/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.