### PR TITLE
fix: ask for "Create New" even if options to select is empty

### DIFF
--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -268,14 +268,27 @@ namespace AWS.Deploy.CLI
                     defaultValue = userInputConfiguration.CreateNew || !options.Any() ? createNewLabel : userInputConfiguration.DisplaySelector(options.First());
             }
 
-            if (optionStrings.Any())
-            {
-                var displayOptionStrings = new List<string>(optionStrings);
-                if (userInputConfiguration.EmptyOption)
-                    displayOptionStrings.Insert(0, Constants.CLI.EMPTY_LABEL);
-                if (userInputConfiguration.CreateNew)
-                    displayOptionStrings.Add(createNewLabel);
+            var displayOptionStrings = new List<string>();
 
+            // add empty option at the top if configured
+            if (userInputConfiguration.EmptyOption)
+            {
+                displayOptionStrings.Add(Constants.CLI.EMPTY_LABEL);
+            }
+
+            // add all the options, this can be empty list if there are no options
+            // e.g. selecting a role for a service when there are no roles with a service principal
+            displayOptionStrings.AddRange(optionStrings);
+
+            // add create new option at the bottom if configured
+            if (userInputConfiguration.CreateNew)
+            {
+                displayOptionStrings.Add(createNewLabel);
+            }
+
+            // if list contains any options, ask user to choose one
+            if (displayOptionStrings.Any())
+            {
                 var selectedString = AskUserToChoose(displayOptionStrings, title, defaultValue, defaultChoosePrompt);
 
                 if (selectedString == Constants.CLI.EMPTY_LABEL)

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -157,6 +157,37 @@ namespace AWS.Deploy.CLI.UnitTests
         }
 
         [Fact]
+        public void AskUserToChooseOrCreateNewNoOptions()
+        {
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "1"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager);
+            var userInputConfiguration = new UserInputConfiguration<OptionItem>(
+                option => option.DisplayName,
+                option => option.DisplayName,
+                option => option.Identifier.Equals("Identifier2"),
+                "NewIdentifier")
+            {
+                AskNewName = false,
+                CreateNew = true,
+                EmptyOption = false
+            };
+            var userResponse = consoleUtilities.AskUserToChooseOrCreateNew(Array.Empty<OptionItem>(), "Title", userInputConfiguration);
+
+            Assert.Equal("Title", interactiveServices.OutputMessages[0]);
+
+            Assert.True(interactiveServices.OutputContains("Title"));
+            Assert.True(interactiveServices.OutputContains("1: *** Create new *** (default)"));
+
+            Assert.True(userResponse.CreateNew);
+            Assert.Null(userResponse.SelectedOption);
+            Assert.Null(userResponse.NewName);
+            Assert.False(userResponse.IsEmpty);
+        }
+
+        [Fact]
         public void AskUserToChooseStringsPickDefault()
         {
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string> { "" });


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

## Motivation
`AskUserToChooseOrCreateNew` allows users to select an existing option or create new one. When there are no options to select, **Create New** is not shown and CLI returns to previous screen with default selection **Create New** which is correct in theory because that's the only action user can take. However, this is not a good UX.

## Changes
The check to display selection is moved to (Options + **Empty** + **Create New**) combination, i.e. if any of the options are present, user will be asked to pick one. If none of the exists, the there is modeling error and should be handled at recipe level.

## Result
In cases like selecting ECS application role and there doesn't exist any compatible role in AWS account, customer is still asked to picked Create New.

Before

https://user-images.githubusercontent.com/8882380/164570933-dfa28f01-ce58-48ea-8dec-ace2ef1f5869.mp4

After

https://user-images.githubusercontent.com/8882380/164571049-8638d335-e0a0-4cd0-8521-53e260a1cf48.mp4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
