### PR TITLE
fix: Rename the "ECR Repository Name" advanced option to reference "ECR" instead of "ECS" for Docker-based recipes

### DIFF
--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -23,8 +23,8 @@
         },
         {
             "Id": "ECRRepositoryName",
-            "Name": "ECS Repository Name",
-            "Description": "Specifies the ECR repository where the docker images will be stored",
+            "Name": "ECR Repository Name",
+            "Description": "Specifies the ECR repository where the Docker images will be stored",
             "Type": "String",
             "TypeHint": "ECRRepository",
             "DefaultValue": "{DefaultECRRepositoryName}",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 

The name of this option references ECS even though we're technically pushing the image to an ECR repository (especially now that we have an ECR-only recipe). It appears this may have been a typo.

Before:
```
18. ECS Repository Name: aspnetwebapp

Or press 'Enter' to deploy:
18

ECS Repository Name:
Specifies the ECR repository where the docker images will be stored
Select ECR Repository:
----------------------
1 : aspnetwebapp
```

After:
```
18. ECR Repository Name: aspwebapi

Or press 'Enter' to deploy:
18

ECR Repository Name:
Specifies the ECR repository where the Docker images will be stored
Select ECR Repository:
----------------------
1 : aspnetwebapp
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
