### PR TITLE
fix: add missing Type attribute to option setting in AppRunner recipe

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -402,6 +402,7 @@
                     "Id": "VpcId",
                     "Name": "VPC ID",
                     "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
+                    "Type": "String",
                     "TypeHint": "ExistingVpc",
                     "DefaultValue": null,
                     "AdvancedSetting": false,


### PR DESCRIPTION
*Description of changes:*
VPCConnector child setting VpcId is missing the Type attribute. The current behavior does not cause any issues since VPCConnector uses a typehint and does not need to access the Type of the child settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
