### PR TITLE
fix: catch AmazonServiceException on making calls to AWS services and wrap into DeployToolException

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -108,7 +108,8 @@ namespace AWS.Deploy.Common
         FailedToRunCDKBootstrap = 10008800,
         FailedToGetCredentialsForProfile = 10008900,
         FailedToRunCDKDiff = 10009000,
-        FailedToCreateCDKProject = 10009100
+        FailedToCreateCDKProject = 10009100,
+        ResourceQuery = 10009200
     }
 
     public class ProjectFileNotFoundException : DeployToolException
@@ -244,6 +245,15 @@ namespace AWS.Deploy.Common
     {
         public FailedToDeserializeException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+
+    /// <summary>
+    /// Exception thrown if a failure occured while querying resources in AWS. It must be used in conjunction with <see cref="DeployToolErrorCode.ResourceQuery"/>.
+    /// </summary>
+    public class ResourceQueryException : DeployToolException
+    {
+        public ResourceQueryException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
 
     public static class ExceptionExtensions
     {

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.AppRunner.Model;
@@ -28,6 +29,7 @@ using Amazon.ElasticLoadBalancingV2;
 using Amazon.ElasticLoadBalancingV2.Model;
 using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
+using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
@@ -103,17 +105,20 @@ namespace AWS.Deploy.Orchestration.Data
                     new Filter()
                     {
                         Name = "vpc-id",
-                        Values = new List<string> { vpcID }
+                        Values = new List<string>
+                        {
+                            vpcID
+                        }
                     }
                 };
 
             if (string.IsNullOrEmpty(vpcID))
                 return new List<Subnet>();
 
-            return await ec2Client.Paginators
+            return await HandleException(async () => await ec2Client.Paginators
                 .DescribeSubnets(request)
                 .Subnets
-                .ToListAsync();
+                .ToListAsync());
         }
 
         /// <summary>
@@ -131,33 +136,31 @@ namespace AWS.Deploy.Orchestration.Data
                     new Filter()
                     {
                         Name = "vpc-id",
-                        Values = new List<string> { vpcID }
+                        Values = new List<string>
+                        {
+                            vpcID
+                        }
                     }
                 };
 
             if (string.IsNullOrEmpty(vpcID))
                 return new List<SecurityGroup>();
 
