### PR TITLE
chore: Update third party licenses with current dependencies

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,246 +1,228 @@
-**  Amazon.CDK; version 1.89.0 -- https://www.nuget.org/packages/Amazon.CDK
-** Amazon.CDK.CloudAssembly.Schema; version 1.89.0 --
-https://www.nuget.org/packages/Amazon.CDK.CloudAssembly.Schema/
-** Amazon.CDK.CXAPI; version 1.89.0 --
-https://www.nuget.org/packages/Amazon.CDK.CXAPI
-** Amazon.CDK.RegionInfo; version 1.89.0 --
-https://www.nuget.org/packages/Amazon.CDK.RegionInfo
-** Amazon.JSII.Runtime; version 1.15.0 --
-https://www.nuget.org/packages/Amazon.JSII.Runtime
-** AWSSDK.CloudFormation; version 3.5.2.27 --
-https://www.nuget.org/packages/AWSSDK.CloudFormation
-** AWSSDK.Core; version 3.5.2.9 -- https://www.nuget.org/packages/AWSSDK.Core
-** AWSSDK.EC2; version 3.5.29.4 -- https://www.nuget.org/packages/AWSSDK.EC2
-** AWSSDK.ECR; version 3.5.1.5 -- https://www.nuget.org/packages/AWSSDK.ECR
-** AWSSDK.ECS; version 3.5.2.18 -- https://www.nuget.org/packages/AWSSDK.ECS
-** AWSSDK.ElasticBeanstalk; version 3.5.2.23 --
-https://www.nuget.org/packages/AWSSDK.ElasticBeanstalk
-** AWSSDK.Extensions.NETCore.Setup; version 3.3.101 --
-https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup
-** AWSSDK.IdentityManagement; version 3.5.0.65 --
-https://www.nuget.org/packages/AWSSDK.IdentityManagement
-** AWSSDK.SecurityToken; version 3.5.1.45 --
-https://www.nuget.org/packages/AWSSDK.SecurityToken
-** Constructs; version 3.2.0 -- https://www.nuget.org/packages/Constructs
 
+
+** AWSSDK.AppRunner; version 3.7.3.11 -- https://www.nuget.org/packages/AWSSDK.AppRunner/
+** AWSSDK.CloudFront; version 3.7.3.10 -- https://www.nuget.org/packages/AWSSDK.CloudFront/
+** AWSSDK.CloudWatchEvents; version 3.7.3.14 -- https://www.nuget.org/packages/AWSSDK.CloudWatchEvents/
+** AWSSDK.DynamoDBv2; version 3.7.0.83 -- https://www.nuget.org/packages/AWSSDK.DynamoDBv2/
+** AWSSDK.EC2; version 3.7.19.1 -- https://www.nuget.org/packages/AWSSDK.EC2/
+** AWSSDK.ElasticLoadBalancingV2; version 3.7.0.48 -- https://www.nuget.org/packages/AWSSDK.ElasticLoadBalancingV2/
+** AWSSDK.S3; version 3.7.1.17 -- https://www.nuget.org/packages/AWSSDK.S3/
+** AWSSDK.SimpleNotificationService; version 3.7.2.53 -- https://www.nuget.org/packages/AWSSDK.SimpleNotificationService/
+** AWSSDK.SQS; version 3.7.2.53 -- https://www.nuget.org/packages/AWSSDK.SQS/
+** AWSSDK.CloudFormation; version 3.7.7.14 -- https://www.nuget.org/packages/AWSSDK.CloudFormation
+** AWSSDK.Core; version 3.7.6 -- https://www.nuget.org/packages/AWSSDK.Core
+** AWSSDK.EC2; version 3.7.19.1 -- https://www.nuget.org/packages/AWSSDK.EC2
+** AWSSDK.ECR; version 3.7.0.45 -- https://www.nuget.org/packages/AWSSDK.ECR
+** AWSSDK.ECS; version 3.7.2.20 -- https://www.nuget.org/packages/AWSSDK.ECS
+** AWSSDK.ElasticBeanstalk; version 3.7.0.45 -- https://www.nuget.org/packages/AWSSDK.ElasticBeanstalk
+** AWSSDK.Extensions.NETCore.Setup; version 3.7.1 -- https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup
+** AWSSDK.IdentityManagement; version 3.7.2.25 -- https://www.nuget.org/packages/AWSSDK.IdentityManagement
+** AWSSDK.SecurityToken; version 3.7.1.35 -- https://www.nuget.org/packages/AWSSDK.SecurityToken
+** Constructs; version 10.0.0 -- https://www.nuget.org/packages/Constructs
+** Amazon.CDK.Lib; version 2.13.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
+** Amazon.JSII.Runtime; version 1.54.0 -- https://www.nuget.org/packages/Amazon.JSII.Runtime
+ 
 Apache License
