### PR TITLE
fix: server mode startup code not very resilient

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.ServerMode.Client/CommandLineWrapper.cs
@@ -45,9 +45,22 @@ namespace AWS.Deploy.ServerMode.Client
                 throw new InvalidOperationException();
             }
 
-            foreach (var line in stdIn)
+            try
             {
-                await process.StandardInput.WriteLineAsync(line).ConfigureAwait(false);
+                foreach (var line in stdIn)
+                {
+                    await process.StandardInput.WriteLineAsync(line).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                process.Kill();
+
+                return await Task.FromResult(new RunResult
+                {
+                    ExitCode = -1,
+                    StandardError = ex.Message
+                }).ConfigureAwait(false);
             }
 
             process.OutputDataReceived += (sender, e) =>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5792

*Description of changes:*
Added a try catch block to catch the exception thrown when trying to write to the StandardInput which caused an issue in the toolkit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