-            return await ec2Client.Paginators
+            return await HandleException(async () => await ec2Client.Paginators
                 .DescribeSecurityGroups(request)
                 .SecurityGroups
-                .ToListAsync();
+                .ToListAsync());
         }
 
         public async Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName)
         {
             var cfClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
-            var stackEvents = new List<StackEvent>();
-            var listInstanceTypesPaginator = cfClient.Paginators.DescribeStackEvents(new DescribeStackEventsRequest {
+            var listInstanceTypesPaginator = cfClient.Paginators.DescribeStackEvents(new DescribeStackEventsRequest
+            {
                 StackName = stackName
             });
 
-            await foreach (var response in listInstanceTypesPaginator.Responses)
-            {
-                stackEvents.AddRange(response.StackEvents);
-            }
-
-            return stackEvents;
+            return await HandleException(async () => await listInstanceTypesPaginator.StackEvents.ToListAsync());
         }
 
         public async Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes()
@@ -166,111 +169,135 @@ namespace AWS.Deploy.Orchestration.Data
             var instanceTypes = new List<InstanceTypeInfo>();
             var listInstanceTypesPaginator = ec2Client.Paginators.DescribeInstanceTypes(new DescribeInstanceTypesRequest());
 
-            await foreach (var response in listInstanceTypesPaginator.Responses)
+            return await HandleException(async () =>
             {
-                instanceTypes.AddRange(response.InstanceTypes);
-            }
+                await foreach (var response in listInstanceTypesPaginator.Responses)
+                {
+                    instanceTypes.AddRange(response.InstanceTypes);
+                }
 
-            return instanceTypes;
+                return instanceTypes;
+            });
         }
 
         public async Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors()
         {
             var appRunnerClient = _awsClientFactory.GetAWSClient<Amazon.AppRunner.IAmazonAppRunner>();
-            var connections = await appRunnerClient.ListVpcConnectorsAsync(new Amazon.AppRunner.Model.ListVpcConnectorsRequest());
-            return connections.VpcConnectors;
+            return await HandleException(async () =>
+            {
+                var connections = await appRunnerClient.ListVpcConnectorsAsync(new ListVpcConnectorsRequest());
+                return connections.VpcConnectors;
+            });
         }
 
         public async Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn)
         {
             var appRunnerClient = _awsClientFactory.GetAWSClient<Amazon.AppRunner.IAmazonAppRunner>();
 
-            var service = (await appRunnerClient.DescribeServiceAsync(new Amazon.AppRunner.Model.DescribeServiceRequest
+            return await HandleException(async () =>
             {
-                ServiceArn = serviceArn
-            })).Service;
+                var service = (await appRunnerClient.DescribeServiceAsync(new DescribeServiceRequest
+                {
+                    ServiceArn = serviceArn
+                })).Service;
 
-            if (service == null)
-            {
-                throw new AWSResourceNotFoundException(DeployToolErrorCode.AppRunnerServiceDoesNotExist, $"The AppRunner service '{serviceArn}' does not exist.");
-            }
+                if (service == null)
+                {
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.AppRunnerServiceDoesNotExist, $"The AppRunner service '{serviceArn}' does not exist.");
+                }
 
-            return service;
+                return service;
+            });
         }
 
         public async Task<List<StackResource>> DescribeCloudFormationResources(string stackName)
         {
             var cfClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
-            var resources = await cfClient.DescribeStackResourcesAsync(new DescribeStackResourcesRequest { StackName = stackName });
+            return await HandleException(async () =>
+            {
+                var resources = await cfClient.DescribeStackResourcesAsync(new DescribeStackResourcesRequest { StackName = stackName });
 
-            return resources.StackResources;
+                return resources.StackResources;
+            });
         }
 
         public async Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentName)
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
-
-            var environment = await beanstalkClient.DescribeEnvironmentsAsync(new DescribeEnvironmentsRequest {
-                EnvironmentNames = new List<string> { environmentName }
-            });
-
-            if (!environment.Environments.Any())
+            return await HandleException(async () =>
             {
-                throw new AWSResourceNotFoundException(DeployToolErrorCode.BeanstalkEnvironmentDoesNotExist, $"The elastic beanstalk environment '{environmentName}' does not exist.");
-            }
+                var environment = await beanstalkClient.DescribeEnvironmentsAsync(new DescribeEnvironmentsRequest {
+                    EnvironmentNames = new List<string> { environmentName }
+                });
 
-            return environment.Environments.First();
+                if (!environment.Environments.Any())
+                {
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.BeanstalkEnvironmentDoesNotExist, $"The elastic beanstalk environment '{environmentName}' does not exist.");
+                }
+
+                return environment.Environments.First();
+            });
         }
 
         public async Task<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn)
         {
             var elasticLoadBalancingClient = _awsClientFactory.GetAWSClient<IAmazonElasticLoadBalancingV2>();
 
-            var loadBalancers = await elasticLoadBalancingClient.DescribeLoadBalancersAsync(new DescribeLoadBalancersRequest
-            {
-                LoadBalancerArns = new List<string> { loadBalancerArn }
+            return await HandleException(async () => {
+
+                var loadBalancers = await elasticLoadBalancingClient.DescribeLoadBalancersAsync(new DescribeLoadBalancersRequest
+                {
+                    LoadBalancerArns = new List<string>
+                    {
+                        loadBalancerArn
+                    }
+                });
+
+                if (!loadBalancers.LoadBalancers.Any())
+                {
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.LoadBalancerDoesNotExist, $"The load balancer '{loadBalancerArn}' does not exist.");
+                }
+
+                return loadBalancers.LoadBalancers.First();
             });
-
-            if (!loadBalancers.LoadBalancers.Any())
-            {
-                throw new AWSResourceNotFoundException(DeployToolErrorCode.LoadBalancerDoesNotExist, $"The load balancer '{loadBalancerArn}' does not exist.");
-            }
-
-            return loadBalancers.LoadBalancers.First();
         }
 
         public async Task<List<Amazon.ElasticLoadBalancingV2.Model.Listener>> DescribeElasticLoadBalancerListeners(string loadBalancerArn)
         {
             var elasticLoadBalancingClient = _awsClientFactory.GetAWSClient<IAmazonElasticLoadBalancingV2>();
-
-            var listeners = await elasticLoadBalancingClient.DescribeListenersAsync(new DescribeListenersRequest
+            return await HandleException(async () =>
             {
-                LoadBalancerArn = loadBalancerArn
+                var listeners = await elasticLoadBalancingClient.DescribeListenersAsync(new DescribeListenersRequest
+                {
+                    LoadBalancerArn = loadBalancerArn
+                });
+
+                if (!listeners.Listeners.Any())
+                {
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.LoadBalancerListenerDoesNotExist, $"The load balancer '{loadBalancerArn}' does not have any listeners.");
+                }
+
+                return listeners.Listeners;
             });
-
-            if (!listeners.Listeners.Any())
-            {
-                throw new AWSResourceNotFoundException(DeployToolErrorCode.LoadBalancerListenerDoesNotExist, $"The load balancer '{loadBalancerArn}' does not have any listeners.");
-            }
-
-            return listeners.Listeners;
         }
 
         public async Task<DescribeRuleResponse> DescribeCloudWatchRule(string ruleName)
         {
             var cloudWatchEventsClient = _awsClientFactory.GetAWSClient<IAmazonCloudWatchEvents>();
-
-            var rule = await cloudWatchEventsClient.DescribeRuleAsync(new DescribeRuleRequest
+            return await HandleException(async () =>
             {
-                Name = ruleName
+                var rule = await cloudWatchEventsClient.DescribeRuleAsync(new DescribeRuleRequest
+                {
+                    Name = ruleName
+                });
+
+                if (rule == null)
+                {
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.CloudWatchRuleDoesNotExist, $"The CloudWatch rule'{ruleName}' does not exist.");
+                }
+
+                return rule;
             });
-
-            if (rule == null)
-            {
-                throw new AWSResourceNotFoundException(DeployToolErrorCode.CloudWatchRuleDoesNotExist, $"The CloudWatch rule'{ruleName}' does not exist.");
-            }
-
-            return rule;
         }
 
         public async Task<string> GetS3BucketLocation(string bucketName)
@@ -282,7 +309,7 @@ namespace AWS.Deploy.Orchestration.Data
 
             var s3Client = _awsClientFactory.GetAWSClient<IAmazonS3>();
 
-            var location = await s3Client.GetBucketLocationAsync(bucketName);
+            var location = await HandleException(async () => await s3Client.GetBucketLocationAsync(bucketName));
 
             var region = "";
             if (location.Location.Equals(S3Region.USEast1))
@@ -299,7 +326,7 @@ namespace AWS.Deploy.Orchestration.Data
         {
             var s3Client = _awsClientFactory.GetAWSClient<IAmazonS3>();
 
-            var response = await s3Client.GetBucketWebsiteAsync(bucketName);
+            var response = await HandleException(async () => await s3Client.GetBucketWebsiteAsync(bucketName));
 
             return response.WebsiteConfiguration;
         }
@@ -308,14 +335,17 @@ namespace AWS.Deploy.Orchestration.Data
         {
             var ecsClient = _awsClientFactory.GetAWSClient<IAmazonECS>();
 
-            var clusterArns = await ecsClient.Paginators
-                .ListClusters(new ListClustersRequest())
-                .ClusterArns
-                .ToListAsync();
-
-            var clusters = await ecsClient.DescribeClustersAsync(new DescribeClustersRequest
+            var clusters = await HandleException(async () =>
             {
-                Clusters = clusterArns
+                var clusterArns = await ecsClient.Paginators
+                    .ListClusters(new ListClustersRequest())
+                    .ClusterArns
+                    .ToListAsync();
+
+                return await ecsClient.DescribeClustersAsync(new DescribeClustersRequest
+                {
+                    Clusters = clusterArns
+                });
             });
 
             return clusters.Clusters;
@@ -324,39 +354,42 @@ namespace AWS.Deploy.Orchestration.Data
         public async Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications()
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
-            var applications = await beanstalkClient.DescribeApplicationsAsync();
+            var applications = await HandleException(async () => await beanstalkClient.DescribeApplicationsAsync());
             return applications.Applications;
         }
 
         public async Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName = null)
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
-            var environments = new List<EnvironmentDescription>();
 
             var request = new DescribeEnvironmentsRequest
             {
                 ApplicationName = applicationName
             };
 
-            do
+            return await HandleException(async () =>
             {
-                var response = await beanstalkClient.DescribeEnvironmentsAsync(request);
-                request.NextToken = response.NextToken;
+                var environments = new List<EnvironmentDescription>();
+                do
+                {
+                    var response = await beanstalkClient.DescribeEnvironmentsAsync(request);
+                    request.NextToken = response.NextToken;
 
-                environments.AddRange(response.Environments);
+                    environments.AddRange(response.Environments);
 
-            } while (!string.IsNullOrEmpty(request.NextToken));
+                } while (!string.IsNullOrEmpty(request.NextToken));
 
-            return environments;
+                return environments;
+            });
         }
 
         public async Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn)
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
-            var response = await beanstalkClient.ListTagsForResourceAsync(new Amazon.ElasticBeanstalk.Model.ListTagsForResourceRequest
+            var response = await HandleException(async () => await beanstalkClient.ListTagsForResourceAsync(new Amazon.ElasticBeanstalk.Model.ListTagsForResourceRequest
             {
                 ResourceArn = resourceArn
-            });
+            }));
 
             return response.ResourceTags;
         }
