### PR TITLE
fix: stack name generator incorrectly increments projects

### DIFF
--- a/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
@@ -67,13 +67,23 @@ namespace AWS.Deploy.Orchestration.Utilities
 
             // make sure the recommendation doesn't exist already in existingApplications
             var recommendation = recommendedPrefix;
-            var suffix = 1;
+            var suffix = 0;
+            var recommendationCharArray = recommendation.ToCharArray();
+            for (var i = recommendationCharArray.Length - 1; i >= 0; i--)
+            {
+                if (char.IsDigit(recommendationCharArray[i]))
+                    suffix = suffix * 10 + (recommendationCharArray[i] - '0');
+                else
+                    break;
+            }
+
+            var prefix = suffix != 0 ? recommendation[..^suffix.ToString().Length] : recommendedPrefix;
             while (suffix < 100)
             {
                 if (existingApplications.All(x => x.Name != recommendation) && IsValidName(recommendation))
                     return recommendation;
 
-                recommendation = $"{recommendedPrefix}{suffix++}";
+                recommendation = $"{prefix}{++suffix}";
             }
 
             throw new ArgumentException("Failed to generate a valid and unique name.");

--- a/test/AWS.Deploy.Orchestration.UnitTests/Utilities/CloudApplicationNameGeneratorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/Utilities/CloudApplicationNameGeneratorTests.cs
@@ -105,5 +105,54 @@ namespace AWS.Deploy.Orchestration.UnitTests.Utilities
             // ASSERT
             recommendation.ShouldEqual(expectedRecommendation);
         }
+
+        [Fact]
+        public async Task SuggestsValidNameAndRespectsExistingApplications_ProjectWithNumber()
+        {
+            // ARRANGE
+            var projectFile = "SuperTest1";
+            var expectedRecommendation = $"SuperTest2";
+
+            var projectPath = _fakeFileManager.AddEmptyProjectFile($"c:\\{projectFile}.csproj");
+
+            var projectDefinition = await _projectDefinitionParser.Parse(projectPath);
+
+            var existingApplication = new List<CloudApplication>
+            {
+                new CloudApplication(projectFile, string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty)
+            };
+
+            // ACT
+            var recommendation = _cloudApplicationNameGenerator.GenerateValidName(projectDefinition, existingApplication);
+
+            // ASSERT
+            recommendation.ShouldEqual(expectedRecommendation);
+        }
+
+        [Fact]
+        public async Task SuggestsValidNameAndRespectsExistingApplications_MultipleProjectWithNumber()
+        {
+            // ARRANGE
+            var projectFile = "SuperTest1";
+            var projectFile2 = "SuperTest2";
+            var expectedRecommendation = $"SuperTest3";
+
+            var projectPath = _fakeFileManager.AddEmptyProjectFile($"c:\\{projectFile}.csproj");
+            var projectPath2 = _fakeFileManager.AddEmptyProjectFile($"c:\\{projectFile2}.csproj");
+
+            var projectDefinition = await _projectDefinitionParser.Parse(projectPath);
+
+            var existingApplication = new List<CloudApplication>
+            {
+                new CloudApplication(projectFile, string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty),
+                new CloudApplication(projectFile2, string.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty)
+            };
+
+            // ACT
+            var recommendation = _cloudApplicationNameGenerator.GenerateValidName(projectDefinition, existingApplication);
+
+            // ASSERT
+            recommendation.ShouldEqual(expectedRecommendation);
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*
Currently, if we have a project "WebApp1" and that project is already deployed, when we try to create a new stack based on that same project, the suggested name will be "WebApp11" instead of "WebApp2". 
This PR fixes this behavior by extracting the number from the end of the project name and increments that instead of just tacking a new number to the end of the project name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
