### PR TITLE
fix: Throw an error when using non-existent profile names with commands

### DIFF
--- a/src/AWS.Deploy.CLI/AWSUtilities.cs
+++ b/src/AWS.Deploy.CLI/AWSUtilities.cs
@@ -7,9 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
-using Amazon.EC2.Model;
-using System.IO;
-using AWS.Deploy.CLI.Commands.CommandHandlerInput;
 using AWS.Deploy.CLI.Utilities;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
@@ -18,7 +15,7 @@ namespace AWS.Deploy.CLI
 {
     public interface IAWSUtilities
     {
-        Task<AWSCredentials> ResolveAWSCredentials(string? profileName, string? lastUsedProfileName = null);
+        Task<AWSCredentials> ResolveAWSCredentials(string? profileName);
         string ResolveAWSRegion(string? region, string? lastRegionUsed = null);
     }
 
@@ -38,26 +35,26 @@ namespace AWS.Deploy.CLI
             _directoryManager = directoryManager;
         }
 
-        public async Task<AWSCredentials> ResolveAWSCredentials(string? profileName, string? lastUsedProfileName = null)
+        public async Task<AWSCredentials> ResolveAWSCredentials(string? profileName)
         {
             async Task<AWSCredentials> Resolve()
             {
                 var chain = new CredentialProfileStoreChain();
 
-                if (!string.IsNullOrEmpty(profileName) && chain.TryGetAWSCredentials(profileName, out var profileCredentials) &&
+                if (!string.IsNullOrEmpty(profileName))
+                {
+                    if (chain.TryGetAWSCredentials(profileName, out var profileCredentials) &&
                     // Skip checking CanLoadCredentials for AssumeRoleAWSCredentials because it might require an MFA token and the callback hasn't been setup yet.
                     (profileCredentials is AssumeRoleAWSCredentials || await CanLoadCredentials(profileCredentials)))
-                {
-                    _toolInteractiveService.WriteLine($"Configuring AWS Credentials from Profile {profileName}.");
-                    return profileCredentials;
-                }
-
-                if (!string.IsNullOrEmpty(lastUsedProfileName) &&
-                    chain.TryGetAWSCredentials(lastUsedProfileName, out var lastUsedCredentials) &&
-                    await CanLoadCredentials(lastUsedCredentials))
-                {
-                    _toolInteractiveService.WriteLine($"Configuring AWS Credentials with previous configured profile value {lastUsedProfileName}.");
-                    return lastUsedCredentials;
+                    {
+                        _toolInteractiveService.WriteLine($"Configuring AWS Credentials from Profile {profileName}.");
+                        return profileCredentials;
+                    }
+                    else
+                    {
+                        var message = $"Failed to get credentials for profile \"{profileName}\". Please provide a valid profile name and try again.";
+                        throw new FailedToGetCredentialsForProfile(DeployToolErrorCode.FailedToGetCredentialsForProfile, message);
+                    }
                 }
 
                 try

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -76,4 +76,12 @@ namespace AWS.Deploy.CLI
     {
         public FailedToFindDeploymentProjectRecipeIdException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if failed to retrieve credentials from the specified profile name.
+    /// </summary>
+    public class FailedToGetCredentialsForProfile : DeployToolException
+    {
+        public FailedToGetCredentialsForProfile(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Reflection;
 using AWS.Deploy.Common.Recipes;
-using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Common
 {
@@ -107,7 +105,8 @@ namespace AWS.Deploy.Common
         FailedToDeserializeRecipe = 10008500,
         FailedToDeserializeDeploymentBundle = 10008600,
         FailedToDeserializeDeploymentProjectRecipe = 10008700,
-        FailedToRunCDKBootstrap = 10008800
+        FailedToRunCDKBootstrap = 10008800,
+        FailedToGetCredentialsForProfile = 10008900
     }
 
     public class ProjectFileNotFoundException : DeployToolException


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5802

*Description of changes:*
Currently, all CLI commands (deploy, list, delete) accept the `--profile` option. However, when a non-existent profile is passed, the tool falls back to using the default credentials for the user. This behavior can introduce unintentional destructive changes in the user's account.

This PR changes this behavior by throwing an error when a non-existent profile is passed. 

**Note - This a breaking change**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
