### PR TITLE
Amend IAM Roles Associated with Elastic Beanstalk Deployments

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Recipe.cs
@@ -14,7 +14,6 @@ using AspNetAppAppRunner.Configurations;
 using CfnService = Amazon.CDK.AWS.AppRunner.CfnService;
 using CfnServiceProps = Amazon.CDK.AWS.AppRunner.CfnServiceProps;
 using Constructs;
-using System.Linq;
 using System.Collections.Generic;
 
 // This is a generated file from the original deployment recipe. It is recommended to not modify this file in order

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -19,6 +19,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         public IAMRoleConfiguration ApplicationIAMRole { get; set; }
 
         /// <summary>
+        /// A service role is the IAM role that Elastic Beanstalk assumes when calling other services on your behalf
+        /// </summary>
+        public IAMRoleConfiguration ServiceIAMRole { get; set; }
+
+        /// <summary>
         /// The type of environment for the Elastic Beanstalk application.
         /// </summary>
         public string EnvironmentType { get; set; } = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE;
@@ -105,6 +110,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
 
         public Configuration(
             IAMRoleConfiguration applicationIAMRole,
+            IAMRoleConfiguration serviceIAMRole,
             string instanceType,
             BeanstalkEnvironmentConfiguration beanstalkEnvironment,
             BeanstalkApplicationConfiguration beanstalkApplication,
@@ -122,6 +128,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             string enhancedHealthReporting = Recipe.ENHANCED_HEALTH_REPORTING)
         {
             ApplicationIAMRole = applicationIAMRole;
+            ServiceIAMRole = serviceIAMRole;
             InstanceType = instanceType;
             BeanstalkEnvironment = beanstalkEnvironment;
             BeanstalkApplication = beanstalkApplication;

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -258,6 +258,57 @@
             ]
         },
         {
+            "Id": "ServiceIAMRole",
+            "Name": "Service IAM Role",
+            "Description": "A service role is the IAM role that Elastic Beanstalk assumes when calling other services on your behalf.",
+            "Type": "Object",
+            "TypeHint": "IAMRole",
+            "TypeHintData": {
+                "ServicePrincipal": "elasticbeanstalk.amazonaws.com"
+            },
+            "AdvancedSetting": false,
+            "Updatable": false,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New Role",
+                    "Description": "Do you want to create a new role?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
+                },
+                {
+                    "Id": "RoleArn",
+                    "Name": "Existing Role ARN",
+                    "Description": "The ARN of the existing role to use.",
+                    "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "elasticbeanstalk.amazonaws.com"
+                    },
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "ServiceIAMRole.CreateNew",
+                            "Value": false
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration" : {
+                                "Regex": "arn:.+:iam::[0-9]{12}:.+",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid IAM Role ARN. The ARN should contain the arn:[PARTITION]:iam namespace, followed by the account ID, and then the resource path. For example - arn:aws:iam::123456789012:role/S3Access is a valid IAM Role ARN. For more information visit https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "Id": "EC2KeyPair",
             "Name": "Key Pair",
             "Description": "The EC2 key pair used to SSH into EC2 instances for the Elastic Beanstalk environment.",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -213,7 +213,7 @@
             "Type": "Object",
             "TypeHint": "IAMRole",
             "TypeHintData": {
-                "ServicePrincipal": "elasticbeanstalk.amazonaws.com"
+                "ServicePrincipal": "ec2.amazonaws.com"
             },
             "AdvancedSetting": false,
             "Updatable": false,
@@ -234,7 +234,7 @@
                     "Type": "String",
                     "TypeHint": "ExistingIAMRole",
                     "TypeHintData": {
-                        "ServicePrincipal": "elasticbeanstalk.amazonaws.com"
+                        "ServicePrincipal": "ec2.amazonaws.com"
                     },
                     "AdvancedSetting": false,
                     "Updatable": false,


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5561

*Description of changes:*
This PR makes the following changes to the Elastic Beanstalk deployment configuration.
* Fixes a bug where the service principal for Application IAM Role is incorrectly set to _**"elasticbeanstalk.amazonaws.com"**_. It should be set to _**"ec2.amazonaws.com"**_
* Introduces a Service IAM Role option setting as part of the recipe and the corresponding CDK template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