@@ -364,7 +397,7 @@ namespace AWS.Deploy.Orchestration.Data
         public async Task<List<KeyPairInfo>> ListOfEC2KeyPairs()
         {
             var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>();
-            var response = await ec2Client.DescribeKeyPairsAsync();
+            var response = await HandleException(async () => await ec2Client.DescribeKeyPairsAsync());
 
             return response.KeyPairs;
         }
@@ -375,9 +408,9 @@ namespace AWS.Deploy.Orchestration.Data
 
             var request = new CreateKeyPairRequest { KeyName = keyName };
 
-            var response = await ec2Client.CreateKeyPairAsync(request);
+            var response = await HandleException(async () => await ec2Client.CreateKeyPairAsync(request));
 
-            File.WriteAllText(Path.Combine(saveLocation, $"{keyName}.pem"), response.KeyPair.KeyMaterial);
+            await File.WriteAllTextAsync(Path.Combine(saveLocation, $"{keyName}.pem"), response.KeyPair.KeyMaterial);
 
             return response.KeyPair.KeyName;
         }
@@ -387,16 +420,19 @@ namespace AWS.Deploy.Orchestration.Data
             var identityManagementServiceClient = _awsClientFactory.GetAWSClient<IAmazonIdentityManagementService>();
 
             var listRolesRequest = new ListRolesRequest();
