### PR TITLE
feat: add typehints to App Runner VPC Connector

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -533,8 +533,9 @@ namespace AWS.Deploy.CLI.Commands
             var title = "Select an existing AWS deployment target to deploy your application to.";
 
             var userInputConfiguration = new UserInputConfiguration<CloudApplication>(
-                app => app.DisplayName,
-                app => app.DisplayName.Equals(deployedApplications.First().DisplayName))
+                idSelector: app => app.DisplayName,
+                displaySelector: app => app.DisplayName,
+                defaultSelector: app => app.DisplayName.Equals(deployedApplications.First().DisplayName))
             {
                 AskNewName = false,
                 CanBeEmpty = false
@@ -811,8 +812,9 @@ namespace AWS.Deploy.CLI.Commands
             if (setting.AllowedValues?.Count > 0)
             {
                 var userInputConfig = new UserInputConfiguration<string>(
-                    x => setting.ValueMapping.ContainsKey(x) ? setting.ValueMapping[x] : x,
-                    x => x.Equals(currentValue))
+                    idSelector: x => x,
+                    displaySelector: x => setting.ValueMapping.ContainsKey(x) ? setting.ValueMapping[x] : x,
+                    defaultSelector: x => x.Equals(currentValue))
                 {
                     CreateNew = false
                 };
@@ -900,7 +902,8 @@ namespace AWS.Deploy.CLI.Commands
 
                 displayValue = ((IDisplayable?)response)?.ToDisplayString();
             }
