### PR TITLE
fix: users can create a new stack with existing stack name

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -603,10 +603,12 @@ namespace AWS.Deploy.CLI.Commands
                         allowEmpty: false,
                         defaultAskValuePrompt: inputPrompt);
 
-                if (!string.IsNullOrEmpty(cloudApplicationName) && _cloudApplicationNameGenerator.IsValidName(cloudApplicationName))
+                if (string.IsNullOrEmpty(cloudApplicationName) || !_cloudApplicationNameGenerator.IsValidName(cloudApplicationName))
+                    PrintInvalidApplicationNameMessage();
+                else if (deployedApplications.Any(x => x.Name.Equals(cloudApplicationName)))
+                    PrintApplicationNameAlreadyExistsMessage();
+                else
                     return cloudApplicationName;
-
-                PrintInvalidApplicationNameMessage();
             }
         }
 
@@ -650,6 +652,14 @@ namespace AWS.Deploy.CLI.Commands
             _toolInteractiveService.WriteErrorLine(
                 "Invalid application name. The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
                 "It must start with an alphabetic character and can't be longer than 128 characters");
+        }
+
+        private void PrintApplicationNameAlreadyExistsMessage()
+        {
+            _toolInteractiveService.WriteLine();
+            _toolInteractiveService.WriteErrorLine(
+                "Invalid application name. There already exists a CloudFormation stack with the name you provided. " +
+                "Please choose another application name.");
         }
 
         private bool ConfirmDeployment(Recommendation recommendation)


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5810

*Description of changes:*
Currently, users can choose to create a new stack but choose an existing stack name for the new deployment. This behavior allows users to overwrite an existing stack with another completely different application. This PR fixes this behavior by not allowing the use of an existing stack name.
This error message is presented:
![image](https://user-images.githubusercontent.com/53088140/163403160-c3228384-4048-4248-9433-2574a7cf4fb1.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
