### PR TITLE
fix: remove --project-path argument from list-deployments command

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -353,7 +353,6 @@ namespace AWS.Deploy.CLI.Commands
             {
                 listCommand.Add(_optionProfile);
                 listCommand.Add(_optionRegion);
-                listCommand.Add(_optionProjectPath);
                 listCommand.Add(_optionDiagnosticLogging);
             }
 

--- a/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/ListCommandHandlerInput.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/ListCommandHandlerInput.cs
@@ -12,7 +12,6 @@ namespace AWS.Deploy.CLI.Commands.CommandHandlerInput
     {
         public string? Profile { get; set; }
         public string? Region { get; set; }
-        public string? ProjectPath { get; set; }
         public bool Diagnostics { get; set; }
     }
 }


### PR DESCRIPTION
*Description of changes:*
This PR removes the redundant `--project-path` CLI option from the `list-deployments` command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
