### PR TITLE
Add TypeHintData to GetConfigSettings response in API

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -193,6 +193,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 var settingSummary = new OptionSettingItemSummary(setting.Id, setting.Name, setting.Description, setting.Type.ToString())
                 {
                     TypeHint = setting.TypeHint?.ToString(),
+                    TypeHintData = setting.TypeHintData,
                     Value = recommendation.GetOptionSettingValue(setting),
                     Advanced = setting.AdvancedSetting,
                     ReadOnly = recommendation.IsExistingCloudApplication && !setting.Updatable,

--- a/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
@@ -20,6 +20,8 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public string? TypeHint { get; set; }
 
+        public Dictionary<string, object> TypeHintData { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
         public bool Advanced { get; set; }
 
         public bool ReadOnly { get; set; }

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1664,6 +1664,9 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("typeHint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string TypeHint { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("typeHintData", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.IDictionary<string, object> TypeHintData { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("advanced", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool Advanced { get; set; }
     

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -16,6 +16,7 @@ using AWS.Deploy.CLI.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Helpers;
 using AWS.Deploy.CLI.IntegrationTests.Services;
+using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.ServerMode.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -76,7 +77,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
         [Fact]
         public async Task GetAndApplyAppRunnerSettings_VPCConnector()
         {
-            _stackName = $"ServerModeWebFargate{Guid.NewGuid().ToString().Split('-').Last()}";
+            _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
             var portNumber = 4001;
@@ -93,35 +94,12 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
                 await WaitTillServerModeReady(restClient);
 
-                var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
-                {
-                    AwsRegion = _awsRegion,
-                    ProjectPath = projectPath
-                });
-
-                var sessionId = startSessionOutput.SessionId;
-                Assert.NotNull(sessionId);
-
-                var signalRClient = new DeploymentCommunicationClient(baseUrl);
-                await signalRClient.JoinSession(sessionId);
+                var sessionId = await StartDeploymentSession(restClient, projectPath);
 
                 var logOutput = new StringBuilder();
-                signalRClient.ReceiveLogAllLogAction = (line) =>
-                {
-                    logOutput.AppendLine(line);
-                };
+                await SetupSignalRConnection(baseUrl, sessionId, logOutput);
 
-                var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
-                Assert.NotEmpty(getRecommendationOutput.Recommendations);
-
-                var appRunnerRecommendation = getRecommendationOutput.Recommendations.FirstOrDefault(x => string.Equals(x.RecipeId, "AspNetAppAppRunner"));
-                Assert.NotNull(appRunnerRecommendation);
-
-                await restClient.SetDeploymentTargetAsync(sessionId, new SetDeploymentTargetInput
-                {
-                    NewDeploymentName = _stackName,
-                    NewDeploymentRecipeId = appRunnerRecommendation.RecipeId
-                });
+                var appRunnerRecommendation = await GetRecommendationsAndSelectAppRunner(restClient, sessionId);
 
                 var vpcResources = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.VpcId");
                 var subnetsResourcesEmpty = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.Subnets");
@@ -190,6 +168,45 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
             }
         }
 
+        [Fact]
+        public async Task GetAppRunnerConfigSettings_TypeHintData()
+        {
+            _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
+            var portNumber = 4001;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await WaitTillServerModeReady(restClient);
+
+                var sessionId = await StartDeploymentSession(restClient, projectPath);
+
+                var logOutput = new StringBuilder();
+                await SetupSignalRConnection(baseUrl, sessionId, logOutput);
+
+                await GetRecommendationsAndSelectAppRunner(restClient, sessionId);
+
+                var configSettings = restClient.GetConfigSettingsAsync(sessionId);
+                Assert.NotEmpty(configSettings.Result.OptionSettings);
+                var iamRoleSetting = Assert.Single(configSettings.Result.OptionSettings, o => o.Id == "ApplicationIAMRole");
+                Assert.NotEmpty(iamRoleSetting.TypeHintData);
+                Assert.Equal("tasks.apprunner.amazonaws.com", iamRoleSetting.TypeHintData[nameof(IAMRoleTypeHintData.ServicePrincipal)]);
+            }
+            finally
+            {
+                cancelSource.Cancel();
+                _stackName = null;
+            }
+        }
 
         private async Task WaitTillServerModeReady(RestAPIClient restApiClient)
         {
@@ -206,6 +223,45 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
                 return status == SystemStatus.Ready;
             }, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
+        }
+
+        private async Task<string> StartDeploymentSession(RestAPIClient restClient, string projectPath)
+        {
+            var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
+            {
+                AwsRegion = _awsRegion,
+                ProjectPath = projectPath
+            });
+
+            var sessionId = startSessionOutput.SessionId;
+            Assert.NotNull(sessionId);
+            return sessionId;
+        }
+
+        private static async Task SetupSignalRConnection(string baseUrl, string sessionId, StringBuilder logOutput)
+        {
+            var signalRClient = new DeploymentCommunicationClient(baseUrl);
+            await signalRClient.JoinSession(sessionId);
+
+            signalRClient.ReceiveLogAllLogAction = (line) => { logOutput.AppendLine(line); };
+        }
+
+        private async Task<RecommendationSummary> GetRecommendationsAndSelectAppRunner(RestAPIClient restClient, string sessionId)
+        {
+            var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
+            Assert.NotEmpty(getRecommendationOutput.Recommendations);
+
+            var appRunnerRecommendation =
+                getRecommendationOutput.Recommendations.FirstOrDefault(x => string.Equals(x.RecipeId, "AspNetAppAppRunner"));
+            Assert.NotNull(appRunnerRecommendation);
+
+            await restClient.SetDeploymentTargetAsync(sessionId,
+                new SetDeploymentTargetInput
+                {
+                    NewDeploymentName = _stackName,
+                    NewDeploymentRecipeId = appRunnerRecommendation.RecipeId
+                });
+            return appRunnerRecommendation;
         }
 
         public void Dispose()


### PR DESCRIPTION

*Description of changes:*

This change updates the `GetConfigSettingsAsync` response to include `TypeHintData` information. This will allow the Toolkit to show a filtered list of Roles for settings that have a ServicePrincipal associated with them. Users will be less likely to configure deployments involving IAM Roles that do not have appropriate permissions.

I added an integration test to confirm that TypeHintData properties are being returned. I extracted code from an existing test into methods so that I could re-use it. No logic changes were made to the extracted code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
