### PR TITLE
feat: Add support for custom Dockerfile paths

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -210,7 +210,7 @@ namespace AWS.Deploy.CLI.Commands
                         AWSProfileName = input.Profile ?? userDeploymentSettings?.AWSProfile ?? null
                     };
 
-                    var dockerEngine = new DockerEngine.DockerEngine(projectDefinition, _fileManager);
+                    var dockerEngine = new DockerEngine.DockerEngine(projectDefinition, _fileManager, _directoryManager);
 
                     var deploy = new DeployCommand(
                         _serviceProvider,

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: async buildArgs => await ValidateBuildArgs(buildArgs))
+                    validators: async buildArgs => await ValidateBuildArgs(buildArgs, recommendation))
                 .ToString()
                 .Replace("\"", "\"\"");
 
@@ -47,15 +47,15 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         /// <param name="dockerBuildArgs">Arguments to be passed when performing a Docker build</param>
         public async Task OverrideValue(Recommendation recommendation, string dockerBuildArgs)
         {
-            var resultString = await ValidateBuildArgs(dockerBuildArgs);
+            var resultString = await ValidateBuildArgs(dockerBuildArgs, recommendation);
             if (!string.IsNullOrEmpty(resultString))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerBuildArgs, resultString);
             recommendation.DeploymentBundle.DockerBuildArgs = dockerBuildArgs;
         }
 
-        private async Task<string> ValidateBuildArgs(string buildArgs)
+        private async Task<string> ValidateBuildArgs(string buildArgs, Recommendation recommendation)
         {
-            var validationResult = await new DockerBuildArgsValidator().Validate(buildArgs);
+            var validationResult = await new DockerBuildArgsValidator().Validate(buildArgs, recommendation);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: async publishArgs => await ValidateDotnetPublishArgs(publishArgs))
+                    validators: async publishArgs => await ValidateDotnetPublishArgs(publishArgs, recommendation))
                 .ToString()
                 .Replace("\"", "\"\"");
 
@@ -48,15 +48,15 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         /// <param name="publishArgs">The user specified Dotnet build arguments.</param>
         public async Task OverrideValue(Recommendation recommendation, string publishArgs)
         {
-            var resultString = await ValidateDotnetPublishArgs(publishArgs);
+            var resultString = await ValidateDotnetPublishArgs(publishArgs, recommendation);
             if (!string.IsNullOrEmpty(resultString))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDotnetPublishArgs, resultString);
             recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments = publishArgs.Replace("\"", "\"\"");
         }
 
-        private async Task<string> ValidateDotnetPublishArgs(string publishArgs)
+        private async Task<string> ValidateDotnetPublishArgs(string publishArgs, Recommendation recommendation)
         {
-            var validationResult = await new DotnetPublishArgsValidator().Validate(publishArgs);
+            var validationResult = await new DotnetPublishArgsValidator().Validate(publishArgs, recommendation);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/FilePathCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/FilePathCommand.cs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.TypeHintData;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    /// <summary>
+    /// Typehint that lets the user specify a path to a file.
+    /// This can either be an absolute path to the file or relative to the project path.
+    /// </summary>
+    public class FilePathCommand : ITypeHintCommand
+    {
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IFileManager _fileManager;
+
+        public FilePathCommand(IConsoleUtilities consoleUtilities , IOptionSettingHandler optionSettingHandler, IFileManager fileManager)
+        {
+            _consoleUtilities = consoleUtilities;
+            _optionSettingHandler = optionSettingHandler;
+            _fileManager = fileManager;
+        }
+
+        /// <summary>
+        /// Not implemented, specific files are not suggested to the user
+        /// </summary>
+        /// <returns>Empty list</returns>
+        public Task<List<TypeHintResource>?> GetResources(Recommendation recommendation, OptionSettingItem optionSetting) => Task.FromResult<List<TypeHintResource>?>(null);
+
+        /// <summary>
+        /// Prompts the user to enter a path to a file
+        /// </summary>
+        public Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var typeHintData = optionSetting.GetTypeHintData<FilePathTypeHintData>();
+
+            var userFilePath = _consoleUtilities
+               .AskUserForValue(
+                   string.Empty,
+                   _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
+                   allowEmpty: typeHintData?.AllowEmpty ?? true,
+                   resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "") ;
+
+            return Task.FromResult<object>(userFilePath);
+        }
+
+        /// <summary>
+        /// This method will be invoked to set a file path setting in the deployment bundle
+        /// when it is specified as part of the user provided configuration file.
+        /// </summary>
+        /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
+        /// <param name="filePath">File path entered by the user</param>
+        public async Task OverrideValue(Recommendation recommendation, string filePath)
+        {
+            var validator = new FileExistsValidator(_fileManager);
+            var validationResult = await (validator as IOptionSettingItemValidator).Validate(filePath, recommendation);
+
+            if (!validationResult.IsValid)
+                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidFilePath, validationResult.ValidationFailedMessage ?? validator.ValidationFailedMessage);
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -69,6 +69,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.ExistingSubnets,  ActivatorUtilities.CreateInstance<ExistingSubnetsCommand>(serviceProvider) },
                 { OptionSettingTypeHint.ExistingSecurityGroups, ActivatorUtilities.CreateInstance<ExistingSecurityGroupsCommand>(serviceProvider) },
                 { OptionSettingTypeHint.VPCConnector, ActivatorUtilities.CreateInstance<VPCConnectorCommand>(serviceProvider) },
