### PR TITLE
chore: change NuGet package name from AWS.Deploy.CLI to AWS.Deploy.Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ The deployment tool is distributed as a .NET Tool from NuGet.org. The installati
 To install the deployment tool, use the dotnet tool install command:
 
 ```
-dotnet tool install -g aws.deploy.cli
+dotnet tool install -g aws.deploy.tools
 ```
 
 To update to the latest version of the deployment tool, use the dotnet tool update command.
 
 ```
-dotnet tool update -g aws.deploy.cli
+dotnet tool update -g aws.deploy.tools
 ```
 
 To uninstall it, simply type:
 ```
-dotnet tool uninstall -g aws.deploy.cli
+dotnet tool uninstall -g aws.deploy.tools
 ```
 
 Once you install the tool, you can view the list of available commands by typing:

--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <Description>Opinionated tooling that simplifies deployment of .NET applications with minimum AWS knowledge.</Description>
     <Product>AWS .NET deployment tool</Product>
-    <PackageId>AWS.Deploy.CLI</PackageId>
+    <PackageId>AWS.Deploy.Tools</PackageId>
     <PackageTags>AWS;Amazon;ElasticBeanstalk;ECS;Deploy</PackageTags>
     <AssemblyName>AWS.Deploy.CLI</AssemblyName>
     <RootNamespace>AWS.Deploy.CLI</RootNamespace>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/README.md
@@ -4,7 +4,7 @@ This .NET project is a deployment project used by the AWS deploy tool to deploy 
 up of 2 parts.
 
 First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
-the AWS.Deploy.CLI tool and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
 with this deployment project.
 
 The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
@@ -26,7 +26,7 @@ In a regular CDK project the CDK CLI, acquired from NPM, would be used to execut
 tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
 the deployment project.
 
-The AWS deploy tool from either AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
 should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
 CDK CLI passing in all of the settings gathered in the AWS deploy tool.
 
@@ -44,7 +44,7 @@ file for information on how to customize the CDK project.
 ## Can I add more settings to the recipe?
 
 As you customize the deployment project you might want to present the user's of the deployment project more
-settings that will be displayed in the AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio. The recipe
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
 file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
 recipe.
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/README.md
@@ -4,7 +4,7 @@ This .NET project is a deployment project used by the AWS deploy tool to deploy 
 up of 2 parts.
 
 First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
-the AWS.Deploy.CLI tool and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
 with this deployment project.
 
 The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
@@ -26,7 +26,7 @@ In a regular CDK project the CDK CLI, acquired from NPM, would be used to execut
 tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
 the deployment project.
 
-The AWS deploy tool from either AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
 should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
 CDK CLI passing in all of the settings gathered in the AWS deploy tool.
 
@@ -44,7 +44,7 @@ file for information on how to customize the CDK project.
 ## Can I add more settings to the recipe?
 
 As you customize the deployment project you might want to present the user's of the deployment project more
-settings that will be displayed in the AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio. The recipe
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
 file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
 recipe.
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/README.md
@@ -4,7 +4,7 @@ This .NET project is a deployment project used by the AWS deploy tool to deploy 
 up of 2 parts.
 
 First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
-the AWS.Deploy.CLI tool and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
 with this deployment project.
 
 The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
@@ -26,7 +26,7 @@ In a regular CDK project the CDK CLI, acquired from NPM, would be used to execut
 tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
 the deployment project.
 
-The AWS deploy tool from either AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
 should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
 CDK CLI passing in all of the settings gathered in the AWS deploy tool.
 
@@ -44,7 +44,7 @@ file for information on how to customize the CDK project.
 ## Can I add more settings to the recipe?
 
 As you customize the deployment project you might want to present the user's of the deployment project more
-settings that will be displayed in the AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio. The recipe
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
 file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
 recipe.
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/README.md
@@ -4,7 +4,7 @@ This .NET project is a deployment project used by the AWS deploy tool to deploy 
 up of 2 parts.
 
 First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
-the AWS.Deploy.CLI tool and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
 with this deployment project.
 
 The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
@@ -26,7 +26,7 @@ In a regular CDK project the CDK CLI, acquired from NPM, would be used to execut
 tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
 the deployment project.
 
-The AWS deploy tool from either AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
 should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
 CDK CLI passing in all of the settings gathered in the AWS deploy tool.
 
@@ -44,7 +44,7 @@ file for information on how to customize the CDK project.
 ## Can I add more settings to the recipe?
 
 As you customize the deployment project you might want to present the user's of the deployment project more
-settings that will be displayed in the AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio. The recipe
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
 file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
 recipe.
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/README.md
@@ -4,7 +4,7 @@ This .NET project is a deployment project used by the AWS deploy tool to deploy 
 up of 2 parts.
 
 First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
-the AWS.Deploy.CLI tool and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
 with this deployment project.
 
 The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
@@ -26,7 +26,7 @@ In a regular CDK project the CDK CLI, acquired from NPM, would be used to execut
 tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
 the deployment project.
 
-The AWS deploy tool from either AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
 should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
 CDK CLI passing in all of the settings gathered in the AWS deploy tool.
 
@@ -44,7 +44,7 @@ file for information on how to customize the CDK project.
 ## Can I add more settings to the recipe?
 
 As you customize the deployment project you might want to present the user's of the deployment project more
-settings that will be displayed in the AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio. The recipe
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
 file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
 recipe.
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/README.md
@@ -4,7 +4,7 @@ This .NET project is a deployment project used by the AWS deploy tool to deploy 
 up of 2 parts.
 
 First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
-the AWS.Deploy.CLI tool and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
 with this deployment project.
 
 The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
@@ -26,7 +26,7 @@ In a regular CDK project the CDK CLI, acquired from NPM, would be used to execut
 tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
 the deployment project.
 
-The AWS deploy tool from either AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
 should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
 CDK CLI passing in all of the settings gathered in the AWS deploy tool.
 
@@ -44,7 +44,7 @@ file for information on how to customize the CDK project.
 ## Can I add more settings to the recipe?
 
 As you customize the deployment project you might want to present the user's of the deployment project more
-settings that will be displayed in the AWS.Deploy.CLI tool package or AWS Toolkit for Visual Studio. The recipe
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
 file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
 recipe.
 

--- a/test/ManualLinuxTesting/Dockerfile
+++ b/test/ManualLinuxTesting/Dockerfile
@@ -94,7 +94,7 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 
 #install aws deploy
-RUN dotnet tool install AWS.Deploy.CLI -g --add-source /app --version $AWS_CLI_VERSION
+RUN dotnet tool install AWS.Deploy.Tools -g --add-source /app --version $AWS_CLI_VERSION
 
 # verify it worked
 RUN dotnet aws --version


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5803

*Description of changes:*
change NuGet package name from AWS.Deploy.CLI to AWS.Deploy.Tools and update all doc references.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