-
 Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND
-DISTRIBUTION
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-   1. Definitions.
+1. Definitions.
 
-      "License" shall mean the terms and conditions for use, reproduction, and
-      distribution as defined by Sections 1 through 9 of this document.
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
 
-      "Licensor" shall mean the copyright owner or entity authorized by the
-      copyright owner that is granting the License.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
 
-      "Legal Entity" shall mean the union of the acting entity and all other
-      entities that control, are controlled by, or are under common control
-      with that entity. For the purposes of this definition, "control" means
-      (i) the power, direct or indirect, to cause the direction or management
-      of such entity, whether by contract or otherwise, or (ii) ownership of
-      fifty percent (50%) or more of the outstanding shares, or (iii)
-      beneficial ownership of such entity.
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-      "You" (or "Your") shall mean an individual or Legal Entity exercising
-      permissions granted by this License.
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation source,
-      and configuration files.
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but not limited
-      to compiled object code, generated documentation, and conversions to
-      other media types.
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
 
-      "Work" shall mean the work of authorship, whether in Source or Object
-      form, made available under the License, as indicated by a copyright
-      notice that is included in or attached to the work (an example is
-      provided in the Appendix below).
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
 
-      "Derivative Works" shall mean any work, whether in Source or Object form,
-      that is based on (or derived from) the Work and for which the editorial
-      revisions, annotations, elaborations, or other modifications represent,
-      as a whole, an original work of authorship. For the purposes of this
-      License, Derivative Works shall not include works that remain separable
-      from, or merely link (or bind by name) to the interfaces of, the Work and
-      Derivative Works thereof.
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
 
-      "Contribution" shall mean any work of authorship, including the original
-      version of the Work and any modifications or additions to that Work or
-      Derivative Works thereof, that is intentionally submitted to Licensor for
-      inclusion in the Work by the copyright owner or by an individual or Legal
-      Entity authorized to submit on behalf of the copyright owner. For the
-      purposes of this definition, "submitted" means any form of electronic,
-      verbal, or written communication sent to the Licensor or its
-      representatives, including but not limited to communication on electronic
-      mailing lists, source code control systems, and issue tracking systems
-      that are managed by, or on behalf of, the Licensor for the purpose of
-      discussing and improving the Work, but excluding communication that is
-      conspicuously marked or otherwise designated in writing by the copyright
-      owner as "Not a Contribution."
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity on
-      behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of this
-   License, each Contributor hereby grants to You a perpetual, worldwide,
-   non-exclusive, no-charge, royalty-free, irrevocable copyright license to
-   reproduce, prepare Derivative Works of, publicly display, publicly perform,
-   sublicense, and distribute the Work and such Derivative Works in Source or
-   Object form.
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide, non-
+exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+prepare Derivative Works of, publicly display, publicly perform, sublicense, and
+distribute the Work and such Derivative Works in Source or Object form.
 
-   3. Grant of Patent License. Subject to the terms and conditions of this
-   License, each Contributor hereby grants to You a perpetual, worldwide,
-   non-exclusive, no-charge, royalty-free, irrevocable (except as stated in
-   this section) patent license to make, have made, use, offer to sell, sell,
-   import, and otherwise transfer the Work, where such license applies only to
-   those patent claims licensable by such Contributor that are necessarily
-   infringed by their Contribution(s) alone or by combination of their
-   Contribution(s) with the Work to which such Contribution(s) was submitted.
-   If You institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work or a
-   Contribution incorporated within the Work constitutes direct or contributory
-   patent infringement, then any patent licenses granted to You under this
-   License for that Work shall terminate as of the date such litigation is
-   filed.
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-
+charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
 
-   4. Redistribution. You may reproduce and distribute copies of the Work or
-   Derivative Works thereof in any medium, with or without modifications, and
-   in Source or Object form, provided that You meet the following conditions:
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
 
-      (a) You must give any other recipients of the Work or Derivative Works a
-      copy of this License; and
+     (a) You must give any other recipients of the Work or Derivative Works a
+copy of this License; and
 
-      (b) You must cause any modified files to carry prominent notices stating
-      that You changed the files; and
+     (b) You must cause any modified files to carry prominent notices stating
+that You changed the files; and
 