+                { OptionSettingTypeHint.FilePath, ActivatorUtilities.CreateInstance<FilePathCommand>(serviceProvider) },
             };
         }
 

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -726,7 +726,8 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                                     serviceProvider.GetRequiredService<ILocalUserSettingsEngine>(),
                                     new DockerEngine.DockerEngine(
                                         session.ProjectDefinition,
-                                        serviceProvider.GetRequiredService<IFileManager>()),
+                                        serviceProvider.GetRequiredService<IFileManager>(),
+                                        serviceProvider.GetRequiredService<IDirectoryManager>()),
                                     serviceProvider.GetRequiredService<IRecipeHandler>(),
                                     serviceProvider.GetRequiredService<IFileManager>(),
                                     serviceProvider.GetRequiredService<IDirectoryManager>(),

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -29,4 +29,6 @@
     <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" Version="3.7.0.48" />
   </ItemGroup>
 
+  <Import Project="..\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems" Label="Shared" />
+
 </Project>

--- a/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
+++ b/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.IO;
+
 namespace AWS.Deploy.Common
 {
     /// <summary>
@@ -17,6 +19,11 @@ namespace AWS.Deploy.Common
         /// The list of additional dotnet publish args passed to the target application.
         /// </summary>
         public string DockerBuildArgs { get; set; } = "";
+
+        /// <summary>
+        /// The path to the Dockerfile. This can either be an absolute path or relative to the project directory.
+        /// </summary>
+        public string DockerfilePath { get; set; } = "";
 
         /// <summary>
         /// The ECR Repository Name where the docker image will be pushed to.

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -116,7 +116,8 @@ namespace AWS.Deploy.Common
         FailedToGetECRAuthorizationToken = 10009400,
         InvalidCloudApplicationName = 10009500,
         SelectedValueIsNotAllowed = 10009600,
-        MissingValidatorConfiguration = 10009700
+        MissingValidatorConfiguration = 10009700,
+        InvalidFilePath = 10009800
     }
 
     public class ProjectFileNotFoundException : DeployToolException
@@ -269,6 +270,13 @@ namespace AWS.Deploy.Common
         public ResourceQueryException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