-            else
+
+            if (displayValue == null)
             {
                 var value = recommendation.GetOptionSettingValue(optionSetting);
                 objectValues = value as Dictionary<string, object>;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
@@ -45,9 +45,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<BeanstalkApplicationTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<ApplicationDescription>(
-                app => app.ApplicationName,
-                app => app.ApplicationName.Equals(currentTypeHintResponse?.ApplicationName),
-                currentTypeHintResponse.ApplicationName)
+                idSelector: app => app.ApplicationName,
+                displaySelector: app => app.ApplicationName,
+                defaultSelector: app => app.ApplicationName.Equals(currentTypeHintResponse?.ApplicationName),
+                defaultNewName: currentTypeHintResponse.ApplicationName)
             {
                 AskNewName = true,
             };

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
@@ -44,9 +44,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<BeanstalkEnvironmentTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<EnvironmentDescription>(
-                env => env.EnvironmentName,
-                app => app.EnvironmentName.Equals(currentTypeHintResponse?.EnvironmentName),
-                currentTypeHintResponse.EnvironmentName)
+                idSelector: env => env.EnvironmentName,
+                displaySelector: env => env.EnvironmentName,
+                defaultSelector: app => app.EnvironmentName.Equals(currentTypeHintResponse?.EnvironmentName),
+                defaultNewName: currentTypeHintResponse.EnvironmentName)
             {
                 AskNewName = true,
             };

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
@@ -42,8 +42,9 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var platformArns = await GetData();
 
             var userInputConfiguration = new UserInputConfiguration<PlatformSummary>(
-                platform => $"{platform.PlatformBranchName} v{platform.PlatformVersion}",
-                platform => platform.PlatformArn.Equals(currentValue))
+                idSelector: platform => platform.PlatformArn,
+                displaySelector: platform => $"{platform.PlatformBranchName} v{platform.PlatformVersion}",
+                defaultSelector: platform => platform.PlatformArn.Equals(currentValue))
             {
                 CreateNew = false
             };

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
@@ -45,8 +45,9 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var keyPairs = await GetData();
 
             var userInputConfiguration = new UserInputConfiguration<KeyPairInfo>(
-                kp => kp.KeyName,
-                kp => kp.KeyName.Equals(currentValue)
+                idSelector: kp => kp.KeyName,
+                displaySelector: kp => kp.KeyName,
+                defaultSelector: kp => kp.KeyName.Equals(currentValue)
                 )
             {
                 AskNewName = true,

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ECRRepositoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ECRRepositoryCommand.cs
@@ -31,9 +31,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentRepositoryName = recommendation.GetOptionSettingValue<string>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<Repository>(
-                rep => rep.RepositoryName,
-                rep => rep.RepositoryName.Equals(currentRepositoryName),
-                currentRepositoryName)
+                idSelector: rep => rep.RepositoryName,
+                displaySelector: rep => rep.RepositoryName,
+                defaultSelector: rep => rep.RepositoryName.Equals(currentRepositoryName),
+                defaultNewName: currentRepositoryName)
             {
                 AskNewName = true,
             };

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ECSClusterCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ECSClusterCommand.cs
@@ -43,9 +43,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<ECSClusterTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<Cluster>(
-                cluster => cluster.ClusterName,
-                cluster => cluster.ClusterArn.Equals(currentTypeHintResponse?.ClusterArn),
-                currentTypeHintResponse.NewClusterName)
+                idSelector: cluster => cluster.ClusterArn,
+                displaySelector: cluster => cluster.ClusterName,
+                defaultSelector: cluster => cluster.ClusterArn.Equals(currentTypeHintResponse?.ClusterArn),
+                defaultNewName: currentTypeHintResponse.NewClusterName)
             {
                 AskNewName = true
             };

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingApplicationLoadBalancerCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingApplicationLoadBalancerCommand.cs
@@ -44,8 +44,9 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentValue = recommendation.GetOptionSettingValue<string>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<LoadBalancer>(
-                loadBalancer => loadBalancer.LoadBalancerName,
-                loadBalancer => loadBalancer.LoadBalancerArn.Equals(currentValue))
+                idSelector: loadBalancer => loadBalancer.LoadBalancerArn,
+                displaySelector: loadBalancer => loadBalancer.LoadBalancerName,
+                defaultSelector: loadBalancer => loadBalancer.LoadBalancerArn.Equals(currentValue))
             {
                 AskNewName = false
             };

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSecurityGroupsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSecurityGroupsCommand.cs
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class ExistingSecurityGroupsCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public ExistingSecurityGroupsCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        private async Task<List<SecurityGroup>> GetData(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            string? vpcId = null;
+            if (!string.IsNullOrEmpty(optionSetting.ParentSettingId))
+            {
+                var vpcIdOptionSetting = recommendation.GetOptionSetting(optionSetting.ParentSettingId);
+                vpcId = recommendation.GetOptionSettingValue<string>(vpcIdOptionSetting);
+            }
+            return await _awsResourceQueryer.DescribeSecurityGroups(vpcId);
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var securityGroups = await GetData(recommendation, optionSetting);
+            return securityGroups.Select(securityGroup => new TypeHintResource(securityGroup.GroupId, securityGroup.GroupId)).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var availableSecurityGroups = (await GetData(recommendation, optionSetting)).OrderBy(x => x.VpcId).ToList();
+            var groupNamePadding = 0;
+            availableSecurityGroups.ForEach(x =>
+            {
+                if (x.GroupName.Length > groupNamePadding)
+                    groupNamePadding = x.GroupName.Length;
+            });
+            var userInputConfigurationSecurityGroups = new UserInputConfiguration<SecurityGroup>(
+                idSelector: securityGroup => securityGroup.GroupId,
+                displaySelector: securityGroup => $"{securityGroup.GroupName.PadRight(groupNamePadding)} | {securityGroup.GroupId.PadRight(20)} | {securityGroup.VpcId}",
+                defaultSelector: securityGroup => false)
+            {
+                CanBeEmpty = true,
+                CreateNew = false
+            };
+            return _consoleUtilities.AskUserForList<SecurityGroup>(userInputConfigurationSecurityGroups, availableSecurityGroups, optionSetting, recommendation);
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSubnetsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSubnetsCommand.cs
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class ExistingSubnetsCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+
+        public ExistingSubnetsCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+        }
+
+        private async Task<List<Subnet>> GetData(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            string? vpcId = null;
+            if (!string.IsNullOrEmpty(optionSetting.ParentSettingId))
+            {
+                var vpcIdOptionSetting = recommendation.GetOptionSetting(optionSetting.ParentSettingId);
+                vpcId = recommendation.GetOptionSettingValue<string>(vpcIdOptionSetting);
+            }
+            return await _awsResourceQueryer.DescribeSubnets(vpcId);
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var subnets = await GetData(recommendation, optionSetting);
+            return subnets.Select(subnet => new TypeHintResource(subnet.SubnetId, subnet.SubnetId)).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var availableSubnets = (await GetData(recommendation, optionSetting)).OrderBy(x => x.VpcId).ToList();
+            var userInputConfigurationSubnets = new UserInputConfiguration<Subnet>(
+                idSelector: subnet => subnet.SubnetId,
+                displaySelector: subnet => $"{subnet.SubnetId.PadRight(24)} | {subnet.VpcId.PadRight(21)} | {subnet.AvailabilityZone}",
+                defaultSelector: subnet => false)
+            {
+                CanBeEmpty = true,
+                CreateNew = false
+            };
+
+            return _consoleUtilities.AskUserForList<Subnet>(userInputConfigurationSubnets, availableSubnets, optionSetting, recommendation);
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcConnectorCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcConnectorCommand.cs
@@ -40,9 +40,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentVpcConnector = recommendation.GetOptionSettingValue<string>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<VpcConnector>(
-                vpcConnector => vpcConnector.VpcConnectorName,
-                vpcConnector => vpcConnector.VpcConnectorArn.Equals(currentVpcConnector),
-                currentVpcConnector)
+                idSelector: vpcConnector => vpcConnector.VpcConnectorArn,
+                displaySelector: vpcConnector => vpcConnector.VpcConnectorName,
+                defaultSelector: vpcConnector => vpcConnector.VpcConnectorArn.Equals(currentVpcConnector),
+                defaultNewName: currentVpcConnector)
             {
                 CanBeEmpty = true,
                 CreateNew = false

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
@@ -45,8 +45,9 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentTypeHintResponse = recommendation.GetOptionSettingValue<IAMRoleTypeHintResponse>(optionSetting);
 
             var userInputConfiguration = new UserInputConfiguration<Role>(
-                role => role.RoleName,
-                role => currentTypeHintResponse.RoleArn?.Equals(role.Arn) ?? false);
+                idSelector: role => role.Arn,
+                displaySelector: role => role.RoleName,
+                defaultSelector: role => currentTypeHintResponse.RoleArn?.Equals(role.Arn) ?? false);
 
             var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(existingRoles ,"Select an IAM role", userInputConfiguration);
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -60,7 +60,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.S3BucketName, new S3BucketNameCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.InstanceType, new InstanceTypeCommand(awsResourceQueryer, consoleUtilities) },
                 { OptionSettingTypeHint.ECRRepository,  new ECRRepositoryCommand(awsResourceQueryer, consoleUtilities, toolInteractiveService) },
