### PR TITLE
feat: Use CDK Diff to perform server mode integ tests

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Exceptions.cs
@@ -15,6 +15,14 @@ namespace AWS.Deploy.CLI.ServerMode
     }
 
     /// <summary>
+     /// Throw if the selected recommendation is incompatible with the operation performed.
+     /// </summary>
+    public class SelectedRecommendationIsIncompatibleException : Exception
+    {
+        public SelectedRecommendationIsIncompatibleException(string message, Exception? innerException = null) : base(message, innerException) { }
+    }
+
+    /// <summary>
     /// Throw if the tool was not able to retrieve the AWS Credentials.
     /// </summary>
     public class FailedToRetrieveAWSCredentialsException : Exception

--- a/src/AWS.Deploy.CLI/ServerMode/Models/GenerateCloudFormationTemplateOutput.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/GenerateCloudFormationTemplateOutput.cs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.CLI.ServerMode.Controllers;
+
+namespace AWS.Deploy.CLI.ServerMode.Models
+{
+    /// <summary>
+    /// The response that will be returned by the <see cref="DeploymentController.GenerateCloudFormationTemplate(string)"/> operation.
+    /// </summary>
+    public class GenerateCloudFormationTemplateOutput
+    {
+        /// <summary>
+        /// The CloudFormation template of the generated CDK deployment project.
+        /// </summary>
+        public string CloudFormationTemplate { get; set; }
+
+        public GenerateCloudFormationTemplateOutput(string cloudFormationTemplate)
+        {
+            CloudFormationTemplate = cloudFormationTemplate;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
@@ -15,10 +15,12 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
     {
         private readonly CloudApplication _cloudApplication;
         private readonly Orchestrator _orchestrator;
+        private readonly OrchestratorSession _orchestratorSession;
         private readonly Recommendation _selectedRecommendation;
 
-        public DeployRecommendationTask(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation selectedRecommendation)
+        public DeployRecommendationTask(OrchestratorSession orchestratorSession, Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation selectedRecommendation)
         {
+            _orchestratorSession = orchestratorSession;
             _orchestrator = orchestrator;
             _cloudApplication = cloudApplication;
             _selectedRecommendation = selectedRecommendation;
@@ -28,6 +30,28 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
         {
             await CreateDeploymentBundle();
             await _orchestrator.DeployRecommendation(_cloudApplication, _selectedRecommendation);
+        }
+
+        /// <summary>
+        /// Generates the CloudFormation template that will be used by CDK for the deployment.
+        /// This involves creating a deployment bundle, generating the CDK project and running 'cdk diff' to get the CF template.
+        /// This operation returns the CloudFormation template that is created for this deployment.
+        /// </summary>
+        public async Task<string> GenerateCloudFormationTemplate(CdkProjectHandler cdkProjectHandler)
+        {
+            if (cdkProjectHandler == null)
+                throw new FailedToCreateCDKProjectException(DeployToolErrorCode.FailedToCreateCDKProject, $"We could not create a CDK deployment project due to a missing dependency '{nameof(cdkProjectHandler)}'.");
+
+            await CreateDeploymentBundle();
+            var cdkProject = await cdkProjectHandler.ConfigureCdkProject(_orchestratorSession, _cloudApplication, _selectedRecommendation);
+            try
+            {
+                return await cdkProjectHandler.PerformCdkDiff(cdkProject, _cloudApplication);
+            }
+            finally
+            {
+                cdkProjectHandler.DeleteTemporaryCdkProject(cdkProject);
+            }
         }
 
         private async Task CreateDeploymentBundle()

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -106,7 +106,9 @@ namespace AWS.Deploy.Common
         FailedToDeserializeDeploymentBundle = 10008600,
         FailedToDeserializeDeploymentProjectRecipe = 10008700,
         FailedToRunCDKBootstrap = 10008800,
-        FailedToGetCredentialsForProfile = 10008900
+        FailedToGetCredentialsForProfile = 10008900,
+        FailedToRunCDKDiff = 10009000,
+        FailedToCreateCDKProject = 10009100
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -19,7 +19,8 @@ namespace AWS.Deploy.Orchestration
         Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
         string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
         Task DeployCdkProject(OrchestratorSession session, CloudApplication cloudApplication, string cdkProjectPath, Recommendation recommendation);
-        void DeleteTemporaryCdkProject(OrchestratorSession session, string cdkProjectPath);
+        void DeleteTemporaryCdkProject(string cdkProjectPath);
+        Task<string> PerformCdkDiff(string cdkProjectPath, CloudApplication cloudApplication);
     }
 
     public class CdkProjectHandler : ICdkProjectHandler
@@ -29,17 +30,20 @@ namespace AWS.Deploy.Orchestration
         private readonly CdkAppSettingsSerializer _appSettingsBuilder;
         private readonly IDirectoryManager _directoryManager;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IFileManager _fileManager;
 
         public CdkProjectHandler(
             IOrchestratorInteractiveService interactiveService,
             ICommandLineWrapper commandLineWrapper,
-            IAWSResourceQueryer awsResourceQueryer)
+            IAWSResourceQueryer awsResourceQueryer,
+            IFileManager fileManager)
         {
             _interactiveService = interactiveService;
             _commandLineWrapper = commandLineWrapper;
             _awsResourceQueryer = awsResourceQueryer;
             _appSettingsBuilder = new CdkAppSettingsSerializer();
             _directoryManager = new DirectoryManager();
+            _fileManager = fileManager;
         }
 
         public async Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation)
@@ -67,6 +71,25 @@ namespace AWS.Deploy.Orchestration
             await appSettingsFile.WriteAsync(appSettingsBody);
 
             return cdkProjectPath;
+        }
+
+        /// <summary>
+        /// Run 'cdk diff' on the deployment project <param name="cdkProjectPath"/> to get the CF template that will be used by CDK to deploy the application.
+        /// </summary>
+        /// <returns>The CloudFormation template that is created for this deployment.</returns>
+        public async Task<string> PerformCdkDiff(string cdkProjectPath, CloudApplication cloudApplication)
+        {
+            var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
+
+            var cdkDiff = await _commandLineWrapper.TryRunWithResult($"npx cdk diff -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
+                workingDirectory: cdkProjectPath,
+                needAwsCredentials: true);
+
+            if (cdkDiff.ExitCode != 0)
+                throw new FailedToRunCDKDiffException(DeployToolErrorCode.FailedToRunCDKDiff, "The CDK Diff command encountered an error and failed.");
+
+            var templateFilePath = Path.Combine(cdkProjectPath, "cdk.out", $"{cloudApplication.Name}.template.json");
+            return await _fileManager.ReadAllTextAsync(templateFilePath);
         }
 
         public async Task DeployCdkProject(OrchestratorSession session, CloudApplication cloudApplication, string cdkProjectPath, Recommendation recommendation)
@@ -161,7 +184,7 @@ namespace AWS.Deploy.Orchestration
             return saveCdkDirectoryPath;
         }
 
