### PR TITLE
chore: enable semgrep

### DIFF
--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -1,0 +1,36 @@
+name: Semgrep
+
+on:
+  # Scan changed files in PRs, block on new issues only (existing issues ignored)
+  pull_request:
+
+  push:
+    branches: ["dev", "main"]
+
+  schedule:
+    - cron: '23 20 * * 1'
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    # Skip any PR created by dependabot to avoid permission issues
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      # Fetch project source
+      - uses: actions/checkout@v3
+
+      - run: semgrep scan --sarif --output=semgrep.sarif
+        env:
+          SEMGREP_RULES: >- # more at semgrep.dev/explore
+            p/security-audit
+            p/secrets
+            p/owasp-top-ten
+
+      - name: Upload SARIF file for GitHub Advanced Security Dashboard
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep.sarif
+        if: always()

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,1 @@
+testapps/


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5807

*Description of changes:*
This PR enables code scanning using Semgrep CI
Read more: https://semgrep.dev/docs/semgrep-ci/overview/

While scanning the entire repo with the current rule set, 63 JQuery vulnerabilities were discovered across 12 test web-apps.
Fixing them periodically, will increase toil and therefore `testapps/` have been excluded from code scanning.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
