### PR TITLE
Add .NET 6 support for Elastic Beanstalk

### DIFF
--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -68,6 +68,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.ServerMode.Clien
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerServiceExample", "testapps\WorkerServiceExample\WorkerServiceExample.csproj", "{7C330493-9BF7-4DB6-815B-807C08500AC6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiNET6", "testapps\WebApiNET6\WebApiNET6.csproj", "{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{3f7a5ca6-7178-4dbf-8dad-6a63684c7a8e}*SharedItemsImports = 5
@@ -173,6 +175,10 @@ Global
 		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C330493-9BF7-4DB6-815B-807C08500AC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -203,6 +209,7 @@ Global
 		{F2266C44-C8C5-45AD-AA9B-44F8825BDF63} = {11C7056E-93C1-408B-BD87-5270595BBE0E}
 		{74444ED0-9044-4DF7-A111-7D9F81ADF0FD} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 		{7C330493-9BF7-4DB6-815B-807C08500AC6} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
+		{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -79,12 +79,12 @@ namespace AWS.Deploy.Orchestration
 
             _interactiveService.LogMessageLine("Deploying AWS CDK project");
 
+            var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
+
             // Ensure region is bootstrapped
-            await _commandLineWrapper.Run($"npx cdk bootstrap aws://{session.AWSAccountId}/{session.AWSRegion}",
+            await _commandLineWrapper.Run($"npx cdk bootstrap aws://{session.AWSAccountId}/{session.AWSRegion} -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
                 workingDirectory: cdkProjectPath,
                 needAwsCredentials: true);
-
-            var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
 
             var deploymentStartDate = DateTime.Now;
             // Handover to CDK command line tool

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -32,7 +32,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0" ]
+                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -24,7 +24,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0" ]
+                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
                     }
                 }
             ],

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -65,6 +65,26 @@ namespace AWS.Deploy.CLI.UnitTests
         }
 
         [Fact]
+        public async Task WebApiNET6()
+        {
+            var engine = await BuildRecommendationEngine("WebApiNET6");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            recommendations
+                .Any(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID)
+                .ShouldBeTrue("Failed to receive Recommendation: " + Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            recommendations
+                .Any(r => r.Recipe.Id == Constants.ASPNET_CORE_ASPNET_CORE_FARGATE_RECIPE_ID)
+                .ShouldBeTrue("Failed to receive Recommendation: " + Constants.ASPNET_CORE_ASPNET_CORE_FARGATE_RECIPE_ID);
+
+            recommendations
+                .Any(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID)
+                .ShouldBeTrue("Failed to receive Recommendation: " + Constants.ASPNET_CORE_APPRUNNER_ID);
+        }
+
+        [Fact]
         public async Task WebAppWithDockerFileTest()
         {
 

--- a/testapps/WebApiNET6/Program.cs
+++ b/testapps/WebApiNET6/Program.cs
@@ -1,0 +1,12 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+app.MapGet("/", () =>
+{
+    return "Hello";
+});
+
+app.Run();

--- a/testapps/WebApiNET6/WebApiNET6.csproj
+++ b/testapps/WebApiNET6/WebApiNET6.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/testapps/WebApiNET6/appsettings.Development.json
+++ b/testapps/WebApiNET6/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/testapps/WebApiNET6/appsettings.json
+++ b/testapps/WebApiNET6/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
*Description of changes:*
Update Elastic Beanstalk recipe to support deploying .NET 6 applications now that Beanstalk has added support for .NET 6.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
