### PR TITLE
feat: Add TypeHintData to GetConfigSettings response in Server Mode

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -193,6 +193,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 var settingSummary = new OptionSettingItemSummary(setting.Id, setting.Name, setting.Description, setting.Type.ToString())
                 {
                     TypeHint = setting.TypeHint?.ToString(),
+                    TypeHintData = setting.TypeHintData,
                     Value = recommendation.GetOptionSettingValue(setting),
                     Advanced = setting.AdvancedSetting,
                     ReadOnly = recommendation.IsExistingCloudApplication && !setting.Updatable,

--- a/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
@@ -20,6 +20,8 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public string? TypeHint { get; set; }
 
+        public Dictionary<string, object> TypeHintData { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
         public bool Advanced { get; set; }
 
         public bool ReadOnly { get; set; }

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1861,6 +1861,9 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("typeHint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string TypeHint { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("typeHintData", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.IDictionary<string, object> TypeHintData { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("advanced", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool Advanced { get; set; }
     


### PR DESCRIPTION
*Description of changes:*
On behalf of @awschristou and #499 

This change updates the GetConfigSettingsAsync response to include TypeHintData information. This will allow the Toolkit to show a filtered list of Roles for settings that have a ServicePrincipal associated with them. Users will be less likely to configure deployments involving IAM Roles that do not have appropriate permissions.

I added an integration test to confirm that TypeHintData properties are being returned. I extracted code from an existing test into methods so that I could re-use it. No logic changes were made to the extracted code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