-            var roles = new List<Role>();
 
             var listStacksPaginator = identityManagementServiceClient.Paginators.ListRoles(listRolesRequest);
-            await foreach (var response in listStacksPaginator.Responses)
+            return await HandleException(async () =>
             {
-                var filteredRoles = response.Roles.Where(role => AssumeRoleServicePrincipalSelector(role, servicePrincipal));
-                roles.AddRange(filteredRoles);
-            }
+                var roles = new List<Role>();
+                await foreach (var response in listStacksPaginator.Responses)
+                {
+                    var filteredRoles = response.Roles.Where(role => AssumeRoleServicePrincipalSelector(role, servicePrincipal));
+                    roles.AddRange(filteredRoles);
+                }
 
-            return roles;
+                return roles;
+            });
         }
 
         private static bool AssumeRoleServicePrincipalSelector(Role role, string? servicePrincipal)
@@ -410,12 +446,12 @@ namespace AWS.Deploy.Orchestration.Data
         {
             var vpcClient = _awsClientFactory.GetAWSClient<IAmazonEC2>();
 
-            return await vpcClient.Paginators
+            return await HandleException(async () => await vpcClient.Paginators
                 .DescribeVpcs(new DescribeVpcsRequest())
                 .Vpcs
                 .OrderByDescending(x => x.IsDefault)
                 .ThenBy(x => x.VpcId)
-                .ToListAsync();
+                .ToListAsync());
         }
 
         public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns()
@@ -434,7 +470,7 @@ namespace AWS.Deploy.Orchestration.Data
                     }
                 }
             };
-            var response = await beanstalkClient.ListPlatformVersionsAsync(request);
+            var response = await HandleException(async () => await beanstalkClient.ListPlatformVersionsAsync(request));
 
             var platformVersions = new List<PlatformSummary>();
             foreach (var version in response.PlatformSummaryList)
@@ -470,7 +506,7 @@ namespace AWS.Deploy.Orchestration.Data
         {
             var ecrClient = _awsClientFactory.GetAWSClient<IAmazonECR>();
 
-            var response = await ecrClient.GetAuthorizationTokenAsync(new GetAuthorizationTokenRequest());
+            var response = await HandleException(async () => await ecrClient.GetAuthorizationTokenAsync(new GetAuthorizationTokenRequest()));
 
             return response.AuthorizationData;
         }
@@ -484,19 +520,19 @@ namespace AWS.Deploy.Orchestration.Data
                 RepositoryNames = repositoryNames
             };
 
-            try
+            return await HandleException(async () =>
             {
-                return (await ecrClient.Paginators
-                    .DescribeRepositories(request)
-                    .Repositories
-                    .ToListAsync())
-                    .OrderByDescending(x => x.CreatedAt)
-                    .ToList();
-            }
-            catch (RepositoryNotFoundException)
-            {
-                return new List<Repository>();
-            }
+                try
+                {
+                    return (await ecrClient.Paginators.DescribeRepositories(request).Repositories.ToListAsync())
+                        .OrderByDescending(x => x.CreatedAt)
+                        .ToList();
+                }
+                catch (RepositoryNotFoundException)
+                {
+                    return new List<Repository>();
+                }
+            });
         }
 
         public async Task<Repository> CreateECRRepository(string repositoryName)
@@ -508,137 +544,114 @@ namespace AWS.Deploy.Orchestration.Data
                 RepositoryName = repositoryName
             };
 