-        public void DeleteTemporaryCdkProject(OrchestratorSession session, string cdkProjectPath)
+        public void DeleteTemporaryCdkProject(string cdkProjectPath)
         {
             var parentPath = Path.GetFullPath(Constants.CDK.ProjectsDirectory);
             cdkProjectPath = Path.GetFullPath(cdkProjectPath);

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
@@ -48,7 +48,7 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
             }
             finally
             {
-                orchestrator._cdkProjectHandler.DeleteTemporaryCdkProject(orchestrator._session, cdkProject);
+                orchestrator._cdkProjectHandler.DeleteTemporaryCdkProject(cdkProject);
             }
 
             await orchestrator._localUserSettingsEngine.UpdateLastDeployedStack(cloudApplication.Name, orchestrator._session.ProjectDefinition.ProjectName, orchestrator._session.AWSAccountId, orchestrator._session.AWSRegion);

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -142,6 +142,14 @@ namespace AWS.Deploy.Orchestration
     }
 
     /// <summary>
+    /// Exception thrown if the 'cdk diff' command failed.
+    /// </summary>
+    public class FailedToRunCDKDiffException : DeployToolException
+    {
+        public FailedToRunCDKDiffException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
     /// Exception thrown if an AWS Resource is not found or does not exist.
     /// </summary>
     public class AWSResourceNotFoundException : DeployToolException
@@ -219,5 +227,13 @@ namespace AWS.Deploy.Orchestration
     public class FailedToFindCloudApplicationResourceType : DeployToolException
     {
         public FailedToFindCloudApplicationResourceType(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Throw if we are unable to generate a CDK Project
+    /// </summary>
+    public class FailedToCreateCDKProjectException : DeployToolException
+    {
+        public FailedToCreateCDKProjectException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 }

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -119,6 +119,19 @@ namespace AWS.Deploy.ServerMode.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<GetCompatibilityOutput> GetCompatibilityAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
+        /// <summary>Creates the CloudFormation template that will be used by CDK for the deployment.
+        /// This operation returns the CloudFormation template that is created for this deployment.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<GenerateCloudFormationTemplateOutput> GenerateCloudFormationTemplateAsync(string sessionId);
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Creates the CloudFormation template that will be used by CDK for the deployment.
+        /// This operation returns the CloudFormation template that is created for this deployment.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<GenerateCloudFormationTemplateOutput> GenerateCloudFormationTemplateAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
+    
         /// <summary>Begin execution of the deployment.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -954,6 +967,89 @@ namespace AWS.Deploy.ServerMode.Client
             }
         }
     
+        /// <summary>Creates the CloudFormation template that will be used by CDK for the deployment.
+        /// This operation returns the CloudFormation template that is created for this deployment.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<GenerateCloudFormationTemplateOutput> GenerateCloudFormationTemplateAsync(string sessionId)
+        {
+            return GenerateCloudFormationTemplateAsync(sessionId, System.Threading.CancellationToken.None);
+        }
+    
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>Creates the CloudFormation template that will be used by CDK for the deployment.
+        /// This operation returns the CloudFormation template that is created for this deployment.</summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<GenerateCloudFormationTemplateOutput> GenerateCloudFormationTemplateAsync(string sessionId, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/v1/Deployment/session/<sessionId>/cftemplate?");
+            if (sessionId != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("sessionId") + "=").Append(System.Uri.EscapeDataString(ConvertToString(sessionId, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+    
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+    
+                    PrepareRequest(client_, request_, urlBuilder_);
+    
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+    
+                    PrepareRequest(client_, request_, url_);
+    
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+    
+                        ProcessResponse(client_, response_);
+    
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<GenerateCloudFormationTemplateOutput>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+    
         /// <summary>Begin execution of the deployment.</summary>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -1647,6 +1743,17 @@ namespace AWS.Deploy.ServerMode.Client
     
         [Newtonsoft.Json.JsonProperty("existingDeploymentId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ExistingDeploymentId { get; set; }
+    
+    
+    }
+    
+    /// <summary>The response that will be returned by the M:AWS.Deploy.CLI.ServerMode.Controllers.DeploymentController.GenerateCloudFormationTemplate(System.String) operation.</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class GenerateCloudFormationTemplateOutput 
+    {
+        /// <summary>The CloudFormation template of the generated CDK deployment project.</summary>
+        [Newtonsoft.Json.JsonProperty("cloudFormationTemplate", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string CloudFormationTemplate { get; set; }
     
     
     }


### PR DESCRIPTION
*Description of changes:*
* Add a StartDryRunDeployment operation in server mode that basically generates the CDK project and runs CDK Diff on that project
* In the integ test, we now check the generated CF template if it contains the correct settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