-                { OptionSettingTypeHint.ExistingVpcConnector,  new ExistingVpcConnectorCommand(awsResourceQueryer, consoleUtilities) }
+                { OptionSettingTypeHint.ExistingVpcConnector,  new ExistingVpcConnectorCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ExistingSubnets,  new ExistingSubnetsCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.ExistingSecurityGroups,  new ExistingSecurityGroupsCommand(awsResourceQueryer, consoleUtilities) },
+                { OptionSettingTypeHint.VPCConnector,  new VPCConnectorCommand(awsResourceQueryer, consoleUtilities, toolInteractiveService) }
             };
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VPCConnectorCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VPCConnectorCommand.cs
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.AppRunner.Model;
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration.Data;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class VPCConnectorCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IToolInteractiveService _toolInteractiveService;
+
+        public VPCConnectorCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities, IToolInteractiveService toolInteractiveService)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+            _toolInteractiveService = toolInteractiveService;
+        }
+
+        private async Task<List<VpcConnector>> GetData()
+        {
+            return await _awsResourceQueryer.DescribeAppRunnerVpcConnectors();
+        }
+
+        public async Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var vpcConnectors = await GetData();
+            return vpcConnectors.Select(vpcConnector => new TypeHintResource(vpcConnector.VpcConnectorArn, vpcConnector.VpcConnectorName)).ToList();
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            _toolInteractiveService.WriteLine();
+            var createNewOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+            var createNew = recommendation.GetOptionSettingValue<string>(createNewOptionSetting) ?? "false";
+            var createNewVPCConnectorAnswer = _consoleUtilities.AskYesNoQuestion("Do you want to create a new VPC Connector?", createNew);
+            var createNewVPCConnector = createNewVPCConnectorAnswer == YesNo.Yes;
+
+            _toolInteractiveService.WriteLine();
+            if (createNewVPCConnector)
+            {
+                _toolInteractiveService.WriteLine("In order to create a new VPC Connector, you need to select 1 or more Subnets as well as 1 or more Security groups.");
+                _toolInteractiveService.WriteLine();
+
+                var vpcOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("VpcId"));
+                var currentVpcValue = recommendation.GetOptionSettingValue(vpcOptionSetting).ToString();
+                var userInputConfigurationVPCs = new UserInputConfiguration<Vpc>(
+                    idSelector: vpc => vpc.VpcId,
+                    displaySelector: vpc => vpc.VpcId,
+                    defaultSelector: vpc => !string.IsNullOrEmpty(currentVpcValue) ? vpc.VpcId.Equals(currentVpcValue) : vpc.IsDefault)
+                {
+                    CanBeEmpty = false,
+                    CreateNew = false
+                };
+                var availableVpcs = await _awsResourceQueryer.GetListOfVpcs();
+                var vpc = _consoleUtilities.AskUserToChooseOrCreateNew<Vpc>(availableVpcs, "Select a VPC:", userInputConfigurationVPCs);
+
+                if (vpc.SelectedOption == null)
+                    return new VPCConnectorTypeHintResponse()
+                    {
+                        CreateNew = false
+                    };
+
+                var availableSubnets = (await _awsResourceQueryer.DescribeSubnets(vpc.SelectedOption.VpcId)).OrderBy(x => x.SubnetId).ToList();
+                var userInputConfigurationSubnets = new UserInputConfiguration<Subnet>(
+                    idSelector: subnet => subnet.SubnetId,
+                    displaySelector: subnet => $"{subnet.SubnetId.PadRight(24)} | {subnet.VpcId.PadRight(21)} | {subnet.AvailabilityZone}",
+                    defaultSelector: subnet => false)
+                {
+                    CanBeEmpty = true,
+                    CreateNew = false
+                };
+                var subnetsOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("Subnets"));
+                _toolInteractiveService.WriteLine($"{subnetsOptionSetting.Id}:");
+                _toolInteractiveService.WriteLine(subnetsOptionSetting.Description);
+                var subnets = _consoleUtilities.AskUserForList<Subnet>(userInputConfigurationSubnets, availableSubnets, subnetsOptionSetting, recommendation);
+
+                var availableSecurityGroups = (await _awsResourceQueryer.DescribeSecurityGroups(vpc.SelectedOption.VpcId)).OrderBy(x => x.VpcId).ToList();
+                var groupNamePadding = 0;
+                availableSecurityGroups.ForEach(x =>
+                {
+                    if (x.GroupName.Length > groupNamePadding)
+                        groupNamePadding = x.GroupName.Length;
+                });
+                var userInputConfigurationSecurityGroups = new UserInputConfiguration<SecurityGroup>(
+                    idSelector: securityGroup => securityGroup.GroupId,
+                    displaySelector: securityGroup => $"{securityGroup.GroupName.PadRight(groupNamePadding)} | {securityGroup.GroupId.PadRight(20)} | {securityGroup.VpcId}",
+                    defaultSelector: securityGroup => false)
+                {
+                    CanBeEmpty = true,
+                    CreateNew = false
+                };
+                var securityGroupsOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("SecurityGroups"));
+                _toolInteractiveService.WriteLine($"{securityGroupsOptionSetting.Id}:");
+                _toolInteractiveService.WriteLine(securityGroupsOptionSetting.Description);
+                var securityGroups = _consoleUtilities.AskUserForList<SecurityGroup>(userInputConfigurationSecurityGroups, availableSecurityGroups, securityGroupsOptionSetting, recommendation);
+
+                return new VPCConnectorTypeHintResponse()
+                {
+                    CreateNew = true,
+                    VpcId = vpc.SelectedOption.VpcId,
+                    Subnets = subnets,
+                    SecurityGroups = securityGroups
+                };
+            }
+            else
+            {
+                var vpcConnectors = await GetData();
+
+                var userInputConfiguration = new UserInputConfiguration<VpcConnector>(
+                    idSelector: vpcConnector => vpcConnector.VpcConnectorArn,
+                    displaySelector: vpcConnector => vpcConnector.VpcConnectorName,
+                    defaultSelector: vpcConnector => false
+                    )
+                {
+                    CanBeEmpty = true,
+                    CreateNew = false
+                };
+
+                var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(vpcConnectors, "Select VPC Connector:", userInputConfiguration);
+
+                var selectedVpcConnector = userResponse.SelectedOption?.VpcConnectorArn ?? string.Empty;
+
+                return new VPCConnectorTypeHintResponse()
+                {
+                    CreateNew = false,
+                    VpcConnectorId = selectedVpcConnector
+                };
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
@@ -58,7 +58,8 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var vpcs = await GetData();
 
             var userInputConfig = new UserInputConfiguration<Vpc>(
-                vpc =>
+                idSelector: vpc => vpc.VpcId,
+                displaySelector: vpc =>
                 {
                     var name = vpc.Tags?.FirstOrDefault(x => x.Key == "Name")?.Value ?? string.Empty;
                     var namePart =
@@ -73,7 +74,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
                     return $"{vpc.VpcId}{namePart}{isDefaultPart}";
                 },
-                vpc =>
+                defaultSelector: vpc =>
                     !string.IsNullOrEmpty(currentVpcTypeHintResponse?.VpcId)
                         ? vpc.VpcId == currentVpcTypeHintResponse.VpcId
                         : vpc.IsDefault);

--- a/src/AWS.Deploy.CLI/IDisplayable.cs
+++ b/src/AWS.Deploy.CLI/IDisplayable.cs
@@ -11,10 +11,11 @@ namespace AWS.Deploy.CLI
     /// which allows custom CLI display logic.
     /// </summary>
     /// <remarks>
+    /// If the method <see cref="ToDisplayString"/> returns null, the default display method is used.
     /// If a type hint response doesn't implement <see cref="IDisplayable"/>, it is displayed similar to a JSON dictionary indented by level.
     /// </remarks>
     public interface IDisplayable
     {
-        string ToDisplayString();
+        string? ToDisplayString();
     }
 }