-            var response = await ecrClient.CreateRepositoryAsync(request);
+            var response = await HandleException(async () => await ecrClient.CreateRepositoryAsync(request));
 
             return response.Repository;
         }
 
         public async Task<List<Stack>> GetCloudFormationStacks()
         {
-            using var cloudFormationClient = _awsClientFactory.GetAWSClient<Amazon.CloudFormation.IAmazonCloudFormation>();
-            return await cloudFormationClient.Paginators.DescribeStacks(new DescribeStacksRequest()).Stacks.ToListAsync();
+            using var cloudFormationClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
+            return await HandleException(async () => await cloudFormationClient.Paginators
+                .DescribeStacks(new DescribeStacksRequest())
+                .Stacks.ToListAsync());
         }
 
         public async Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion)
         {
             var request = new GetCallerIdentityRequest();
+            using var stsClient = _awsClientFactory.GetAWSClient<IAmazonSecurityTokenService>(awsRegion);
 
-            try
+            return await HandleException(async () =>
             {
-                using var stsClient = _awsClientFactory.GetAWSClient<IAmazonSecurityTokenService>(awsRegion);
-                return await stsClient.GetCallerIdentityAsync(request);
-            }
-            catch (Exception ex)
-            {
-                var regionEndpointPartition = RegionEndpoint.GetBySystemName(awsRegion).PartitionName ?? String.Empty;
-                if (regionEndpointPartition.Equals("aws") && !awsRegion.Equals(Constants.CLI.DEFAULT_STS_AWS_REGION))
+                try
                 {
-                    try
+                    return await stsClient.GetCallerIdentityAsync(request);
+                }
+                catch (Exception ex)
+                {
+                    var regionEndpointPartition = RegionEndpoint.GetBySystemName(awsRegion).PartitionName ?? String.Empty;
+                    if (regionEndpointPartition.Equals("aws") && !awsRegion.Equals(Constants.CLI.DEFAULT_STS_AWS_REGION))
                     {
-                        using var stsClient = _awsClientFactory.GetAWSClient<IAmazonSecurityTokenService>(Constants.CLI.DEFAULT_STS_AWS_REGION);
-                        await stsClient.GetCallerIdentityAsync(request);
-                    }
-                    catch (Exception e)
-                    {
+                        try
+                        {
+                            using var defaultRegionStsClient = _awsClientFactory.GetAWSClient<IAmazonSecurityTokenService>(Constants.CLI.DEFAULT_STS_AWS_REGION);
+                            await defaultRegionStsClient.GetCallerIdentityAsync(request);
+                        }
+                        catch (Exception e)
+                        {
+                            throw new UnableToAccessAWSRegionException(
+                                DeployToolErrorCode.UnableToAccessAWSRegion,
+                                $"We were unable to access the AWS region '{awsRegion}'. Make sure you have correct permissions for that region and the region is accessible.",
+                                e);
+                        }
+
                         throw new UnableToAccessAWSRegionException(
-                           DeployToolErrorCode.UnableToAccessAWSRegion,
-                           $"We were unable to access the AWS region '{awsRegion}'. Make sure you have correct permissions for that region and the region is accessible.",
-                           e);
+                            DeployToolErrorCode.OptInRegionDisabled,
+                            $"We were unable to access the Opt-In region '{awsRegion}'. Please enable the AWS Region '{awsRegion}' and try again. Additional details could be found at https://docs.aws.amazon.com/general/latest/gr/rande-manage.html",
+                            ex);
                     }
 
                     throw new UnableToAccessAWSRegionException(
-                        DeployToolErrorCode.OptInRegionDisabled,
-                        $"We were unable to access the Opt-In region '{awsRegion}'. Please enable the AWS Region '{awsRegion}' and try again. Additional details could be found at https://docs.aws.amazon.com/general/latest/gr/rande-manage.html",
+                        DeployToolErrorCode.UnableToAccessAWSRegion,
+                        $"We were unable to access the AWS region '{awsRegion}'. Make sure you have correct permissions for that region and the region is accessible.",
                         ex);
                 }
-
-                throw new UnableToAccessAWSRegionException(
-                   DeployToolErrorCode.UnableToAccessAWSRegion,
-                   $"We were unable to access the AWS region '{awsRegion}'. Make sure you have correct permissions for that region and the region is accessible.",
-                   ex);
-            }
+            });
         }
 
         public async Task<List<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer>> ListOfLoadBalancers(Amazon.ElasticLoadBalancingV2.LoadBalancerTypeEnum loadBalancerType)
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonElasticLoadBalancingV2>();
 
-            var loadBalancers = new List<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer>();
-
-            await foreach(var loadBalancer in client.Paginators.DescribeLoadBalancers(new DescribeLoadBalancersRequest()).LoadBalancers)
+            return await HandleException(async () =>
             {
-                if(loadBalancer.Type == loadBalancerType)
-                {
-                    loadBalancers.Add(loadBalancer);
-                }
-            }
-
-            return loadBalancers;
+                return await client.Paginators.DescribeLoadBalancers(new DescribeLoadBalancersRequest())
+                    .LoadBalancers.Where(loadBalancer => loadBalancer.Type == loadBalancerType)
+                    .ToListAsync();
+            });
         }
 
         public async Task<Distribution> GetCloudFrontDistribution(string distributionId)
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonCloudFront>();
 
-            var response = await client.GetDistributionAsync(new GetDistributionRequest
+            return await HandleException(async () =>
             {
-                Id = distributionId
-            });
+                var response = await client.GetDistributionAsync(new GetDistributionRequest
+                {
+                    Id = distributionId
+                });
 
-            return response.Distribution;
+                return response.Distribution;
+            });
         }
 
         public async Task<List<string>> ListOfDyanmoDBTables()
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonDynamoDB>();
-
-            var tables = new List<string>();
-
-            await foreach(var table in client.Paginators.ListTables(new ListTablesRequest()).TableNames)
-            {
-                tables.Add(table);
-            }
-
-            return tables;
+            return await HandleException(async () => await client.Paginators.ListTables(new ListTablesRequest()).TableNames.ToListAsync());
         }
 
         public async Task<List<string>> ListOfSQSQueuesUrls()
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonSQS>();
-
-            var queueUrls = new List<string>();
-            await foreach(var queueUrl in client.Paginators.ListQueues(new ListQueuesRequest()).QueueUrls)
-            {
-                queueUrls.Add(queueUrl);
-            }
-
-            return queueUrls;
+            return await HandleException(async () => await client.Paginators.ListQueues(new ListQueuesRequest()).QueueUrls.ToListAsync());
         }
 
         public async Task<List<string>> ListOfSNSTopicArns()
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonSimpleNotificationService>();
-
-            var arns = new List<string>();
-            await foreach (var topic in client.Paginators.ListTopics(new ListTopicsRequest()).Topics)
+            return await HandleException(async () =>
             {
-                arns.Add(topic.TopicArn);
-            }
-
-            return arns;
+                return await client.Paginators.ListTopics(new ListTopicsRequest()).Topics.Select(topic => topic.TopicArn).ToListAsync();
+            });
         }
 
         public async Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets()
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonS3>();
-
-            var buckets = new List<Amazon.S3.Model.S3Bucket>();
-            foreach (var bucket in (await client.ListBucketsAsync()).Buckets)
-            {
-                buckets.Add(bucket);
-            }
-
-            return buckets;
+            return await HandleException(async () => (await client.ListBucketsAsync()).Buckets.ToList());
         }
 
         public async Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentName)