-      (c) You must retain, in the Source form of any Derivative Works that You
-      distribute, all copyright, patent, trademark, and attribution notices
-      from the Source form of the Work, excluding those notices that do not
-      pertain to any part of the Derivative Works; and
+     (c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-      distribution, then any Derivative Works that You distribute must include
-      a readable copy of the attribution notices contained within such NOTICE
-      file, excluding those notices that do not pertain to any part of the
-      Derivative Works, in at least one of the following places: within a
-      NOTICE text file distributed as part of the Derivative Works; within the
-      Source form or documentation, if provided along with the Derivative
-      Works; or, within a display generated by the Derivative Works, if and
-      wherever such third-party notices normally appear. The contents of the
-      NOTICE file are for informational purposes only and do not modify the
-      License. You may add Your own attribution notices within Derivative Works
-      that You distribute, alongside or as an addendum to the NOTICE text from
-      the Work, provided that such additional attribution notices cannot be
-      construed as modifying the License.
+     (d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
 
-      You may add Your own copyright statement to Your modifications and may
-      provide additional or different license terms and conditions for use,
-      reproduction, or distribution of Your modifications, or for any such
-      Derivative Works as a whole, provided Your use, reproduction, and
-      distribution of the Work otherwise complies with the conditions stated in
-      this License.
+     You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such Derivative
+Works as a whole, provided Your use, reproduction, and distribution of the Work
+otherwise complies with the conditions stated in this License.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise, any
-   Contribution intentionally submitted for inclusion in the Work by You to the
-   Licensor shall be under the terms and conditions of this License, without
-   any additional terms or conditions. Notwithstanding the above, nothing
-   herein shall supersede or modify the terms of any separate license agreement
-   you may have executed with Licensor regarding such Contributions.
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
 
-   6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor, except
-   as required for reasonable and customary use in describing the origin of the
-   Work and reproducing the content of the NOTICE file.
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
-   writing, Licensor provides the Work (and each Contributor provides its
-   Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied, including, without limitation, any
-   warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
-   FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
-   the appropriateness of using or redistributing the Work and assume any risks
-   associated with Your exercise of permissions under this License.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
 
-   8. Limitation of Liability. In no event and under no legal theory, whether
-   in tort (including negligence), contract, or otherwise, unless required by
-   applicable law (such as deliberate and grossly negligent acts) or agreed to
-   in writing, shall any Contributor be liable to You for damages, including
-   any direct, indirect, special, incidental, or consequential damages of any
-   character arising as a result of this License or out of the use or inability
-   to use the Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all other
-   commercial damages or losses), even if such Contributor has been advised of
-   the possibility of such damages.
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of such
+damages.
 
-   9. Accepting Warranty or Additional Liability. While redistributing the Work
-   or Derivative Works thereof, You may choose to offer, and charge a fee for,
-   acceptance of support, warranty, indemnity, or other liability obligations
-   and/or rights consistent with this License. However, in accepting such
-   obligations, You may act only on Your own behalf and on Your sole
-   responsibility, not on behalf of any other Contributor, and only if You
-   agree to indemnify, defend, and hold each Contributor harmless for any
-   liability incurred by, or claims asserted against, such Contributor by
-   reason of your accepting any such warranty or additional liability. END OF
-   TERMS AND CONDITIONS
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree to
+indemnify, defend, and hold each Contributor harmless for any liability incurred
+by, or claims asserted against, such Contributor by reason of your accepting any
+such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
 
 APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate
 notice, with the fields enclosed by brackets "[]" replaced with your own
-identifying information. (Don't include the brackets!) The text should be
+identifying information. (Don't include the brackets!)  The text should be
 enclosed in the appropriate comment syntax for the file format. We also
 recommend that a file or class name and description of purpose be included on
-the same "printed page" as the copyright notice for easier identification
-within third-party archives.
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
 
 Copyright [yyyy] [name of copyright owner]
 
 Licensed under the Apache License, Version 2.0 (the "License");
-
 you may not use this file except in compliance with the License.
-
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-
 distributed under the License is distributed on an "AS IS" BASIS,
-
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 See the License for the specific language governing permissions and
-
 limitations under the License.
 
-* For  Amazon.CDK see also this required NOTICE:
-    AWS Cloud Development Kit (AWS CDK)
-    Copyright 2018-2018 Amazon.com, Inc. or its affiliates. All Rights
-    Reserved.
-* For Amazon.CDK.CloudAssembly.Schema see also this required NOTICE:
-    AWS Cloud Development Kit (AWS CDK)
-    Copyright 2018-2018 Amazon.com, Inc. or its affiliates. All Rights
-    Reserved.
-* For Amazon.CDK.CXAPI see also this required NOTICE:
-    AWS Cloud Development Kit (AWS CDK)
-    Copyright 2018-2018 Amazon.com, Inc. or its affiliates. All Rights
-    Reserved.
-* For Amazon.CDK.RegionInfo see also this required NOTICE:
-    AWS Cloud Development Kit (AWS CDK)
-    Copyright 2018-2018 Amazon.com, Inc. or its affiliates. All Rights
-    Reserved.
-* For Amazon.JSII.Runtime see also this required NOTICE:
-    AWS Cloud Development Kit (AWS CDK)
-    Copyright 2018-2018 Amazon.com, Inc. or its affiliates. All Rights
-    Reserved.
+* For AWSSDK.AppRunner see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.CloudFront see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.CloudWatchEvents see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.DynamoDBv2 see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.EC2 see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.ElasticLoadBalancingV2 see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.S3 see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.SimpleNotificationService see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.SQS see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * For AWSSDK.CloudFormation see also this required NOTICE:
     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * For AWSSDK.Core see also this required NOTICE:
@@ -261,97 +243,78 @@ limitations under the License.
     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * For Constructs see also this required NOTICE:
     Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For Amazon.CDK.Lib see also this required NOTICE:
+    AWS Cloud Development Kit (AWS CDK)
+    Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For Amazon.JSII.Runtime see also this required NOTICE:
+    AWS Cloud Development Kit (AWS CDK)
+    Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 ------
 
-** Microsoft.Extensions.DependencyInjection.Abstractions; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions
+** Microsoft.Bcl.AsyncInterfaces; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/
 Copyright (c) .NET Foundation and Contributors
-** Microsoft.Bcl.AsyncInterfaces; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Configuration; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Configuration
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Configuration.Abstractions; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Abstractions
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Configuration.Binder; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Binder
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Configuration.FileExtensions; version 3.1.7 --
-https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Configuration.Json; version 3.1.7 --
-https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterhttps://www.nuget.org/packages/Microsoft.Extensions.Configuration.Jsonfaces
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.DependencyInjection; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.FileProviders.Abstractions; version 3.1.7 --
-https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Abstractions
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.FileProviders.Physical; version 3.1.7 --
-https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Physical
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.FileSystemGlobbing; version 3.1.7 --
-https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Logging; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Logging.
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Logging.Abstractions; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Logging.Configuration; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Logging.Configuration
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Logging.Console; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Logging.Console
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Options; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Options
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Options.ConfigurationExtensions; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.Extensions.Primitives; version 5.0.0 --
-https://www.nuget.org/packages/Microsoft.Extensions.Primitives
-Copyright (c) .NET Foundation and Contributors
-** Microsoft.TemplateEngine.Abstractions; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.Abstractions
-Copyright (c) 2016 .NET Foundation
-** Microsoft.TemplateEngine.Core; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.Core
-Copyright (c) 2016 .NET Foundation
-** Microsoft.TemplateEngine.Core.Contracts; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.Core.Contracts
-Copyright (c) 2016 .NET Foundation
-** Microsoft.TemplateEngine.Edge; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.Edge
-Copyright (c) 2016 .NET Foundation
-** Microsoft.TemplateEngine.IDE; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.IDE
-Copyright (c) 2016 .NET Foundation
-** Microsoft.TemplateEngine.Orchestrator.RunnableProjects; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.Orchestrator.RunnableProjects
-Copyright (c) 2016 .NET Foundation
-** Microsoft.TemplateEngine.Utils; version 5.0.1 --
-https://www.nuget.org/packages/Microsoft.TemplateEngine.Utils
-Copyright (c) 2016 .NET Foundation
-** System.CommandLine; version 2.0.0-beta1.20574.7 --
-https://www.nuget.org/packages/System.CommandLine/
+** System.CommandLine; version 2.0.0-beta1.20574.7 -- https://www.nuget.org/packages/System.CommandLine/
 Copyright © .NET Foundation and Contributors
-** System.Diagnostics.DiagnosticSource; version 5.0.0 --
-https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource
+** System.Linq.Async; version 4.0.0 -- https://www.nuget.org/packages/System.Linq.Async
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Configuration.Abstractions; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Abstractions
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Configuration.Binder; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Binder
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Configuration; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Configuration
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Configuration.FileExtensions; version 3.1.7 -- https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.FileProviders.Abstractions; version 3.1.7 -- https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Abstractions
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.FileProviders.Physical; version 3.1.7 -- https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Physical
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.FileSystemGlobbing; version 3.1.7 -- https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Logging.Abstractions; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Logging.Configuration; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Logging.Configuration
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Logging.Console; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Logging.Console
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Logging; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Logging.
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Options.ConfigurationExtensions; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Options; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Options
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.Extensions.Primitives; version 5.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.Primitives
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.TemplateEngine.Abstractions; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.Abstractions
 Copyright (c) 2016 .NET Foundation
-** System.Linq.Async; version 4.0.0 --
-https://www.nuget.org/packages/System.Linq.Async
+** Microsoft.TemplateEngine.Core.Contracts; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.Core.Contracts
+Copyright (c) 2016 .NET Foundation
+** Microsoft.TemplateEngine.Core; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.Core
+Copyright (c) 2016 .NET Foundation
+** Microsoft.TemplateEngine.Edge; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.Edge
+Copyright (c) 2016 .NET Foundation
+** Microsoft.TemplateEngine.IDE; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.IDE
+Copyright (c) 2016 .NET Foundation
+** Microsoft.TemplateEngine.Utils; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.Utils
+Copyright (c) 2016 .NET Foundation
+** System.Diagnostics.DiagnosticSource; version 5.0.0 -- https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource
+Copyright (c) 2016 .NET Foundation
+** Microsoft.TemplateEngine.Orchestrator.RunnableProjects; version 5.0.1 -- https://www.nuget.org/packages/Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+Copyright (c) 2016 .NET Foundation
+** Microsoft.Extensions.Configuration.Json; version 3.1.7 -- https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterhttps://www.nuget.org/packages/Microsoft.Extensions.Configuration.Jsonfaces
 Copyright (c) .NET Foundation and Contributors
-** System.Text.Json; version 4.7.2 --
-https://www.nuget.org/packages/System.Text.Json
+** System.Text.Json; version 5.0.0 -- https://www.nuget.org/packages/System.Text.Json
 Copyright (c) .NET Foundation and Contributors
-
+** Microsoft.Extensions.DependencyInjection; version 6.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection
+Copyright (c) .NET Foundation and Contributors
+**  Microsoft.Extensions.DependencyInjection.Abstractions; version 6.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions
+Copyright (c) .NET Foundation and Contributors
+** System.Runtime.CompilerServices.Unsafe; version 6.0.0 -- https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/
+Copyright (c) .NET Foundation and Contributors
+** Microsoft.OpenApi; version 1.2.3 -- https://www.nuget.org/packages/Microsoft.OpenApi/
+Copyright (c) Microsoft Corporation.
+ 
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -376,13 +339,18 @@ SOFTWARE.
 
 ** libyaml; version 0.1.7 -- https://github.com/yaml/libyaml
 Copyright (c) 2006 Kirill Simonov
-** Newtonsoft.Json; version 12.0.3 --
-https://www.nuget.org/packages/Newtonsoft.Json/
+** Newtonsoft.Json; version 13.0.1 -- https://www.nuget.org/packages/Newtonsoft.Json/
 Copyright (c) 2007 James Newton-King
 ** YamlDotNet; version 9.1.4 -- https://www.nuget.org/packages/YamlDotNet
 Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014 Antoine Aubry and
 contributors
-
+** Swashbuckle.AspNetCore.Annotations; version 6.1.2 -- https://www.nuget.org/packages/Swashbuckle.AspNetCore.Annotations/
+Copyright (c) 2016 Richard Morris
+** Swashbuckle.AspNetCore.Swagger; version 6.1.2 -- https://www.nuget.org/packages/Swashbuckle.AspNetCore.Swagger/
+Copyright (c) 2016 Richard Morris
+** Swashbuckle.AspNetCore.SwaggerGen ; version 6.1.2 -- https://www.nuget.org/packages/Swashbuckle.AspNetCore.SwaggerGen/
+Copyright (c) 2016 Richard Morris
+ 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5765

*Description of changes:*
Updating THIRD_PARTY_LICENSES to match our current dependency graph. This was reviewed internally also.

The rough categories of changes:
1. New AWSSDK dependencies (and upgrading others to 3.7)
2. Swapping out CDK dependencies with V1 to V2 upgrade
3. Adding Swashbuckle and OpenApi for server mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