--- a/src/AWS.Deploy.CLI/TypeHintResponses/VPCConnectorTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/VPCConnectorTypeHintResponse.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.CLI.TypeHintResponses
+{
+    /// <summary>
+    /// The <see cref="VPCConnectorTypeHintResponse"/> class encapsulates
+    /// <see cref="OptionSettingTypeHint.VPCConnector"/> type hint response
+    /// </summary>
+    public class VPCConnectorTypeHintResponse : IDisplayable
+    {
+        public string? VpcConnectorId { get; set; }
+        public bool CreateNew { get; set; }
+        public string? VpcId { get; set; }
+        public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();
+        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
+
+        /// <summary>
+        /// Returning null will default to the tool's default display.
+        /// </summary>
+        public string? ToDisplayString() => null;
+    }
+}

--- a/src/AWS.Deploy.CLI/UserInputConfiguration.cs
+++ b/src/AWS.Deploy.CLI/UserInputConfiguration.cs
@@ -14,6 +14,12 @@ namespace AWS.Deploy.CLI
     {
         /// <summary>
         /// Func to select string property from the option type
+        /// which is returned as the ID of the selected option.
+        /// </summary>
+        public Func<T, string> IDSelector;
+
+        /// <summary>
+        /// Func to select string property from the option type
         /// which is displayed to the user.
         /// </summary>
         public Func<T, string> DisplaySelector;
@@ -63,10 +69,12 @@ namespace AWS.Deploy.CLI
         public bool EmptyOption { get; set; }
 
         public UserInputConfiguration(
+            Func<T, string> idSelector,
             Func<T, string> displaySelector,
             Func<T, bool> defaultSelector,
             string defaultNewName = "")
         {
+            IDSelector = idSelector;
             DisplaySelector = displaySelector;
             DefaultSelector = defaultSelector;
             DefaultNewName = defaultNewName;

--- a/src/AWS.Deploy.Common/Extensions/GenericExtensions.cs
+++ b/src/AWS.Deploy.Common/Extensions/GenericExtensions.cs
@@ -18,7 +18,16 @@ namespace AWS.Deploy.Common.Extensions
         {
             try
             {
-                inputList = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(obj));
+                string serializedObject = "";
+                if (obj is string)
+                {
+                    serializedObject = obj.ToString() ?? string.Empty;
+                }
+                else
+                {
+                    serializedObject = JsonConvert.SerializeObject(obj);
+                }
+                inputList = JsonConvert.DeserializeObject<T>(serializedObject);
 
                 if (inputList == null)
                     return false;

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -32,6 +32,9 @@ namespace AWS.Deploy.Common.Recipes
         ExistingVpc,
         ExistingBeanstalkApplication,
         ECRRepository,
-        ExistingVpcConnector
+        ExistingVpcConnector,
+        ExistingSubnets,
+        ExistingSecurityGroups,
+        VPCConnector
     };
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
@@ -24,6 +24,11 @@ namespace AspNetAppAppRunner.Configurations
         public string? VpcConnectorId { get; set; }
 
         /// <summary>
+        /// The VPC ID to use for the App Runner service.
+        /// </summary>
+        public string? VpcId { get; set; }
+
+        /// <summary>
         /// A list of IDs of subnets that App Runner should use when it associates your service with a custom Amazon VPC.
         /// Specify IDs of subnets of a single Amazon VPC. App Runner determines the Amazon VPC from the subnets you specify.
         /// </summary>

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -369,6 +369,7 @@
             "Name": "VPC Connector",
             "Description": "App Runner requires this resource when you want to associate your App Runner service to a custom Amazon Virtual Private Cloud (Amazon VPC).",
             "Type": "Object",
+            "TypeHint": "VPCConnector",
             "AdvancedSetting": true,
             "Updatable": true,
             "ChildOptionSettings": [
@@ -398,10 +399,37 @@
                     ]
                 },
                 {
+                    "Id": "VpcId",
+                    "Name": "VPC ID",
+                    "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
+                    "TypeHint": "ExistingVpc",
+                    "DefaultValue": null,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPCConnector.CreateNew",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
                     "Id": "Subnets",
                     "Name": "Subnets",
                     "Description": "A list of IDs of subnets that App Runner should use when it associates your service with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC. App Runner determines the Amazon VPC from the subnets you specify.",
                     "Type": "List",
+                    "TypeHint": "ExistingSubnets",
+                    "ParentSettingId": "VPCConnector.VpcId",
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "Validators": [
@@ -426,6 +454,8 @@
                     "Name": "SecurityGroups",
                     "Description": "A list of IDs of security groups that App Runner should use for access to AWS resources under the specified subnets. If not specified, App Runner uses the default security group of the Amazon VPC. The default security group allows all outbound traffic.",
                     "Type": "List",
+                    "TypeHint": "ExistingSecurityGroups",
+                    "ParentSettingId": "VPCConnector.VpcId",
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "Validators": [

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -1,0 +1,243 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.Runtime;
+using AWS.Deploy.CLI.Commands;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using AWS.Deploy.ServerMode.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
+{
+    public class GetApplyOptionSettings : IDisposable
+    {
+        private bool _isDisposed;
+        private string _stackName;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+
+        private readonly string _awsRegion;
+        private readonly TestAppManager _testAppManager;
+        private readonly InMemoryInteractiveService _interactiveService;
+
+        public GetApplyOptionSettings()
+        {
+            _interactiveService = new InMemoryInteractiveService();
+
+            var cloudFormationClient = new AmazonCloudFormationClient(Amazon.RegionEndpoint.USWest2);
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            _serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _awsRegion = "us-west-2";
+
+            _testAppManager = new TestAppManager();
+        }
+
+        public Task<AWSCredentials> ResolveCredentials()
+        {
+            var testCredentials = FallbackCredentialsFactory.GetCredentials();
+            return Task.FromResult<AWSCredentials>(testCredentials);
+        }
+
+        private async Task<DeploymentStatus> WaitForDeployment(RestAPIClient restApiClient, string sessionId)
+        {
+            // Do an initial delay to avoid a race condition of the status being checked before the deployment has kicked off.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            await WaitUntilHelper.WaitUntil(async () =>
+            {
+                DeploymentStatus status = (await restApiClient.GetDeploymentStatusAsync(sessionId)).Status; ;
+                return status != DeploymentStatus.Executing;
+            }, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(15));
+
+            return (await restApiClient.GetDeploymentStatusAsync(sessionId)).Status;
+        }
+
+        [Fact]
+        public async Task GetAndApplyAppRunnerSettings_VPCConnector()
+        {
+            _stackName = $"ServerModeWebFargate{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
+            var portNumber = 4001;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await WaitTillServerModeReady(restClient);
+
+                var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
+                {
+                    AwsRegion = _awsRegion,
+                    ProjectPath = projectPath
+                });
+
+                var sessionId = startSessionOutput.SessionId;
+                Assert.NotNull(sessionId);
+
+                var signalRClient = new DeploymentCommunicationClient(baseUrl);
+                await signalRClient.JoinSession(sessionId);
+
+                var logOutput = new StringBuilder();
+                signalRClient.ReceiveLogAllLogAction = (line) =>
+                {
+                    logOutput.AppendLine(line);
+                };
+
+                var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
+                Assert.NotEmpty(getRecommendationOutput.Recommendations);
+
+                var appRunnerRecommendation = getRecommendationOutput.Recommendations.FirstOrDefault(x => string.Equals(x.RecipeId, "AspNetAppAppRunner"));
+                Assert.NotNull(appRunnerRecommendation);
+
+                await restClient.SetDeploymentTargetAsync(sessionId, new SetDeploymentTargetInput
+                {
+                    NewDeploymentName = _stackName,
+                    NewDeploymentRecipeId = appRunnerRecommendation.RecipeId
+                });
+
+                var vpcResources = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.VpcId");
+                var subnetsResourcesEmpty = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.Subnets");
+                var securityGroupsResourcesEmpty = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.SecurityGroups");
+                Assert.NotEmpty(vpcResources.Resources);
+                Assert.Empty(subnetsResourcesEmpty.Resources);
+                Assert.Empty(securityGroupsResourcesEmpty.Resources);
+
+                await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"VPCConnector.CreateNew", "true"},
+                        {"VPCConnector.VpcId", vpcResources.Resources.First().SystemName}
+                    }
+                });
+
+                var subnetsResources = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.Subnets");
+                var securityGroupsResources = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.SecurityGroups");
+                Assert.NotEmpty(subnetsResources.Resources);
+                Assert.NotEmpty(securityGroupsResources.Resources);
+
+                var setConfigResult = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"VPCConnector.Subnets", JsonConvert.SerializeObject(new List<string>{subnetsResources.Resources.Last().SystemName})},
+                        {"VPCConnector.SecurityGroups", JsonConvert.SerializeObject(new List<string>{securityGroupsResources.Resources.Last().SystemName})}
+                    }
+                });
+
+                await restClient.StartDeploymentAsync(sessionId);
+
+                await WaitForDeployment(restClient, sessionId);
+
+                var stackStatus = await _cloudFormationHelper.GetStackStatus(_stackName);
+                Assert.Equal(StackStatus.CREATE_COMPLETE, stackStatus);
+
+                Assert.True(logOutput.Length > 0);
+                Assert.Contains("Initiating deployment", logOutput.ToString());
+
+                var redeploymentSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
+                {
+                    AwsRegion = _awsRegion,
+                    ProjectPath = projectPath
+                });
+
+                var redeploymentSessionId = redeploymentSessionOutput.SessionId;
+
+                var existingDeployments = await restClient.GetExistingDeploymentsAsync(redeploymentSessionId);
+                var existingDeployment = existingDeployments.ExistingDeployments.First(x => string.Equals(_stackName, x.Name));
+
+                Assert.Equal(_stackName, existingDeployment.Name);
+                Assert.Equal(appRunnerRecommendation.RecipeId, existingDeployment.RecipeId);
+                Assert.Equal(appRunnerRecommendation.Name, existingDeployment.RecipeName);
+                Assert.Equal(appRunnerRecommendation.ShortDescription, existingDeployment.ShortDescription);
+                Assert.Equal(appRunnerRecommendation.Description, existingDeployment.Description);
+                Assert.Equal(appRunnerRecommendation.TargetService, existingDeployment.TargetService);
+                Assert.Equal(DeploymentTypes.CloudFormationStack, existingDeployment.DeploymentType);
+            }
+            finally
+            {
+                cancelSource.Cancel();
+                await _cloudFormationHelper.DeleteStack(_stackName);
+                _stackName = null;
+            }
+        }
+
+
+        private async Task WaitTillServerModeReady(RestAPIClient restApiClient)
+        {
+            await WaitUntilHelper.WaitUntil(async () =>
+            {
+                SystemStatus status = SystemStatus.Error;
+                try
+                {
+                    status = (await restApiClient.HealthAsync()).Status;
+                }
+                catch (Exception)
+                {
+                }
+
+                return status == SystemStatus.Ready;
+            }, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                if(!string.IsNullOrEmpty(_stackName))
+                {
+                    var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                    if (!isStackDeleted)
+                    {
+                        _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                    }
+
+                    _interactiveService.ReadStdOutStartToEnd();
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~GetApplyOptionSettings()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -61,5 +61,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion) => throw new NotImplementedException();
         public Task<Repository> DescribeECRRepository(string respositoryName) => throw new NotImplementedException();
         public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
+        public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
+        public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration.Data;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
+{
+    public class ExistingSecurityGroubsCommandTest
+    {
+        private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
+        private readonly IDirectoryManager _directoryManager;
+
+        public ExistingSecurityGroubsCommandTest()
+        {
+            _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _directoryManager = new TestDirectoryManager();
+        }
+
+        [Fact]
+        public async Task GetResources()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+                );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var securityGroupsOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector.SecurityGroups");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>());
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new ExistingSecurityGroupsCommand(_mockAWSResourceQueryer.Object, consoleUtilities);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeSecurityGroups(It.IsAny<string>()))
+                .ReturnsAsync(new List<SecurityGroup>()
+                {
+                    new SecurityGroup()
+                    {
+                        GroupId = "group1"
+                    }
+                });
+
+            var resources = await command.GetResources(appRunnerRecommendation, securityGroupsOptionSetting);
+
+            Assert.Single(resources);
+            Assert.Equal("group1", resources[0].DisplayName);
+            Assert.Equal("group1", resources[0].SystemName);
+        }
+
+        [Fact]
+        public async Task Execute()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var securityGroupsOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector.SecurityGroups");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "1",
+                "1",
+                "3"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new ExistingSecurityGroupsCommand(_mockAWSResourceQueryer.Object, consoleUtilities);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeSecurityGroups(It.IsAny<string>()))
+                .ReturnsAsync(new List<SecurityGroup>()
+                {
+                    new SecurityGroup()
+                    {
+                        GroupId = "group1",
+                        GroupName = "groupName1",
+                        VpcId = "vpc1"
+                    }
+                });
+
+            var typeHintResponse = await command.Execute(appRunnerRecommendation, securityGroupsOptionSetting);
+
+            var sortedSetResponse = Assert.IsType<SortedSet<string>>(typeHintResponse);
+            Assert.Single(sortedSetResponse);
+            Assert.Contains("group1", sortedSetResponse);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSubnetsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSubnetsCommandTest.cs
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration.Data;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
+{
+    public class ExistingSubnetsCommandTest
+    {
+        private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
+        private readonly IDirectoryManager _directoryManager;
+
+        public ExistingSubnetsCommandTest()
+        {
+            _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _directoryManager = new TestDirectoryManager();
+        }
+
+        [Fact]
+        public async Task GetResources()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+                );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var subnetsOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector.Subnets");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>());
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new ExistingSubnetsCommand(_mockAWSResourceQueryer.Object, consoleUtilities);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeSubnets(It.IsAny<string>()))
+                .ReturnsAsync(new List<Subnet>()
+                {
+                    new Subnet()
+                    {
+                        SubnetId = "subnet1"
+                    }
+                });
+
+            var resources = await command.GetResources(appRunnerRecommendation, subnetsOptionSetting);
+
+            Assert.Single(resources);
+            Assert.Equal("subnet1", resources[0].DisplayName);
+            Assert.Equal("subnet1", resources[0].SystemName);
+        }
+
+        [Fact]
+        public async Task Execute()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var subnetsOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector.Subnets");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "1",
+                "1",
+                "3"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new ExistingSubnetsCommand(_mockAWSResourceQueryer.Object, consoleUtilities);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeSubnets(It.IsAny<string>()))
+                .ReturnsAsync(new List<Subnet>()
+                {
+                    new Subnet()
+                    {
+                        SubnetId = "subnet1",
+                        VpcId = "vpc1",
+                        AvailabilityZone = "us-west-2"
+                    }
+                });
+
+            var typeHintResponse = await command.Execute(appRunnerRecommendation, subnetsOptionSetting);
+
+            var sortedSetResponse = Assert.IsType<SortedSet<string>>(typeHintResponse);
+            Assert.Single(sortedSetResponse);
+            Assert.Contains("subnet1", sortedSetResponse);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
@@ -1,0 +1,196 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.AppRunner.Model;
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration.Data;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
+{
+    public class VPCConnectorCommandTest
+    {
+        private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IToolInteractiveService _toolInteractiveService;
+
+        public VPCConnectorCommandTest()
+        {
+            _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _directoryManager = new TestDirectoryManager();
+            _toolInteractiveService = new TestToolInteractiveServiceImpl();
+        }
+
+        [Fact]
+        public async Task GetResources()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+                );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var vpcConnectorOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>());
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new VPCConnectorCommand(_mockAWSResourceQueryer.Object, consoleUtilities, _toolInteractiveService);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeAppRunnerVpcConnectors())
+                .ReturnsAsync(new List<VpcConnector>()
+                {
+                    new VpcConnector()
+                    {
+                        VpcConnectorArn = "arn:aws:apprunner:us-west-2:123456789010:vpcconnector/fakeVpcConnector",
+                        VpcConnectorName = "vpcConnectorName"
+                    }
+                });
+
+            var resources = await command.GetResources(appRunnerRecommendation, vpcConnectorOptionSetting);
+
+            Assert.Single(resources);
+            Assert.Equal("vpcConnectorName", resources[0].DisplayName);
+            Assert.Equal("arn:aws:apprunner:us-west-2:123456789010:vpcconnector/fakeVpcConnector", resources[0].SystemName);
+        }
+
+        [Fact]
+        public async Task Execute_ExistingVPCConnector()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var vpcConnectorOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "n",
+                "1"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new VPCConnectorCommand(_mockAWSResourceQueryer.Object, consoleUtilities, _toolInteractiveService);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeAppRunnerVpcConnectors())
+                .ReturnsAsync(new List<VpcConnector>()
+                {
+                    new VpcConnector()
+                    {
+                        VpcConnectorArn = "arn:aws:apprunner:us-west-2:123456789010:vpcconnector/fakeVpcConnector",
+                        VpcConnectorName = "vpcConnectorName"
+                    }
+                });
+
+            var typeHintResponse = await command.Execute(appRunnerRecommendation, vpcConnectorOptionSetting);
+
+            var vpcConnectorTypeHintResponse = Assert.IsType<VPCConnectorTypeHintResponse>(typeHintResponse);
+            Assert.False(vpcConnectorTypeHintResponse.CreateNew);
+            Assert.Equal("arn:aws:apprunner:us-west-2:123456789010:vpcconnector/fakeVpcConnector", vpcConnectorTypeHintResponse.VpcConnectorId);
+            Assert.Empty(vpcConnectorTypeHintResponse.Subnets);
+            Assert.Empty(vpcConnectorTypeHintResponse.SecurityGroups);
+        }
+
+        [Fact]
+        public async Task Execute_NewVPCConnector()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var vpcConnectorOptionSetting = appRunnerRecommendation.GetOptionSetting("VPCConnector");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "y",
+                "1",
+                "1",
+                "1",
+                "3",
+                "1",
+                "1",
+                "3"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var command = new VPCConnectorCommand(_mockAWSResourceQueryer.Object, consoleUtilities, _toolInteractiveService);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.GetListOfVpcs())
+                .ReturnsAsync(new List<Vpc>()
+                {
+                    new Vpc()
+                    {
+                        VpcId = "vpc1"
+                    }
+                });
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeSubnets("vpc1"))
+                .ReturnsAsync(new List<Subnet>()
+                {
+                    new Subnet()
+                    {
+                        SubnetId = "subnet1",
+                        VpcId = "vpc1",
+                        AvailabilityZone = "us-west-2"
+                    }
+                });
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeSecurityGroups("vpc1"))
+                .ReturnsAsync(new List<SecurityGroup>()
+                {
+                    new SecurityGroup()
+                    {
+                        GroupId = "group1",
+                        GroupName = "groupName1",
+                        VpcId = "vpc1"
+                    }
+                });
+
+            var typeHintResponse = await command.Execute(appRunnerRecommendation, vpcConnectorOptionSetting);
+
+            var vpcConnectorTypeHintResponse = Assert.IsType<VPCConnectorTypeHintResponse>(typeHintResponse);
+            Assert.True(vpcConnectorTypeHintResponse.CreateNew);
+            Assert.Null(vpcConnectorTypeHintResponse.VpcConnectorId);
+            Assert.Single(vpcConnectorTypeHintResponse.Subnets);
+            Assert.Contains("subnet1", vpcConnectorTypeHintResponse.Subnets);
+            Assert.Single(vpcConnectorTypeHintResponse.SecurityGroups);
+            Assert.Contains("group1", vpcConnectorTypeHintResponse.SecurityGroups);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.RecommendationEngine;
+using AWS.Deploy.Recipes;
+using Moq;
+
+namespace AWS.Deploy.CLI.UnitTests.Utilities
+{
+    public class HelperFunctions
+    {
+        public static async Task<RecommendationEngine> BuildRecommendationEngine(
+            string testProjectName,
+            IFileManager fileManager,
+            IDirectoryManager directoryManager,
+            string awsRegion,
+            string awsAccountId,
+            string awsProfile)
+        {
+            var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
+
+            var parser = new ProjectDefinitionParser(fileManager, directoryManager);
+            var awsCredentials = new Mock<AWSCredentials>();
+            var session =  new OrchestratorSession(
+                await parser.Parse(fullPath),
+                awsCredentials.Object,
+                awsRegion,
+                awsAccountId)
+            {
+                AWSProfileName = awsProfile
+            };
+
+            return new RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() }, session);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -86,5 +86,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion) => throw new NotImplementedException();
         public Task<Repository> DescribeECRRepository(string respositoryName) => throw new NotImplementedException();
         public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
+        public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
+        public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5764

*Description of changes:*
- Add type hints for App Runner VPC Connector option setting, as well as the Subnets and SecurityGroups child settings.
- The VPC Connector type hint lists the available Subnets and then based on that selection, filters the available Security Groups.

https://user-images.githubusercontent.com/53088140/159821622-739d9e20-3b73-4223-af2e-eb962e28b24d.mov


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