@@ -646,41 +659,69 @@ namespace AWS.Deploy.Orchestration.Data
             var optionSetting = new List<ConfigurationOptionSetting>();
             var environmentDescription = await DescribeElasticBeanstalkEnvironment(environmentName);
             var client = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
-            var response = await client.DescribeConfigurationSettingsAsync(new DescribeConfigurationSettingsRequest
+            return await HandleException(async () =>
             {
-                ApplicationName = environmentDescription.ApplicationName,
-                EnvironmentName = environmentName
-            });
-
-            foreach (var settingDescription in response.ConfigurationSettings)
-            {
-                foreach (var setting in settingDescription.OptionSettings)
+                var response = await client.DescribeConfigurationSettingsAsync(new DescribeConfigurationSettingsRequest
                 {
-                    optionSetting.Add(setting);
-                }
-            }
+                    ApplicationName = environmentDescription.ApplicationName,
+                    EnvironmentName = environmentName
+                });
 
-            return optionSetting;
+                optionSetting.AddRange(response.ConfigurationSettings.SelectMany(settingDescription => settingDescription.OptionSettings));
+
+                return optionSetting;
+            });
         }
 
         public async Task<Repository> DescribeECRRepository(string respositoryName)
         {
             var client = _awsClientFactory.GetAWSClient<IAmazonECR>();
+            return await HandleException(async () =>
+            {
 
-            DescribeRepositoriesResponse response;
+                DescribeRepositoriesResponse response;
+                try
+                {
+                    response = await client.DescribeRepositoriesAsync(new DescribeRepositoriesRequest
+                    {
+                        RepositoryNames = new List<string> { respositoryName }
+                    });
+                }
+                catch (RepositoryNotFoundException ex)
+                {
+                    throw new AWSResourceNotFoundException(DeployToolErrorCode.ECRRepositoryDoesNotExist, $"The ECR repository {respositoryName} does not exist.", ex);
+                }
+
+                return response.Repositories.First();
+            });
+        }
+
+        private async Task<T> HandleException<T>(Func<Task<T>> action)
+        {
             try
             {
-                response = await client.DescribeRepositoriesAsync(new DescribeRepositoriesRequest
-                {
-                    RepositoryNames = new List<string> { respositoryName }
-                });
+                return await action();
             }
-            catch (RepositoryNotFoundException ex)
+            catch (AmazonServiceException e)
             {
-                throw new AWSResourceNotFoundException(DeployToolErrorCode.ECRRepositoryDoesNotExist, $"The ECR repository {respositoryName} does not exist.", ex);
-            }
+                var messageBuilder = new StringBuilder();
+                if (!string.IsNullOrEmpty(e.ErrorCode))
+                {
+                    messageBuilder.AppendLine($"{e.ErrorCode}");
+                }
 
-            return response.Repositories.First();
+                if (!string.IsNullOrEmpty(e.Message))
+                {
+                    messageBuilder.AppendLine(e.Message);
+                }
+
+                if (messageBuilder.Length == 0)
+                {
+                    messageBuilder.Append($"An unknown error occurred while communicating with AWS.{Environment.NewLine}");
+                }
+
+                throw new ResourceQueryException(DeployToolErrorCode.ResourceQuery, messageBuilder.ToString(), e);
+            }
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Motivation
When deploy tool makes call to AWS services and a service call fails, this is shown as bug to customer which in most cases are configuration issues such as not having correct permissions for the operation call made. This gives a false impression to customer that there a bug in the deploy tool.

## Changes
Similar to other places, this change wraps the AWS service calls to a try-catch block and if the exception is `AmazonServiceException` which is base exception for all operations, it is wrapped in a  `ResourceQueryException` i.e. a `DeployToolException` to make it an expected exception. Expected exceptions don't emit stacktrace unless `--diagnostics` is provided.

## Result
Case such as not having permission to make a operation call now, shows a ErrorCode and message instead showing stacktrace. On passing the `--diagnostics` flag, stacktrace is shown for debug purpose.

