### PR TITLE
fix: cdk bootstrap using globally installed version of cdk

### DIFF
--- a/src/AWS.Deploy.Constants/CDK.cs
+++ b/src/AWS.Deploy.Constants/CDK.cs
@@ -21,6 +21,6 @@ namespace AWS.Deploy.Constants
         /// <summary>
         /// Default version of CDK CLI
         /// </summary>
-        public static readonly Version DefaultCDKVersion = Version.Parse("1.107.0");
+        public static readonly Version DefaultCDKVersion = Version.Parse("2.13.0");
     }
 }

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -81,6 +81,7 @@ namespace AWS.Deploy.Orchestration
 
             // Ensure region is bootstrapped
             await _commandLineWrapper.Run($"npx cdk bootstrap aws://{session.AWSAccountId}/{session.AWSRegion}",
+                workingDirectory: cdkProjectPath,
                 needAwsCredentials: true);
 
             var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKVersionDetectorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKVersionDetectorTests.cs
@@ -18,9 +18,9 @@ namespace AWS.Deploy.Orchestration.UnitTests.CDK
         }
 
         [Theory]
-        [InlineData("MixedReferences", "1.109.0")]
-        [InlineData("SameReferences", "1.108.0")]
-        [InlineData("NoReferences", "1.107.0")]
+        [InlineData("MixedReferences", "2.15.0")]
+        [InlineData("SameReferences", "2.14.0")]
+        [InlineData("NoReferences", "2.13.0")]
         public void Detect_CSProjPath(string fileName, string expectedVersion)
         {
             var csprojPath = Path.Combine("CDK", "CSProjFiles", fileName);
@@ -38,7 +38,7 @@ namespace AWS.Deploy.Orchestration.UnitTests.CDK
                 "NoReferences"
             }.Select(fileName => Path.Combine("CDK", "CSProjFiles", fileName));
             var version = _cdkVersionDetector.Detect(csprojPaths);
-            Assert.Equal("1.109.0", version.ToString());
+            Assert.Equal("2.15.0", version.ToString());
         }
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/MixedReferences
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/MixedReferences
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="1.109.0" />
-    <PackageReference Include="Amazon.CDK3P" Version="1.110.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="1.108.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.107.0" />
+    <PackageReference Include="Amazon.CDK" Version="2.15.0" />
+    <PackageReference Include="Amazon.CDK3P" Version="2.16.0" />
+    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="2.14.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="2.13.0" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/SameReferences
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/SameReferences
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="1.108.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="1.108.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="1.108.0" />
+    <PackageReference Include="Amazon.CDK" Version="2.14.0" />
+    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="2.14.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="2.14.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
*Description of changes:*
CDK bootstrap is using the globally installed version of CDK. This is problematic when there is a version mismatch between the global one and the minimum version needed for the deploy tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