+    /// <summary>
+    /// Thrown when an invalid file path is specified as an <see cref="OptionSettingItem"/> value
+    /// </summary>
+    public class InvalidFilePath : DeployToolException
+    {
+        public InvalidFilePath(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 
     public static class ExceptionExtensions
     {

--- a/src/AWS.Deploy.Common/IO/FileManager.cs
+++ b/src/AWS.Deploy.Common/IO/FileManager.cs
@@ -11,7 +11,29 @@ namespace AWS.Deploy.Common.IO
 {
     public interface IFileManager
     {
+        /// <summary>
+        /// Determines whether the specified file is at a valid path and exists.
+        /// This can either be an absolute path or relative to the current working directory.
+        /// </summary>
+        /// <param name="path">The file to check</param>
+        /// <returns>
+        /// True if the path is valid, the caller has the required permissions,
+        /// and path contains the name of an existing file
+        /// </returns>
         bool Exists(string path);
+
+        /// <summary>
+        /// Determines whether the specified file is at a valid path and exists.
+        /// This can either be an absolute path or relative to the given directory.
+        /// </summary>
+        /// <param name="path">The file to check</param>
+        /// <param name="directory">Directory to consider the path as relative to</param>
+        /// <returns>
+        /// True if the path is valid, the caller has the required permissions,
+        /// and path contains the name of an existing file
+        /// </returns>
+        bool Exists(string path, string directory);
+
         Task<string> ReadAllTextAsync(string path);
         Task<string[]> ReadAllLinesAsync(string path);
         Task WriteAllTextAsync(string filePath, string contents, CancellationToken cancellationToken = default);
@@ -26,6 +48,18 @@ namespace AWS.Deploy.Common.IO
     public class FileManager : IFileManager
     {
         public bool Exists(string path) => IsFileValid(path);
+
+        public bool Exists(string path, string directory)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return Exists(path);
+            }
+            else
+            {
+                return Exists(Path.Combine(directory, path));
+            }
+        }
 
         public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
 

--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -85,7 +85,7 @@ namespace AWS.Deploy.Common
         private bool CheckIfDockerFileExists(string projectPath)
         {
             var dir = Directory.GetFiles(new FileInfo(projectPath).DirectoryName ??
-                                         throw new InvalidProjectPathException(DeployToolErrorCode.ProjectPathNotFound, "The project path is invalid."), "Dockerfile");
+                                         throw new InvalidProjectPathException(DeployToolErrorCode.ProjectPathNotFound, "The project path is invalid."), Constants.Docker.DefaultDockerfileName);
             return dir.Length == 1;
         }
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -89,6 +89,8 @@ namespace AWS.Deploy.Common.Recipes
         /// <summary>
         /// Assigns a value to the OptionSettingItem.
         /// </summary>
+        /// <param name="valueOverride">Value to assign</param>
+        /// <param name="recommendation">Current deployment recommendation, may be used if the validator needs to consider properties other than itself</param>
         /// <exception cref="ValidationFailedException">
         /// Thrown if one or more <see cref="Validators"/> determine
         /// <paramref name="valueOverride"/> is not valid.
@@ -99,7 +101,7 @@ namespace AWS.Deploy.Common.Recipes
             {
                 foreach (var validator in validators)
                 {
-                    var result = await validator.Validate(valueOverride);
+                    var result = await validator.Validate(valueOverride, recommendation);
                     if (!result.IsValid)
                     {
                         throw new ValidationFailedException(DeployToolErrorCode.OptionSettingItemValueValidationFailed,

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -35,6 +35,7 @@ namespace AWS.Deploy.Common.Recipes
         ExistingVpcConnector,
         ExistingSubnets,
         ExistingSecurityGroups,
-        VPCConnector
+        VPCConnector,
+        FilePath
     };
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
@@ -6,12 +6,18 @@ using System.Threading.Tasks;
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
-    /// This interface outlines the framework for OptionSettingItem validators.
+    /// This interface outlines the framework for <see cref="OptionSettingItem"/> validators.
     /// Validators such as <see cref="RegexValidator"/> implement this interface and provide custom validation logic
     /// on OptionSettingItems
     /// </summary>
     public interface IOptionSettingItemValidator
     {
-        Task<ValidationResult> Validate(object input);
+        /// <summary>
+        /// Validates an override value for an <see cref="OptionSettingItem"/>
+        /// </summary>
+        /// <param name="input">Raw input for an option</param>
+        /// <param name="recommendation">Selected recommendation, which may be used if the validator needs to consider properties other than itself</param>
+        /// <returns>Whether or not the input is valid</returns>
+        Task<ValidationResult> Validate(object input, Recommendation recommendation);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -32,6 +32,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="ExistingResourceValidator"/>
         /// </summary>
-        ExistingResource
+        ExistingResource,
+        /// <summary>
+        /// Must be paired with <see cref="FileExistsValidator"/>
+        /// </summary>
+        FileExists
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
@@ -24,7 +24,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Path to validate</param>
         /// <returns>Valid if the directory exists, invalid otherwise</returns>
-        public Task<ValidationResult> Validate(object input)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
         {
             var executionDirectory = (string)input;
 

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
@@ -17,7 +17,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Proposed Docker build args</param>
         /// <returns>Valid if the options do not contain those set by the deploy tool, invalid otherwise</returns>
-        public Task<ValidationResult> Validate(object input)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
         {
             var buildArgs = Convert.ToString(input);
             var errorMessage = string.Empty;

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
@@ -16,7 +16,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Additional publish arguments</param>
         /// <returns>Valid if the arguments don't interfere with the deploy tool, invalid otherwise</returns>
-        public Task<ValidationResult> Validate(object input)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
         {
             var publishArgs = Convert.ToString(input);
             var errorMessage = string.Empty;

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
             _awsResourceQueryer = awsResourceQueryer;
         }
 
-        public async Task<ValidationResult> Validate(object input)
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation)
         {
             if (string.IsNullOrEmpty(ResourceType))
                 throw new MissingValidatorConfigurationException(DeployToolErrorCode.MissingValidatorConfiguration, $"The validator of type '{typeof(ExistingResourceValidator)}' is missing the configuration property '{nameof(ResourceType)}'.");

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/FileExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/FileExistsValidator.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that a recipe or deployment bundle option with a FilePath typehint points to an actual file.
+    /// This can either be an absolute path to the file or relative to the project path
+    /// </summary>
+    public class FileExistsValidator : IOptionSettingItemValidator
+    {
+        private readonly IFileManager _fileManager;
+
+        public FileExistsValidator(IFileManager fileManager)
+        {
+            _fileManager = fileManager;
+        }
+
+        public string ValidationFailedMessage { get; set; } = "The specified file does not exist";
+
+        /// <summary>
+        /// Whether or not an empty filepath is valid (essentially whether this option is required)
+        /// </summary>
+        public bool AllowEmptyString { get; set; } = true;
+
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        {
+            var inputFilePath = input?.ToString() ?? string.Empty;
+
+            if (string.IsNullOrEmpty(inputFilePath))
+            {
+                if (AllowEmptyString)
+                {
+                    return ValidationResult.ValidAsync();
+                }
+                else
+                {
+                    return ValidationResult.FailedAsync("A file must be specified");
+                }
+            }
+
+            // Otherwise if there is a value, verify that it points to an actual file
+            if (_fileManager.Exists(inputFilePath, recommendation.GetProjectDirectory()))
+            {
+                return ValidationResult.ValidAsync();
+            }
+            else
+            {
+                return ValidationResult.FailedAsync($"The specified file {inputFilePath} does not exist");
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
@@ -24,7 +24,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
         public bool AllowEmptyString { get; set; }
 
-        public Task<ValidationResult> Validate(object input)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
         {
             if (AllowEmptyString && string.IsNullOrEmpty(input?.ToString()))
                 return ValidationResult.ValidAsync();

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
         public bool AllowEmptyString { get; set; }
 
-        public Task<ValidationResult> Validate(object input)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
         {
             var regex = new Regex(Regex);
 

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RequiredValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RequiredValidator.cs
@@ -13,7 +13,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         private static readonly string defaultValidationFailedMessage = "Value can not be empty";
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
 
-        public Task<ValidationResult> Validate(object input) =>
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation) =>
             Task.FromResult<ValidationResult>(new()
             {
                 IsValid = !string.IsNullOrEmpty(input?.ToString()),

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
@@ -13,6 +13,11 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="MinMaxConstraintValidator"/>
         /// </summary>
-        MinMaxConstraint
+        MinMaxConstraint,
+
+        /// <summary>
+        /// Must be paired with <see cref="DockerfilePathValidator"/>
+        /// </summary>
+        ValidDockerfilePath
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/DockerfilePathValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/DockerfilePathValidator.cs
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Utilities;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// This validates that the Dockerfile is within the build context.
+    ///
+    /// Per https://docs.docker.com/engine/reference/commandline/build/#text-files
+    /// "The path must be to a file within the build context."
+    /// </summary>
+    public class DockerfilePathValidator : IRecipeValidator
+    {
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IFileManager _fileManager;
+
+        public DockerfilePathValidator(IDirectoryManager directoryManager, IFileManager fileManager)
+        {
+            _directoryManager = directoryManager;
+            _fileManager = fileManager;
+        }
+
+        public Task<ValidationResult> Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
+        {
+            DockerUtilities.TryGetAbsoluteDockerfile(recommendation, _fileManager, _directoryManager, out var absoluteDockerfilePath);
+
+            // Docker execution directory has its own typehint, which sets the value here
+            var dockerExecutionDirectory = recommendation.DeploymentBundle.DockerExecutionDirectory;
+
+            // We're only checking the interaction here against a user-specified file and execution directory,
+            // it's still possible that we generate a dockerfile and/or compute the execution directory later.
+            if (absoluteDockerfilePath == string.Empty || dockerExecutionDirectory == string.Empty)
+            {
+                return ValidationResult.ValidAsync();
+            }
+
+            // Convert both to absolute paths in case they were specified relative to the project directory
+            var projectPath = recommendation.GetProjectDirectory();
+
+            var absoluteDockerExecutionDirectory = Path.IsPathRooted(dockerExecutionDirectory)
+                            ? dockerExecutionDirectory
+                            : _directoryManager.GetAbsolutePath(projectPath, dockerExecutionDirectory);
+
+            if (!_directoryManager.ExistsInsideDirectory(absoluteDockerExecutionDirectory, absoluteDockerfilePath))
+            {
+                return ValidationResult.FailedAsync($"The specified Dockerfile \"{absoluteDockerfilePath}\" is not located within " +
+                    $"the specified Docker execution directory \"{dockerExecutionDirectory}\"");
+            }
+
+            return ValidationResult.ValidAsync();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -52,13 +52,15 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.DirectoryExists, typeof(DirectoryExistsValidator) },
             { OptionSettingItemValidatorList.DockerBuildArgs, typeof(DockerBuildArgsValidator) },
             { OptionSettingItemValidatorList.DotnetPublishArgs, typeof(DotnetPublishArgsValidator) },
-            { OptionSettingItemValidatorList.ExistingResource, typeof(ExistingResourceValidator) }
+            { OptionSettingItemValidatorList.ExistingResource, typeof(ExistingResourceValidator) },
+            { OptionSettingItemValidatorList.FileExists, typeof(FileExistsValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()
         {
             { RecipeValidatorList.FargateTaskSizeCpuMemoryLimits, typeof(FargateTaskCpuMemorySizeValidator) },
             { RecipeValidatorList.MinMaxConstraint, typeof(MinMaxConstraintValidator) },
+            { RecipeValidatorList.ValidDockerfilePath, typeof(DockerfilePathValidator) }
         };
 
         public IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem, Func<OptionSettingItemValidatorConfig, bool>? filter = null)
@@ -73,7 +75,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public IRecipeValidator[] BuildValidators(RecipeDefinition recipeDefinition)
         {
             return recipeDefinition.Validators
-                .Select(v => Activate(v.ValidatorType, v.Configuration,_recipeValidatorTypeMapping))
+                .Select(v => Activate(v.ValidatorType, v.Configuration, _recipeValidatorTypeMapping))
                 .OfType<IRecipeValidator>()
                 .ToArray();
         }

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -12,6 +12,9 @@ namespace AWS.Deploy.Common
 {
     public class Recommendation : IUserInputOption
     {
+        /// <summary>
+        /// Returns the full path to the project file
+        /// </summary>
         public string ProjectPath => ProjectDefinition.ProjectPath;
 
         public ProjectDefinition ProjectDefinition { get; }
@@ -112,6 +115,20 @@ namespace AWS.Deploy.Common
         public void AddReplacementToken(string key, string value)
         {
             ReplacementTokens[key] = value;
+        }
+
+        /// <summary>
+        /// Helper to get the project's directory
+        /// </summary>
+        /// <returns>Full name of directory containing this recommendation's project file</returns>
+        public string GetProjectDirectory()
+        {
+            var projectDirectory = new FileInfo(ProjectPath).Directory?.FullName;
+
+            if (string.IsNullOrEmpty(projectDirectory))
+                throw new InvalidProjectPathException(DeployToolErrorCode.ProjectPathNotFound, "The project path provided is invalid.");
+
+            return projectDirectory;
         }
     }
 }

--- a/src/AWS.Deploy.Common/TypeHintData/FilePathTypeHintData.cs
+++ b/src/AWS.Deploy.Common/TypeHintData/FilePathTypeHintData.cs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.TypeHintData
+{
+    /// <summary>
+    /// Additional typehint data for file options
+    /// </summary>
+    public class FilePathTypeHintData
+    {
+        /// <summary>
+        /// Corresponds to a Filter property for a System.Windows.Forms.FileDialog
+        /// to determine the choices that would appear in the dialog box if a wrapping tool prompted the user for a file path via a UI.
+        public string Filter { get; set; } = "All files (*.*)|*.*";
+
+        /// <summary>
+        /// Corresponds to the DefaultExt property for a System.Windows.Forms.FileDialog
+        /// to specify the default extension used if the user specifies a file name
+        /// without an extension.
+        /// </summary>
+        public string DefaultExtension { get; set; } = "";
+
+        /// <summary>
+        /// Corresponds to the Title property for a System.Windows.Forms.FileDialog
+        /// to specify the title of the file dialog box.
+        /// </summary>
+        public string Title { get; set; } = "Open";
+
+        /// <summary>
+        /// Corresponds to the CheckFileExists property for a System.Windows.Forms.FileDialog
+        /// to indicate whether the dialog box should display a warning if the user specifies a file that does not exist.
+        /// </summary>
+        public bool CheckFileExists { get; set; } = true;
+
+        /// <summary>
+        /// Corresponds to the the AllowEmpty parameter for ConsoleUtilities.AskUserForValue
+        /// This lets a recipe option that uses the FilePathCommand typehint
+        /// control whether an empty value is allowed during CLI mode
+        /// </summary>
+        public bool AllowEmpty { get; set; } = true;
+    }
+}

--- a/src/AWS.Deploy.Common/Utilities/DockerUtilities.cs
+++ b/src/AWS.Deploy.Common/Utilities/DockerUtilities.cs
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.Common.Utilities
+{
+    /// <summary>
+    ///  Utility methods for working with a recommendation's Docker configuration
+    /// </summary>
+    public static class DockerUtilities
+    {
+        /// <summary>
+        /// Gets the path of a Dockerfile if it exists at the default location: "{ProjectPath}/Dockerfile"
+        /// </summary>
+        /// <param name="recommendation">The selected recommendation settings used for deployment</param>
+        /// <param name="fileManager">File manager, used for validating that the Dockerfile exists</param>
+        /// <param name="dockerfilePath">Path to the Dockerfile, relative to the recommendation's project directory</param>
+        /// <returns>True if the Dockerfile exists at the default location, false otherwise</returns>
+        public static bool TryGetDefaultDockerfile(Recommendation recommendation, IFileManager? fileManager, out string dockerfilePath)
+        {
+            if (fileManager == null)
+            {
+                fileManager = new FileManager();
+            }
+
+            if (fileManager.Exists(Constants.Docker.DefaultDockerfileName, recommendation.GetProjectDirectory()))
+            {
+                // Set the default value to the OS-specific ".\Dockerfile"
+                dockerfilePath = Path.Combine(".", Constants.Docker.DefaultDockerfileName);
+                return true;
+            }
+            else
+            {
+                dockerfilePath = string.Empty;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the path of a the project's Dockerfile if it exists, from either a user-specified or the default location
+        /// </summary>
+        /// <param name="recommendation">The selected recommendation settings used for deployment</param>
+        /// <param name="fileManager">File manager, used for validating that the Dockerfile exists</param>
+        /// <param name="dockerfilePath">Path to a Dockerfile,which may be absolute or relative</param>
+        /// <returns>True if a Dockerfile is specified for this deployment, false otherwise</returns>
+        public static bool TryGetDockerfile(Recommendation recommendation, IFileManager fileManager, out string dockerfilePath)
+        {
+            dockerfilePath = recommendation.DeploymentBundle.DockerfilePath;
+
+            if (!string.IsNullOrEmpty(dockerfilePath))
+            {
+                // Double-check that it still exists in case it was move/deleted after being specified.
+                if (fileManager.Exists(dockerfilePath, recommendation.GetProjectDirectory()))
+                {
+                    return true;
+                }
+                else
+                {
+                    throw new InvalidFilePath(DeployToolErrorCode.InvalidFilePath, $"A dockerfile was specified at {dockerfilePath} but does not exist.");
+                }
+            }
+            else
+            {
+                // Check the default location again, for the case where a file was NOT specified
+                // in the option but we generated one in the default location right before calling docker build.
+                var defaultExists = TryGetDefaultDockerfile(recommendation, fileManager, out dockerfilePath);
+                return defaultExists;
+            }
+        }
+
+        /// <summary>
+        /// Gets the path of a the project's Dockerfile if it exists, from either a user-specified or the default location
+        /// </summary>
+        /// <param name="recommendation">The selected recommendation settings used for deployment</param>
+        /// <param name="fileManager">File manager, used for validating that the Dockerfile exists</param>
+        /// <param name="absoluteDockerfilePath">Absolute path to the Dockerfile</param>
+        /// <returns>True if a Dockerfile is specified for this deployment, false otherwise</returns>
+        public static bool TryGetAbsoluteDockerfile(Recommendation recommendation, IFileManager fileManager, IDirectoryManager directoryManager, out string absoluteDockerfilePath)
+        {
+            var dockerfileExists = TryGetDockerfile(recommendation, fileManager, out var dockerfilePath);
+
+            if (dockerfileExists)
+            {
+                absoluteDockerfilePath = Path.IsPathRooted(dockerfilePath)
+                ? dockerfilePath
+                : directoryManager.GetAbsolutePath(recommendation.GetProjectDirectory(), dockerfilePath);
+            }
+            else
+            {
+                absoluteDockerfilePath = string.Empty;
+            }
+
+            return dockerfileExists;
+        }
+    }
+}

--- a/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
+++ b/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CDK.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CLI.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CloudFormationIdentifier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Docker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ElasticBeanstalk.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RecipeIdentifier.cs" />
   </ItemGroup>

--- a/src/AWS.Deploy.Constants/Docker.cs
+++ b/src/AWS.Deploy.Constants/Docker.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Constants
+{
+    internal class Docker
+    {
+        /// <summary>
+        /// Name of the default Dockerfile that the deployment tool attempts to detect in the project directory
+        /// </summary>
+        public static readonly string DefaultDockerfileName = "Dockerfile";
+
+        /// <summary>
+        /// Id for the Docker Execution Directory recipe option
+        /// </summary>
+        public const string DockerExecutionDirectoryOptionId = "DockerExecutionDirectory";
+
+        /// <summary>
+        /// Id for the Dockerfile Path recipe option
+        /// </summary>
+        public const string DockerfileOptionId = "DockerfilePath";
+
+        /// <summary>
+        /// Id for the Docker Build Args recipe option
+        /// </summary>
+        public const string DockerBuildArgsOptionId = "DockerBuildArgs";
+
+        /// <summary>
+        /// Id for the ECR Repository Name recipe option
+        /// </summary>
+        public const string ECRRepositoryNameOptionId = "ECRRepositoryName";
+
+        /// <summary>
+        /// Id for the Docker Image Tag recipe option
+        /// </summary>
+        public const string ImageTagOptionId = "ImageTag";
+    }
+}

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -14,5 +14,21 @@ namespace AWS.Deploy.Constants
         public const string REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN = "{LatestDotnetBeanstalkPlatformArn}";
         public const string REPLACE_TOKEN_ECR_REPOSITORY_NAME = "{DefaultECRRepositoryName}";
         public const string REPLACE_TOKEN_ECR_IMAGE_TAG = "{DefaultECRImageTag}";
+        public const string REPLACE_TOKEN_DOCKERFILE_PATH = "{DockerfilePath}";
+
+        /// <summary>
+        /// Id for the 'dotnet publish --configuration' recipe option
+        /// </summary>
+        public const string DotnetPublishConfigurationOptionId = "DotnetBuildConfiguration";
+
+        /// <summary>
+        /// Id for the additional args for 'dotnet publish' recipe option
+        /// </summary>
+        public const string DotnetPublishArgsOptionId = "DotnetPublishArgs";
+
+        /// <summary>
+        /// Id for the 'dotnet build --self-contained' recipe option
+        /// </summary>
+        public const string DotnetPublishSelfContainedBuildOptionId = "SelfContainedBuild";
     }
 }

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Utilities;
 using Newtonsoft.Json;
 
 namespace AWS.Deploy.DockerEngine
@@ -33,9 +35,10 @@ namespace AWS.Deploy.DockerEngine
     {
         private readonly ProjectDefinition _project;
         private readonly IFileManager _fileManager;
+        private readonly IDirectoryManager _directoryManager;
         private readonly string _projectPath;
 
-        public DockerEngine(ProjectDefinition project, IFileManager fileManager)
+        public DockerEngine(ProjectDefinition project, IFileManager fileManager, IDirectoryManager directoryManager)
         {
             if (project == null)
             {
@@ -45,6 +48,7 @@ namespace AWS.Deploy.DockerEngine
             _project = project;
             _projectPath = project.ProjectPath;
             _fileManager = fileManager;
+            _directoryManager = directoryManager;
         }
 
         /// <summary>
@@ -158,8 +162,8 @@ namespace AWS.Deploy.DockerEngine
             if (string.IsNullOrEmpty(recommendation.DeploymentBundle.DockerExecutionDirectory))
             {
                 var projectFilename = Path.GetFileName(recommendation.ProjectPath);
-                var dockerFilePath = Path.Combine(Path.GetDirectoryName(recommendation.ProjectPath) ?? "", "Dockerfile");
-                if (_fileManager.Exists(dockerFilePath))
+                
+                if (DockerUtilities.TryGetAbsoluteDockerfile(recommendation, _fileManager, _directoryManager, out var dockerFilePath))
                 {
                     using (var stream = File.OpenRead(dockerFilePath))
                     using (var reader = new StreamReader(stream))

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -43,7 +43,7 @@ namespace AWS.Deploy.Orchestration
 
                 var optionSettingValue = GetOptionSettingValue(recommendation, optionSetting);
                 settingValidatorFailedResults.AddRange(_validatorFactory.BuildValidators(optionSetting)
-                    .Select(async validator => await validator.Validate(optionSettingValue))
+                    .Select(async validator => await validator.Validate(optionSettingValue, recommendation))
                     .Select(x => x.Result)
                     .Where(x => !x.IsValid)
                     .ToList());
@@ -99,22 +99,25 @@ namespace AWS.Deploy.Orchestration
         {
             switch (optionSettingItem.Id)
             {
-                case "DockerExecutionDirectory":
+                case Constants.Docker.DockerExecutionDirectoryOptionId:
                     recommendation.DeploymentBundle.DockerExecutionDirectory = value.ToString() ?? string.Empty;
                     break;
-                case "DockerBuildArgs":
+                case Constants.Docker.DockerfileOptionId:
+                    recommendation.DeploymentBundle.DockerfilePath = value.ToString() ?? string.Empty;
+                    break;
+                case Constants.Docker.DockerBuildArgsOptionId:
                     recommendation.DeploymentBundle.DockerBuildArgs = value.ToString() ?? string.Empty;
                     break;
-                case "ECRRepositoryName":
+                case Constants.Docker.ECRRepositoryNameOptionId:
                     recommendation.DeploymentBundle.ECRRepositoryName = value.ToString() ?? string.Empty;
                     break;
-                case "DotnetBuildConfiguration":
+                case Constants.RecipeIdentifier.DotnetPublishConfigurationOptionId:
                     recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = value.ToString() ?? string.Empty;
                     break;
-                case "DotnetPublishArgs":
+                case Constants.RecipeIdentifier.DotnetPublishArgsOptionId:
                     recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments = value.ToString() ?? string.Empty;
                     break;
-                case "SelfContainedBuild":
+                case Constants.RecipeIdentifier.DotnetPublishSelfContainedBuildOptionId:
                     recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = Convert.ToBoolean(value);
                     break;
                 default:

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -17,6 +17,26 @@
             ]
         },
         {
+            "Id": "DockerfilePath",
+            "Name": "Dockerfile Path",
+            "Description": "Specify a path to a Dockerfile as either an absolute path or a path relative to the project.",
+            "Type": "String",
+            "TypeHint": "FilePath",
+            "TypeHintData": {
+                "Filter": "All files (*.*)|*.*",
+                "CheckFileExists": true,
+                "Title": "Select a Dockerfile"
+            },
+            "DefaultValue": "{DockerfilePath}",
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "FileExists"
+                }
+            ]
+        },
+        {
             "Id": "DockerExecutionDirectory",
             "Name": "Docker Execution Directory",
             "Description": "Specifies the docker execution directory where the docker build command will be executed from.",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -51,7 +51,6 @@
                 "Fail": { "Include": true }
             }
         }
-
     ],
     "Categories": [
         {
@@ -83,6 +82,11 @@
             "Id": "EnvVariables",
             "DisplayName": "Environment Variables",
             "Order": 60
+        }
+    ],
+    "Validators": [
+        {
+            "ValidatorType": "ValidDockerfilePath"
         }
     ],
     "OptionSettings": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -72,6 +72,9 @@
                 "MinValueOptionSettingsId": "AutoScaling.MinCapacity",
                 "MaxValueOptionSettingsId": "AutoScaling.MaxCapacity"
             }
+        },
+        {
+            "ValidatorType": "ValidDockerfilePath"
         }
     ],
     "Categories": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -93,6 +93,9 @@
     "Validators": [
         {
             "ValidatorType": "FargateTaskSizeCpuMemoryLimits"
+        },
+        {
+            "ValidatorType": "ValidDockerfilePath"
         }
     ],
     "Categories": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -135,6 +135,9 @@
                 "MinValueOptionSettingsId": "AutoScaling.MinCapacity",
                 "MaxValueOptionSettingsId": "AutoScaling.MaxCapacity"
             }
+        },
+        {
+            "ValidatorType": "ValidDockerfilePath"
         }
     ],
     "Categories": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/PushContainerImageECR.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/PushContainerImageECR.recipe
@@ -26,6 +26,11 @@
             }
         }
     ],
+    "Validators": [
+        {
+            "ValidatorType": "ValidDockerfilePath"
+        }
+    ],
     "Categories": [
         {
             "Id": "General",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -352,7 +352,8 @@
                         "type": "string",
                         "enum": [
                             "FargateTaskSizeCpuMemoryLimits",
-                            "MinMaxConstraint"
+                            "MinMaxConstraint",
+                            "ValidDockerfilePath"
                         ]
                     }
                 },
@@ -607,7 +608,8 @@
                                     "DirectoryExists",
                                     "DockerBuildArgs",
                                     "DotnetPublishArgs",
-                                    "ExistingResource"
+                                    "ExistingResource",
+                                    "FileExists"
                                 ]
                             }
                         },

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
@@ -31,8 +31,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
         public void Delete(string path, bool recursive = false) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
 
-        public bool ExistsInsideDirectory(string parentDirectoryPath, string childPath) =>
-            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+        public bool ExistsInsideDirectory(string parentDirectoryPath, string childPath) => childPath.Contains(parentDirectoryPath + Path.DirectorySeparatorChar, StringComparison.InvariantCulture);
 
         public bool Exists(string path)
         {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestFileManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestFileManager.cs
@@ -40,6 +40,17 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
         public FileStream OpenRead(string filePath) => throw new NotImplementedException();
         public string GetExtension(string filePath) => throw new NotImplementedException();
         public long GetSizeInBytes(string filePath) => throw new NotImplementedException();
+        public bool Exists(string path, string directory)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return Exists(path);
+            }
+            else
+            {
+                return Exists(Path.Combine(directory, path));
+            }
+        }
     }
 
     public static class TestFileManagerExtensions

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/DockerfilePathValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/DockerfilePathValidationTests.cs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
+{
+    /// <summary>
+    /// Tests for the recipe-level validation between the Dockerfile path and
+    /// docker execution recipe options, <see cref="DockerfilePathValidator"/>
+    /// </summary>
+    public class DockerfilePathValidationTests
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly RecipeDefinition _recipeDefinition;
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IFileManager _fileManager;
+
+        public DockerfilePathValidationTests()
+        {
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _directoryManager = new TestDirectoryManager();
+            _fileManager = new TestFileManager();
+
+            _recipeDefinition = new Mock<RecipeDefinition>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DeploymentTypes>(),
+                It.IsAny<DeploymentBundleTypes>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()).Object;
+        }
+
+        public static IEnumerable<object[]> DockerfilePathTestData => new List<object[]>()
+        {
+            // Dockerfile path | Docker execution directory | expected to be valid?
+
+            // We generate a Dockerfile later if one isn't specified, so not invalid at this point
+            new object[] { "", Path.Combine("C:", "project"), true },
+
+            // We compute the execution directory later if one isn't specified, so not invalid at this point
+            new object[] { Path.Combine("C:", "project", "Dockerfile"), "", true },
+
+            // Dockerfile is in the execution directory, with absolute paths
+            new object[] { Path.Combine("C:", "project", "Dockerfile"), Path.Combine("C:", "project"), true },
+
+            // Dockerfile is in the execution directory, with relative paths
+            new object[] { Path.Combine(".", "Dockerfile"), Path.Combine("."), true },
+
+            // Dockerfile is further down in execution directory, with absolute paths
+            new object[] { Path.Combine("C:", "project", "child", "Dockerfile"), Path.Combine("C:", "project"), true },
+
+            // Dockerfile is further down in execution directory, with relative paths
+            new object[] { Path.Combine(".", "child", "Dockerfile"), Path.Combine("."), true },
+
+            // Dockerfile is outside of the execution directory, which is invalid
+            new object[] { Path.Combine("C:", "project", "Dockerfile"), Path.Combine("C:", "foo"), false }
+        };
+
+        /// <summary>
+        /// Tests for <see cref="DockerfilePathValidator"/>, which validates the relationship
+        /// between a Dockerfile path and the Docker execution directory
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(DockerfilePathTestData))]
+        public async Task DockerfilePathValidationHelperAsync(string dockerfilePath, string dockerExecutionDirectory, bool expectedToBeValid)
+        {
+            var projectPath = Path.Combine("C:", "project", "test.csproj");
+            var options = new List<OptionSettingItem>()
+            {
+                new OptionSettingItem("DockerfilePath", "", "", "")
+            };
+            var projectDefintion = new ProjectDefinition(null, projectPath, "", "");
+            var recommendation = new Recommendation(_recipeDefinition, projectDefintion, options, 100, new Dictionary<string, string>());
+            var validator = new DockerfilePathValidator(_directoryManager, _fileManager);
+
+            recommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;
+            recommendation.DeploymentBundle.DockerfilePath = dockerfilePath;
+
+            // "Write" to the TestFileManager so that "Exists" returns true
+            if (Path.IsPathRooted(dockerfilePath))
+                await _fileManager.WriteAllTextAsync(dockerfilePath, "");
+            else
+                await _fileManager.WriteAllTextAsync(Path.Combine(recommendation.GetProjectDirectory(), dockerfilePath), "");
+
+            var validationResult = await validator.Validate(recommendation, null);
+
+            Assert.Equal(expectedToBeValid, validationResult.IsValid);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
@@ -38,6 +38,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider.Setup(x => x.GetService(typeof(IOptionSettingHandler))).Returns(_optionSettingHandler);
             mockServiceProvider.Setup(x => x.GetService(typeof(IDirectoryManager))).Returns(new TestDirectoryManager());
+            mockServiceProvider.Setup(x => x.GetService(typeof(IFileManager))).Returns(new TestFileManager());
             _serviceProvider = mockServiceProvider.Object;
             mockServiceProvider
                 .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -5,9 +5,13 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.DockerEngine;
+using AWS.Deploy.Orchestration;
+using Moq;
 using Should;
 using Xunit;
 
@@ -32,7 +36,7 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var project = await new ProjectDefinitionParser(fileManager, new DirectoryManager()).Parse(projectPath);
 
-            var engine = new DockerEngine.DockerEngine(project, fileManager);
+            var engine = new DockerEngine.DockerEngine(project, fileManager, new TestDirectoryManager());
 
             engine.GenerateDockerFile();
 

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
@@ -19,6 +19,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
         {
             return InMemoryStore.ContainsKey(path);
         }
+        public bool Exists(string path, string directory) => throw new NotImplementedException();
 
         public Task<string> ReadAllTextAsync(string path)
         {

--- a/testapps/ConsoleAppTask/Docker/Dockerfile
+++ b/testapps/ConsoleAppTask/Docker/Dockerfile
@@ -1,0 +1,25 @@
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# Dockerfile paths are adjusted to allow docker build from the root of the repository
+# This is required for integration tests
+#
+# Note: this is the same as the Dockerfile up one directory, but duplicated
+# here for testing dockerfiles located in alternative locations.
+
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+WORKDIR /src
+COPY ["ConsoleAppTask.csproj", "ConsoleAppTask/"]
+RUN dotnet restore "ConsoleAppTask/ConsoleAppTask.csproj"
+COPY. "ConsoleAppTask/"
+WORKDIR "/src/ConsoleAppTask"
+RUN dotnet build "ConsoleAppTask.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "ConsoleAppTask.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from= publish / app / publish.
+ENTRYPOINT["dotnet", "ConsoleAppTask.dll"]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-dotnet-deploy/issues/155, DOTNET-5573

*Description of changes:* Adds support for `DockerfilePath` to the container deployments. This provides an alternative to the default location we check: `{ProjectPath}.Dockerfile`.
* ~~This takes an absolute path. I had briefly explored supporting either absolute or relative to the project directory, but started simpler.~~ _Updated on 4/27 to take either an absolute path or one relative to the project directory._
* This does not influence `DockerExecutionDirectory`
* Added a typehint. It doesn't suggest any values, but would signal any UIs that wrap this to expose a filepicker.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