Before
```
┌ jangirg@REM-942XY33  netcoreapp3.1   jangirg/fix/aws-service-exception ≢ 4 
└ $ .\AWS.Deploy.CLI.exe deploy --project-path C:\Users\jangirg\source\repos\aws-dotnet-deploy\testapps\ConsoleAppTask
AWS .NET deployment tool for deploying .NET Core applications to AWS.
Project Home: https://github.com/aws/aws-dotnet-deploy

Configuring AWS Credentials using AWS SDK credential search.
Configuring AWS region using AWS SDK region search to us-west-2.
Unhandled exception.  This is a bug.  Please copy the stack trace below and file a bug at https://github.com/aws/aws-dotnet-deploy.
User: arn:aws:iam::123456789012:user/jangirg-limited is not authorized to perform: cloudformation:DescribeStacks because no identity-based policy allows the cloudformation:DescribeStacks action
   at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleExceptionStream(IRequestContext requestContext, IWebResponseData httpErrorResponse, HttpErrorResponseException exception, Stream responseStream)
   at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleExceptionAsync(IExecutionContext executionContext, HttpErrorResponseException exception)
   at Amazon.Runtime.Internal.ExceptionHandler`1.HandleAsync(IExecutionContext executionContext, Exception exception)
   at Amazon.Runtime.Internal.ErrorHandler.ProcessExceptionAsync(IExecutionContext executionContext, Exception exception)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.EndpointDiscoveryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.EndpointDiscoveryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CredentialsRetriever.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorCallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.MetricsHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.CloudFormation.Model.DescribeStacksPaginator.Amazon.Runtime.IPaginator<Amazon.CloudFormation.Model.DescribeStacksResponse>.PaginateAsync(CancellationToken cancellationToken)+MoveNext()
   at Amazon.CloudFormation.Model.DescribeStacksPaginator.Amazon.Runtime.IPaginator<Amazon.CloudFormation.Model.DescribeStacksResponse>.PaginateAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Amazon.Runtime.PaginatedResultKeyResponse`2.GetAsyncEnumerator(CancellationToken cancellationToken)+MoveNext()
   at Amazon.Runtime.PaginatedResultKeyResponse`2.GetAsyncEnumerator(CancellationToken cancellationToken)+MoveNext()
   at Amazon.Runtime.PaginatedResultKeyResponse`2.GetAsyncEnumerator(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at System.Linq.AsyncEnumerable.<ToListAsync>g__Core|620_0[TSource](IAsyncEnumerable`1 source, CancellationToken cancellationToken) in d:\a\1\s\Ix.NET\Source\System.Linq.Async\System\Linq\Operators\ToList.cs:line 27
   at System.Linq.AsyncEnumerable.<ToListAsync>g__Core|620_0[TSource](IAsyncEnumerable`1 source, CancellationToken cancellationToken) in d:\a\1\s\Ix.NET\Source\System.Linq.Async\System\Linq\Operators\ToList.cs:line 27
   at AWS.Deploy.Orchestration.Data.AWSResourceQueryer.GetCloudFormationStacks() in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Data\AWSResourceQueryer.cs:line 519
   at AWS.Deploy.Orchestration.Utilities.DeployedApplicationQueryer.GetExistingCloudFormationStacks() in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Utilities\DeployedApplicationQueryer.cs:line 162
   at AWS.Deploy.Orchestration.Utilities.DeployedApplicationQueryer.GetExistingDeployedApplications(List`1 deploymentTypes) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Utilities\DeployedApplicationQueryer.cs:line 64
   at AWS.Deploy.CLI.Commands.DeployCommand.InitializeDeployment(String applicationName, UserDeploymentSettings userDeploymentSettings, String deploymentProjectPath) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.CLI\Commands\DeployCommand.cs:line 171
   at AWS.Deploy.CLI.Commands.DeployCommand.ExecuteAsync(String applicationName, String deploymentProjectPath, UserDeploymentSettings userDeploymentSettings) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.CLI\Commands\DeployCommand.cs:line 101
   at AWS.Deploy.CLI.Commands.CommandFactory.<BuildDeployCommand>b__38_0(DeployCommandHandlerInput input) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.CLI\Commands\CommandFactory.cs:line 232
Exception of type 'Amazon.Runtime.Internal.HttpErrorResponseException' was thrown.
   at Amazon.Runtime.HttpWebRequestMessage.GetResponseAsync(CancellationToken cancellationToken)
   at Amazon.Runtime.Internal.HttpHandler`1.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.Unmarshaller.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
```

After without --diagnostics
```
┌ jangirg@REM-942XY33  netcoreapp3.1   jangirg/fix/aws-service-exception ≢ ~2 4  error 
└ $ .\AWS.Deploy.CLI.exe deploy --project-path C:\Users\jangirg\source\repos\aws-dotnet-deploy\testapps\ConsoleAppTask
AWS .NET deployment tool for deploying .NET Core applications to AWS.
Project Home: https://github.com/aws/aws-dotnet-deploy

Configuring AWS Credentials using AWS SDK credential search.
Configuring AWS region using AWS SDK region search to us-west-2.

AccessDenied
User: arn:aws:iam::123456789012:user/jangirg-limited is not authorized to perform: cloudformation:DescribeStacks because no identity-based policy allows the cloudformation:DescribeStacks action
```

After with --diagnostics

