### PR TITLE
feat: Add shutdown endpoint to server mode to stop the server

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/ServerController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/ServerController.cs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace AWS.Deploy.CLI.ServerMode.Controllers
+{
+    /// <summary>
+    /// Contains operations to manage the lifecycle of the server
+    /// </summary>
+    [Produces("application/json")]
+    [ApiController]
+    [Route("api/v1/[controller]")]
+    public class ServerController : ControllerBase
+    {
+        private readonly IHostApplicationLifetime _applicationLifetime;
+
+        public ServerController(IHostApplicationLifetime applicationLifetime)
+        {
+            _applicationLifetime = applicationLifetime;
+        }
+
+        /// <summary>
+        /// Requests to stop the deployment tool. Any open sessions are implicitly closed.
+        /// This may return <see cref="OkResult"/> prior to the server being stopped,
+        /// clients may need to wait or check the health after requesting shutdown.
+        /// </summary>
+        [HttpPost("Shutdown")]
+        [SwaggerOperation(OperationId = "Shutdown")]
+        [Authorize]
+        public IActionResult Shutdown()
+        {
+            _applicationLifetime.StopApplication();
+            return Ok();
+        }
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -174,6 +174,21 @@ namespace AWS.Deploy.ServerMode.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<RecipeSummary> GetRecipeAsync(string recipeId, string projectPath, System.Threading.CancellationToken cancellationToken);
     
+        /// <summary>Requests to stop the deployment tool. Any open sessions are implicitly closed.
+        /// This may return Microsoft.AspNetCore.Mvc.OkResult prior to the server being stopped,
+        /// clients may need to wait or check the health after requesting shutdown.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task ShutdownAsync();
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Requests to stop the deployment tool. Any open sessions are implicitly closed.
+        /// This may return Microsoft.AspNetCore.Mvc.OkResult prior to the server being stopped,
+        /// clients may need to wait or check the health after requesting shutdown.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task ShutdownAsync(System.Threading.CancellationToken cancellationToken);
+    
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.10.9.0 (NJsonSchema v10.4.1.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -1317,6 +1332,81 @@ namespace AWS.Deploy.ServerMode.Client
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+    
+        /// <summary>Requests to stop the deployment tool. Any open sessions are implicitly closed.
+        /// This may return Microsoft.AspNetCore.Mvc.OkResult prior to the server being stopped,
+        /// clients may need to wait or check the health after requesting shutdown.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task ShutdownAsync()
+        {
+            return ShutdownAsync(System.Threading.CancellationToken.None);
+        }
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Requests to stop the deployment tool. Any open sessions are implicitly closed.
+        /// This may return Microsoft.AspNetCore.Mvc.OkResult prior to the server being stopped,
+        /// clients may need to wait or check the health after requesting shutdown.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task ShutdownAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/v1/Server/Shutdown");
+    
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+    
+                    PrepareRequest(client_, request_, urlBuilder_);
+    
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+    
+                    PrepareRequest(client_, request_, url_);
+    
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+    
+                        ProcessResponse(client_, response_);
+    
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
                         }
                         else
                         {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5665

*Description of changes:*
Adds an `/api/v1/Health/Shutdown` endpoint to server mode to allow consumers to stop the server. This uses [IHostApplicationLifetime.StopApplication Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostapplicationlifetime.stopapplication).

This can be called from:
1. The `RestAPIClient`'s new `Shutdown`/`ShutdownAsync` methods
2. `ServerModeSession.Shutdown` method

Added integration tests for ~~both~~ routes.
  * _Update: removed the test via `ServerModeSession`, I hadn't realized that this relies on already having the CLI installed locally._

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
