### PR TITLE
chore: add banner to notify of NuGet package name change

### DIFF
--- a/src/AWS.Deploy.CLI/App.cs
+++ b/src/AWS.Deploy.CLI/App.cs
@@ -31,6 +31,12 @@ namespace AWS.Deploy.CLI
             _toolInteractiveService.WriteLine("AWS .NET deployment tool for deploying .NET Core applications to AWS.");
             _toolInteractiveService.WriteLine("Project Home: https://github.com/aws/aws-dotnet-deploy");
             _toolInteractiveService.WriteLine(string.Empty);
+            _toolInteractiveService.WriteLine("---------------------------------------------------------------------");
+            _toolInteractiveService.WriteLine("Deprecation Notice: The name of the AWS .NET deployment tool NuGet package will change from 'AWS.Deploy.CLI' to 'AWS.Deploy.Tools'. " +
+                "In order to keep receiving updates, make sure to uninstall the current dotnet tool 'AWS.Deploy.CLI' and install 'AWS.Deploy.Tools'. " +
+                "The NuGet package 'AWS.Deploy.CLI' will no longer receive any updates, so please make sure to install the new package 'AWS.Deploy.Tools'.");
+            _toolInteractiveService.WriteLine("---------------------------------------------------------------------");
+            _toolInteractiveService.WriteLine(string.Empty);
 
             // if user didn't specify a command, default to help
             if (args.Length == 0)


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5803

*Description of changes:*
Added a banner that informs users that the NuGet package name will change to 'AWS.Deploy.Tools'.
![image](https://user-images.githubusercontent.com/53088140/163451668-0edc9863-bfde-40da-901a-2fe8c1e8bbd3.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