```
┌ jangirg@REM-942XY33  netcoreapp3.1   jangirg/fix/aws-service-exception ≢ ~2 4  error 
└ $ .\AWS.Deploy.CLI.exe deploy --project-path C:\Users\jangirg\source\repos\aws-dotnet-deploy\testapps\ConsoleAppTask --diagnostics
AWS .NET deployment tool for deploying .NET Core applications to AWS.
Project Home: https://github.com/aws/aws-dotnet-deploy

Configuring AWS Credentials using AWS SDK credential search.
Configuring AWS region using AWS SDK region search to us-west-2.

AccessDenied
User: arn:aws:iam::123456789012:user/jangirg-limited is not authorized to perform: cloudformation:DescribeStacks because no identity-based policy allows the cloudformation:DescribeStacks action
   at AWS.Deploy.Orchestration.Data.AWSResourceQueryer.HandleException[T](Func`1 action) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Data\AWSResourceQueryer.cs:line 727
   at AWS.Deploy.Orchestration.Data.AWSResourceQueryer.GetCloudFormationStacks() in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Data\AWSResourceQueryer.cs:line 558
   at AWS.Deploy.Orchestration.Utilities.DeployedApplicationQueryer.GetExistingCloudFormationStacks() in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Utilities\DeployedApplicationQueryer.cs:line 162
   at AWS.Deploy.Orchestration.Utilities.DeployedApplicationQueryer.GetExistingDeployedApplications(List`1 deploymentTypes) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Utilities\DeployedApplicationQueryer.cs:line 64
   at AWS.Deploy.CLI.Commands.DeployCommand.InitializeDeployment(String applicationName, UserDeploymentSettings userDeploymentSettings, String deploymentProjectPath) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.CLI\Commands\DeployCommand.cs:line 171
   at AWS.Deploy.CLI.Commands.DeployCommand.ExecuteAsync(String applicationName, String deploymentProjectPath, UserDeploymentSettings userDeploymentSettings) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.CLI\Commands\DeployCommand.cs:line 101
   at AWS.Deploy.CLI.Commands.CommandFactory.<BuildDeployCommand>b__38_0(DeployCommandHandlerInput input) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.CLI\Commands\CommandFactory.cs:line 232
User: arn:aws:iam::123456789012:user/jangirg-limited is not authorized to perform: cloudformation:DescribeStacks because no identity-based policy allows the cloudformation:DescribeStacks action
   at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleExceptionStream(IRequestContext requestContext, IWebResponseData httpErrorResponse, HttpErrorResponseException exception, Stream responseStream)
   at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleExceptionAsync(IExecutionContext executionContext, HttpErrorResponseException exception)
   at Amazon.Runtime.Internal.ExceptionHandler`1.HandleAsync(IExecutionContext executionContext, Exception exception)
   at Amazon.Runtime.Internal.ErrorHandler.ProcessExceptionAsync(IExecutionContext executionContext, Exception exception)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.EndpointDiscoveryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.EndpointDiscoveryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CredentialsRetriever.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorCallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.MetricsHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.CloudFormation.Model.DescribeStacksPaginator.Amazon.Runtime.IPaginator<Amazon.CloudFormation.Model.DescribeStacksResponse>.PaginateAsync(CancellationToken cancellationToken)+MoveNext()
   at Amazon.CloudFormation.Model.DescribeStacksPaginator.Amazon.Runtime.IPaginator<Amazon.CloudFormation.Model.DescribeStacksResponse>.PaginateAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Amazon.Runtime.PaginatedResultKeyResponse`2.GetAsyncEnumerator(CancellationToken cancellationToken)+MoveNext()
   at Amazon.Runtime.PaginatedResultKeyResponse`2.GetAsyncEnumerator(CancellationToken cancellationToken)+MoveNext()
   at Amazon.Runtime.PaginatedResultKeyResponse`2.GetAsyncEnumerator(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at System.Linq.AsyncEnumerable.<ToListAsync>g__Core|620_0[TSource](IAsyncEnumerable`1 source, CancellationToken cancellationToken) in d:\a\1\s\Ix.NET\Source\System.Linq.Async\System\Linq\Operators\ToList.cs:line 27
   at System.Linq.AsyncEnumerable.<ToListAsync>g__Core|620_0[TSource](IAsyncEnumerable`1 source, CancellationToken cancellationToken) in d:\a\1\s\Ix.NET\Source\System.Linq.Async\System\Linq\Operators\ToList.cs:line 27
   at AWS.Deploy.Orchestration.Data.AWSResourceQueryer.<>c__DisplayClass29_0.<<GetCloudFormationStacks>b__0>d.MoveNext() in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Data\AWSResourceQueryer.cs:line 558
--- End of stack trace from previous location where exception was thrown ---
   at AWS.Deploy.Orchestration.Data.AWSResourceQueryer.HandleException[T](Func`1 action) in C:\Users\jangirg\source\repos\aws-dotnet-deploy\src\AWS.Deploy.Orchestration\Data\AWSResourceQueryer.cs:line 706
Exception of type 'Amazon.Runtime.Internal.HttpErrorResponseException' was thrown.
   at Amazon.Runtime.HttpWebRequestMessage.GetResponseAsync(CancellationToken cancellationToken)
   at Amazon.Runtime.Internal.HttpHandler`1.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.Unmarshaller.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
