### PR TITLE
fix: deployment doesn't fail even if cdk bootstrap fails

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -106,7 +106,8 @@ namespace AWS.Deploy.Common
         ECRRepositoryDoesNotExist = 10008400,
         FailedToDeserializeRecipe = 10008500,
         FailedToDeserializeDeploymentBundle = 10008600,
-        FailedToDeserializeDeploymentProjectRecipe = 10008700
+        FailedToDeserializeDeploymentProjectRecipe = 10008700,
+        FailedToRunCDKBootstrap = 10008800
     }
 
     public class ProjectFileNotFoundException : DeployToolException


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5794

*Description of changes:*
This change makes it so that the deploy tool fails if `cdk bootstrap` fails. Currently, even if `cdk bootstrap` fails, the deployment continues and the subsequent stack fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
