### PR TITLE
feat: Rework deployment logging to have section headers

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -121,8 +121,7 @@ namespace AWS.Deploy.CLI.Commands
 
         private void DisplayOutputResources(List<DisplayedResourceItem> displayedResourceItems)
         {
-            _toolInteractiveService.WriteLine("Resources");
-            _toolInteractiveService.WriteLine("---------");
+            _orchestratorInteractiveService.LogSectionStart("AWS Resource Details", null);
             foreach (var resource in displayedResourceItems)
             {
                 _toolInteractiveService.WriteLine($"{resource.Description}:");
@@ -677,6 +676,9 @@ namespace AWS.Deploy.CLI.Commands
         {
             if (selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.Container)
             {
+                _orchestratorInteractiveService.LogSectionStart("Creating deployment image",
+                    "Using the docker CLI to perform a docker build to create a container image.");
+
                 while (!await orchestrator.CreateContainerDeploymentBundle(cloudApplication, selectedRecommendation))
                 {
                     if (_toolInteractiveService.DisableInteractive)
@@ -710,6 +712,9 @@ namespace AWS.Deploy.CLI.Commands
             }
             else if (selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.DotnetPublishZipFile)
             {
+                _orchestratorInteractiveService.LogSectionStart("Creating deployment zip bundle",
+                    "Using the dotnet CLI build the project and zip the publish artifacts.");
+
                 var dotnetPublishDeploymentBundleResult = await orchestrator.CreateDotnetPublishDeploymentBundle(selectedRecommendation);
                 if (!dotnetPublishDeploymentBundleResult)
                     throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateDotnetPublishDeploymentBundle, "Failed to create a deployment bundle");

--- a/src/AWS.Deploy.CLI/ConsoleOrchestratorLogger.cs
+++ b/src/AWS.Deploy.CLI/ConsoleOrchestratorLogger.cs
@@ -14,17 +14,32 @@ namespace AWS.Deploy.CLI
             _interactiveService = interactiveService;
         }
 
-        public void LogErrorMessageLine(string? message)
+        public void LogSectionStart(string message, string? description)
+        {
+            var sectionBreak = new string('*', message.Length);
+            _interactiveService.WriteLine(string.Empty);
+            _interactiveService.WriteLine(sectionBreak);
+            _interactiveService.WriteLine(message);
+            if(description != null)
+            {
+                _interactiveService.WriteLine(new string('-', message.Length));
+                _interactiveService.WriteLine(description);
+            }
+            _interactiveService.WriteLine(sectionBreak);
+            _interactiveService.WriteLine(string.Empty);
+        }
+
+        public void LogErrorMessage(string? message)
         {
             _interactiveService.WriteErrorLine(message);
         }
 
-        public void LogMessageLine(string? message)
+        public void LogInfoMessage(string? message)
         {
             _interactiveService.WriteLine(message);
         }
 
-        public void LogDebugLine(string? message)
+        public void LogDebugMessage(string? message)
         {
             _interactiveService.WriteDebugLine(message);
         }

--- a/src/AWS.Deploy.CLI/ServerMode/Hubs/DeploymentCommunicationHub.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Hubs/DeploymentCommunicationHub.cs
@@ -12,9 +12,10 @@ namespace AWS.Deploy.CLI.ServerMode.Hubs
     public interface IDeploymentCommunicationHub
     {
         Task JoinSession(string sessionId);
-        Task OnLogDebugLine(string? logs);
-        Task OnLogErrorMessageLine(string? logs);
-        Task OnLogMessageLine(string? logs);
+        Task OnLogSectionStart(string sectionName, string? description);
+        Task OnLogDebugMessage(string? message);
+        Task OnLogErrorMessage(string? message);
+        Task OnLogInfoMessage(string? message);
     }
 
     public class DeploymentCommunicationHub : Hub<IDeploymentCommunicationHub>

--- a/src/AWS.Deploy.CLI/ServerMode/Services/SessionOrchestratorInteractiveService.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/SessionOrchestratorInteractiveService.cs
@@ -23,19 +23,24 @@ namespace AWS.Deploy.CLI.ServerMode.Services
             _hubContext = hubContext;
         }
 
-        public void LogDebugLine(string? message)
+        public void LogSectionStart(string message, string? description)
         {
-            _hubContext.Clients.Group(_sessionId).OnLogDebugLine(message);
+            _hubContext.Clients.Group(_sessionId).OnLogSectionStart(message, description);
         }
 
-        public void LogErrorMessageLine(string? message)
+        public void LogDebugMessage(string? message)
         {
-            _hubContext.Clients.Group(_sessionId).OnLogErrorMessageLine(message);
+            _hubContext.Clients.Group(_sessionId).OnLogDebugMessage(message);
         }
 
-        public void LogMessageLine(string? message)
+        public void LogErrorMessage(string? message)
         {
-            _hubContext.Clients.Group(_sessionId).OnLogMessageLine(message);
+            _hubContext.Clients.Group(_sessionId).OnLogErrorMessage(message);
+        }
+
+        public void LogInfoMessage(string? message)
+        {
+            _hubContext.Clients.Group(_sessionId).OnLogInfoMessage(message);
         }
     }
 }

--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -89,7 +89,7 @@ namespace AWS.Deploy.CLI.Utilities
                 {
                     if(streamOutputToInteractiveService)
                     {
-                        _interactiveService.LogMessageLine(e.Data);
+                        _interactiveService.LogInfoMessage(e.Data);
                     }
 
                     strOutput.AppendLine(e.Data);
@@ -99,7 +99,7 @@ namespace AWS.Deploy.CLI.Utilities
                 {
                     if(streamOutputToInteractiveService)
                     {
-                        _interactiveService.LogMessageLine(e.Data);
+                        _interactiveService.LogInfoMessage(e.Data);
                     }
 
                     strError.AppendLine(e.Data);

--- a/src/AWS.Deploy.Orchestration/CDK/CDKManager.cs
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKManager.cs
@@ -60,7 +60,7 @@ namespace AWS.Deploy.Orchestration.CDK
                 var installedCdkVersion = await _cdkInstaller.GetVersion(workingDirectory);
                 if (installedCdkVersion.Success && installedCdkVersion.Result?.CompareTo(cdkVersion) >= 0)
                 {
-                    _interactiveService.LogDebugLine($"CDK version {installedCdkVersion.Result} found in global node_modules.");
+                    _interactiveService.LogDebugMessage($"CDK version {installedCdkVersion.Result} found in global node_modules.");
                     return;
                 }
 

--- a/src/AWS.Deploy.Orchestration/CDK/NPMPackageInitializer.cs
+++ b/src/AWS.Deploy.Orchestration/CDK/NPMPackageInitializer.cs
@@ -71,7 +71,7 @@ namespace AWS.Deploy.Orchestration.CDK
 
         public async Task Initialize(string workingDirectory, Version cdkVersion)
         {
-            _interactiveService.LogDebugLine($"Creating package.json at {workingDirectory}.");
+            _interactiveService.LogDebugMessage($"Creating package.json at {workingDirectory}.");
             var packageJsonFileContent = _packageJsonGenerator.Generate(cdkVersion);
             var packageJsonFilePath = Path.Combine(workingDirectory, _packageJsonFileName);
 

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.Orchestration
             else
             {
                 // Create a new temporary CDK project for a new deployment
-                _interactiveService.LogMessageLine("Generating AWS Cloud Development Kit (AWS CDK) deployment project");
+                _interactiveService.LogInfoMessage("Generating AWS Cloud Development Kit (AWS CDK) deployment project");
                 cdkProjectPath = CreateCdkProject(recommendation, session);
             }
 
@@ -101,8 +101,6 @@ namespace AWS.Deploy.Orchestration
                 { EnvironmentVariableKeys.AWS_EXECUTION_ENV, recipeInfo }
             };
 
-            _interactiveService.LogMessageLine("Deploying AWS CDK project");
-
             var appSettingsFilePath = Path.Combine(cdkProjectPath, "appsettings.json");
 
             // Ensure region is bootstrapped
@@ -115,6 +113,9 @@ namespace AWS.Deploy.Orchestration
             if (cdkBootstrap.ExitCode != 0)
                 throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToRunCDKBootstrap, "The AWS CDK Bootstrap, which is the process of provisioning initial resources for the deployment environment, has failed. Please review the output above for additional details [and check out our troubleshooting guide for the most common failure reasons]. You can learn more about CDK bootstrapping at https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html.");
 
+
+            _interactiveService.LogSectionStart("Deploying AWS CDK project",
+                "Use the CDK project to create or update the AWS CloudFormation stack and deploy the project to the AWS resources in the stack.");
 
             var deploymentStartDate = DateTime.Now;
             // Handover to CDK command line tool
@@ -181,7 +182,7 @@ namespace AWS.Deploy.Orchestration
             var templateEngine = new TemplateEngine();
             templateEngine.GenerateCDKProjectFromTemplate(recommendation, session, saveCdkDirectoryPath, assemblyName);
 
-            _interactiveService.LogDebugLine($"Saving AWS CDK deployment project to: {saveCdkDirectoryPath}");
+            _interactiveService.LogDebugMessage($"Saving AWS CDK deployment project to: {saveCdkDirectoryPath}");
             return saveCdkDirectoryPath;
         }
 
@@ -199,8 +200,8 @@ namespace AWS.Deploy.Orchestration
             }
             catch (Exception exception)
             {
-                _interactiveService.LogDebugLine(exception.PrettyPrint());
-                _interactiveService.LogErrorMessageLine($"We were unable to delete the temporary project that was created for this deployment. Please manually delete it at this location: {cdkProjectPath}");
+                _interactiveService.LogDebugMessage(exception.PrettyPrint());
+                _interactiveService.LogErrorMessage($"We were unable to delete the temporary project that was created for this deployment. Please manually delete it at this location: {cdkProjectPath}");
             }
         }
     }

--- a/src/AWS.Deploy.Orchestration/CustomRecipeLocator.cs
+++ b/src/AWS.Deploy.Orchestration/CustomRecipeLocator.cs
@@ -50,7 +50,7 @@ namespace AWS.Deploy.Orchestration
             {
                 if (ContainsRecipeFile(recipePath))
                 {
-                    _orchestratorInteractiveService.LogMessageLine($"Found custom recipe file at: {recipePath}");
+                    _orchestratorInteractiveService.LogInfoMessage($"Found custom recipe file at: {recipePath}");
                     customRecipePaths.Add(recipePath);
                 }
             }
@@ -59,7 +59,7 @@ namespace AWS.Deploy.Orchestration
             {
                 if (ContainsRecipeFile(recipePath))
                 {
-                    _orchestratorInteractiveService.LogMessageLine($"Found custom recipe file at: {recipePath}");
+                    _orchestratorInteractiveService.LogInfoMessage($"Found custom recipe file at: {recipePath}");
                     customRecipePaths.Add(recipePath);
                 }
             }
@@ -80,8 +80,8 @@ namespace AWS.Deploy.Orchestration
             }
             catch
             {
-                _orchestratorInteractiveService.LogMessageLine(Environment.NewLine);
-                _orchestratorInteractiveService.LogErrorMessageLine("Failed to load custom deployment recommendations " +
+                _orchestratorInteractiveService.LogErrorMessage(Environment.NewLine);
+                _orchestratorInteractiveService.LogErrorMessage("Failed to load custom deployment recommendations " +
                    "from the deployment-manifest file due to an error while trying to deserialze the file.");
                 return await Task.FromResult(new List<string>());
             }
@@ -126,7 +126,7 @@ namespace AWS.Deploy.Orchestration
                 }
                 catch (Exception e)
                 {
-                    _orchestratorInteractiveService.LogMessageLine($"Failed to find custom recipe paths starting from {rootDirectoryPath}. Encountered the following exception: {e.GetType()}");
+                    _orchestratorInteractiveService.LogInfoMessage($"Failed to find custom recipe paths starting from {rootDirectoryPath}. Encountered the following exception: {e.GetType()}");
                 }
 
                 foreach (var recipeFilePath in recipePathList)
@@ -153,14 +153,14 @@ namespace AWS.Deploy.Orchestration
                 if(_directoryManager.GetDirectories(currentDir, ".git").Any())
                 {
                     var sourceControlRootDirectory = _directoryManager.GetDirectoryInfo(currentDir).FullName;
-                    _orchestratorInteractiveService.LogMessageLine($"source control root directory found at: {sourceControlRootDirectory}");
+                    _orchestratorInteractiveService.LogDebugMessage($"Source control root directory found at: {sourceControlRootDirectory}");
                     return sourceControlRootDirectory;
                 }
 
                 currentDir = _directoryManager.GetDirectoryInfo(currentDir).Parent?.FullName;
             }
 
-            _orchestratorInteractiveService.LogMessageLine($"could not find any source control root directory");
+            _orchestratorInteractiveService.LogDebugMessage($"Could not find any source control root directory");
             return string.Empty;
         }
 

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -46,16 +46,16 @@ namespace AWS.Deploy.Orchestration
 
         public async Task BuildDockerImage(CloudApplication cloudApplication, Recommendation recommendation, string imageTag)
         {
-            _interactiveService.LogMessageLine(string.Empty);
-            _interactiveService.LogMessageLine("Building the docker image...");
+            _interactiveService.LogInfoMessage(string.Empty);
+            _interactiveService.LogInfoMessage("Building the docker image...");
 
             var dockerExecutionDirectory = GetDockerExecutionDirectory(recommendation);
             var dockerFile = GetDockerFilePath(recommendation);
             var buildArgs = GetDockerBuildArgs(recommendation);
 
             var dockerBuildCommand = $"docker build -t {imageTag} -f \"{dockerFile}\"{buildArgs} .";
-            _interactiveService.LogMessageLine($"Docker Execution Directory: {Path.GetFullPath(dockerExecutionDirectory)}");
-            _interactiveService.LogMessageLine($"Docker Build Command: {dockerBuildCommand}");
+            _interactiveService.LogInfoMessage($"Docker Execution Directory: {Path.GetFullPath(dockerExecutionDirectory)}");
+            _interactiveService.LogInfoMessage($"Docker Build Command: {dockerBuildCommand}");
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;
 
@@ -68,8 +68,8 @@ namespace AWS.Deploy.Orchestration
 
         public async Task PushDockerImageToECR(Recommendation recommendation, string repositoryName, string sourceTag)
         {
-            _interactiveService.LogMessageLine(string.Empty);
-            _interactiveService.LogMessageLine("Pushing the docker image to ECR repository...");
+            _interactiveService.LogInfoMessage(string.Empty);
+            _interactiveService.LogInfoMessage("Pushing the docker image to ECR repository...");
 
             await InitiateDockerLogin();
 
@@ -87,8 +87,8 @@ namespace AWS.Deploy.Orchestration
 
         public async Task<string> CreateDotnetPublishZip(Recommendation recommendation)
         {
-            _interactiveService.LogMessageLine(string.Empty);
-            _interactiveService.LogMessageLine("Creating Dotnet Publish Zip file...");
+            _interactiveService.LogInfoMessage(string.Empty);
+            _interactiveService.LogInfoMessage("Creating Dotnet Publish Zip file...");
 
             var publishDirectoryInfo = _directoryManager.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var additionalArguments = recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments;

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
@@ -37,7 +37,7 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
                 throw new AWSResourceNotFoundException(DeployToolErrorCode.FailedToFindElasticBeanstalkApplication, message);
             }
 
-            orchestrator._interactiveService.LogMessageLine($"Initiating deployment to {cloudApplication.DisplayName}...");
+            orchestrator._interactiveService.LogSectionStart($"Creating application version", "Uploading deployment bundle to S3 and create an Elastic Beanstalk application version");
 
             var versionLabel = $"v-{DateTime.Now.Ticks}";
             var s3location = await elasticBeanstalkHandler.CreateApplicationStorageLocationAsync(applicationName, versionLabel, deploymentPackage);
@@ -45,11 +45,13 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
             await elasticBeanstalkHandler.CreateApplicationVersionAsync(applicationName, versionLabel, s3location);
             var environmentConfigurationSettings = elasticBeanstalkHandler.GetEnvironmentConfigurationSettings(recommendation);
 
+
+            orchestrator._interactiveService.LogSectionStart($"Deploying application version", $"Deploy new application version to Elastic Beanstalk environment {environmentName}.");
             var success = await elasticBeanstalkHandler.UpdateEnvironmentAsync(applicationName, environmentName, versionLabel, environmentConfigurationSettings);
 
             if (success)
             {
-                orchestrator._interactiveService.LogMessageLine($"The Elastic Beanstalk Environment {environmentName} has been successfully updated to the application version {versionLabel}" + Environment.NewLine);
+                orchestrator._interactiveService.LogInfoMessage($"The Elastic Beanstalk Environment {environmentName} has been successfully updated to the application version {versionLabel}" + Environment.NewLine);
             } 
             else
             {

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
@@ -31,10 +31,8 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
             if (orchestrator._directoryManager == null)
                 throw new InvalidOperationException($"{nameof(orchestrator._directoryManager)} must not be null.");
 
-            orchestrator._interactiveService.LogMessageLine(string.Empty);
-            orchestrator._interactiveService.LogMessageLine($"Initiating deployment: {recommendation.Name}");
-
-            orchestrator._interactiveService.LogMessageLine("Configuring AWS Cloud Development Kit (CDK)...");
+            orchestrator._interactiveService.LogSectionStart("Configuring AWS Cloud Development Kit (CDK)",
+                "Ensure a compatible CDK version is installed and the CDK bootstrap CloudFormation stack has been created. A CDK project to perform the deployment is generated unless an existing deployment project was selected.");
             var cdkProject = await orchestrator._cdkProjectHandler.ConfigureCdkProject(orchestrator._session, cloudApplication, recommendation);
 
             var projFiles = orchestrator._directoryManager.GetProjFiles(cdkProject);

--- a/src/AWS.Deploy.Orchestration/IOrchestratorInteractiveService.cs
+++ b/src/AWS.Deploy.Orchestration/IOrchestratorInteractiveService.cs
@@ -5,10 +5,12 @@ namespace AWS.Deploy.Orchestration
 {
     public interface IOrchestratorInteractiveService
     {
-        void LogErrorMessageLine(string? message);
+        void LogSectionStart(string sectionName, string? description);
 
-        void LogMessageLine(string? message);
+        void LogErrorMessage(string? message);
 
-        void LogDebugLine(string? message);
+        void LogInfoMessage(string? message);
+
+        void LogDebugMessage(string? message);
     }
 }

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -180,7 +180,7 @@ namespace AWS.Deploy.Orchestration
 
             if (!recommendation.ProjectDefinition.HasDockerFile)
             {
-                _interactiveService.LogMessageLine("Generating Dockerfile...");
+                _interactiveService.LogInfoMessage("Generating Dockerfile...");
                 try
                 {
                     _dockerEngine.GenerateDockerFile();
@@ -209,14 +209,16 @@ namespace AWS.Deploy.Orchestration
                 }
 
                 await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation, imageTag);
+
+                _interactiveService.LogSectionStart("Pushing container image to Elastic Container Registry (ECR)", "Using the docker CLI to log on to ECR and push the local image to ECR.");
                 await _deploymentBundleHandler.PushDockerImageToECR(recommendation, respositoryName, imageTag);
             }
             catch(DockerBuildFailedException ex)
             {
-                _interactiveService.LogErrorMessageLine("We were unable to build the docker image due to the following error:");
-                _interactiveService.LogErrorMessageLine(ex.Message);
-                _interactiveService.LogErrorMessageLine("Docker builds usually fail due to executing them from a working directory that is incompatible with the Dockerfile.");
-                _interactiveService.LogErrorMessageLine("You can try setting the 'Docker Execution Directory' in the option settings.");
+                _interactiveService.LogErrorMessage("We were unable to build the docker image due to the following error:");
+                _interactiveService.LogErrorMessage(ex.Message);
+                _interactiveService.LogErrorMessage("Docker builds usually fail due to executing them from a working directory that is incompatible with the Dockerfile.");
+                _interactiveService.LogErrorMessage("You can try setting the 'Docker Execution Directory' in the option settings.");
                 return false;
             }
 
@@ -236,16 +238,16 @@ namespace AWS.Deploy.Orchestration
             }
             catch (DotnetPublishFailedException exception)
             {
-                _interactiveService.LogErrorMessageLine("We were unable to package the application using 'dotnet publish' due to the following error:");
-                _interactiveService.LogErrorMessageLine(exception.Message);
-                _interactiveService.LogDebugLine(exception.PrettyPrint());
+                _interactiveService.LogErrorMessage("We were unable to package the application using 'dotnet publish' due to the following error:");
+                _interactiveService.LogErrorMessage(exception.Message);
+                _interactiveService.LogDebugMessage(exception.PrettyPrint());
                 return false;
             }
             catch (FailedToCreateZipFileException exception)
             {
-                _interactiveService.LogErrorMessageLine("We were unable to create a zip archive of the packaged application.");
-                _interactiveService.LogErrorMessageLine("Normally this indicates a problem running the \"zip\" utility. Make sure that application is installed and available in your PATH.");
-                _interactiveService.LogDebugLine(exception.PrettyPrint());
+                _interactiveService.LogErrorMessage("We were unable to create a zip archive of the packaged application.");
+                _interactiveService.LogErrorMessage("Normally this indicates a problem running the \"zip\" utility. Make sure that application is installed and available in your PATH.");
+                _interactiveService.LogDebugMessage(exception.PrettyPrint());
                 return false;
             }
 

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
@@ -57,7 +57,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
 
         public async Task<CreateApplicationVersionResponse> CreateApplicationVersionAsync(string applicationName, string versionLabel, S3Location sourceBundle)
         {
-            _interactiveService.LogMessageLine("Creating new application version: " + versionLabel);
+            _interactiveService.LogInfoMessage("Creating new application version: " + versionLabel);
 
             try
             {
@@ -102,11 +102,11 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
 
         public async Task<bool> UpdateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, List<ConfigurationOptionSetting> optionSettings)
         {
-            _interactiveService.LogMessageLine("Getting latest environment event date before update");
+            _interactiveService.LogInfoMessage("Getting latest environment event date before update");
 
             var startingEventDate = await GetLatestEventDateAsync(applicationName, environmentName);
 
-            _interactiveService.LogMessageLine($"Updating environment {environmentName} to new application version {versionLabel}");
+            _interactiveService.LogInfoMessage($"Updating environment {environmentName} to new application version {versionLabel}");
 
             var updateRequest = new UpdateEnvironmentRequest
             {
@@ -146,7 +146,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
 
         private async Task<bool> WaitForEnvironmentUpdateCompletion(string applicationName, string environmentName, DateTime startingEventDate)
         {
-            _interactiveService.LogMessageLine("Waiting for environment update to complete");
+            _interactiveService.LogInfoMessage("Waiting for environment update to complete");
 
             var success = true;
             var environment = new EnvironmentDescription();
@@ -183,7 +183,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
                         if (evnt.EventDate <= lastPrintedEventDate)
                             continue;
 
-                        _interactiveService.LogMessageLine(evnt.EventDate.ToLocalTime() + "    " + evnt.Severity + "    " + evnt.Message);
+                        _interactiveService.LogInfoMessage(evnt.EventDate.ToLocalTime() + "    " + evnt.Severity + "    " + evnt.Message);
                         if (evnt.Severity == EventSeverity.ERROR || evnt.Severity == EventSeverity.FATAL)
                         {
                             success = false;

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSS3Handler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSS3Handler.cs
@@ -37,7 +37,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
         {
             using (var stream = _fileManager.OpenRead(filePath))
             {
-                _interactiveService.LogMessageLine($"Uploading to S3. (Bucket: {bucket} Key: {key} Size: {_fileManager.GetSizeInBytes(filePath)} bytes)");
+                _interactiveService.LogInfoMessage($"Uploading to S3. (Bucket: {bucket} Key: {key} Size: {_fileManager.GetSizeInBytes(filePath)} bytes)");
 
                 var request = new TransferUtilityUploadRequest()
                 {
@@ -71,7 +71,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
                 if (increment == 0)
                     increment = UPLOAD_PROGRESS_INCREMENT;
                 percentToUpdateOn = e.PercentDone + increment;
-                _interactiveService.LogMessageLine($"... Progress: {e.PercentDone}%");
+                _interactiveService.LogInfoMessage($"... Progress: {e.PercentDone}%");
             });
 
             return handler;

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -107,13 +107,13 @@ namespace AWS.Deploy.Orchestration.Utilities
                 }
                 catch (FailedToUpdateLocalUserSettingsFileException ex)
                 {
-                    _orchestratorInteractiveService.LogErrorMessageLine(ex.Message);
-                    _orchestratorInteractiveService.LogDebugLine(ex.PrettyPrint());
+                    _orchestratorInteractiveService.LogErrorMessage(ex.Message);
+                    _orchestratorInteractiveService.LogDebugMessage(ex.PrettyPrint());
                 }
                 catch (InvalidLocalUserSettingsFileException ex)
                 {
-                    _orchestratorInteractiveService.LogErrorMessageLine(ex.Message);
-                    _orchestratorInteractiveService.LogDebugLine(ex.PrettyPrint());
+                    _orchestratorInteractiveService.LogErrorMessage(ex.Message);
+                    _orchestratorInteractiveService.LogDebugMessage(ex.PrettyPrint());
                 }
             }
 

--- a/src/AWS.Deploy.ServerMode.Client/DeploymentCommunicationClient.cs
+++ b/src/AWS.Deploy.ServerMode.Client/DeploymentCommunicationClient.cs
@@ -12,13 +12,11 @@ namespace AWS.Deploy.ServerMode.Client
 {
     public interface IDeploymentCommunicationClient : IDisposable
     {
-        Action<string>? ReceiveLogDebugLine { get; set; }
+        Action<string>? ReceiveLogDebugMessage { get; set; }
 
-        Action<string>? ReceiveLogErrorMessageLine { get; set; }
+        Action<string>? ReceiveLogErrorMessage { get; set; }
 
-        Action<string>? ReceiveLogMessageLineAction { get; set; }
-
-        Action<string>? ReceiveLogAllLogAction { get; set; }
+        Action<string>? ReceiveLogInfoMessage { get; set; }
 
         Task JoinSession(string sessionId);
     }
@@ -30,11 +28,11 @@ namespace AWS.Deploy.ServerMode.Client
         private bool _initialized = false;
         private readonly HubConnection _connection;
 
-        public Action<string>? ReceiveLogDebugLine { get; set; }
-        public Action<string>? ReceiveLogErrorMessageLine { get; set; }
-        public Action<string>? ReceiveLogMessageLineAction { get; set; }
+        public Action<string>? ReceiveLogDebugMessage { get; set; }
+        public Action<string>? ReceiveLogErrorMessage { get; set; }
+        public Action<string>? ReceiveLogInfoMessage { get; set; }
+        public Action<string, string>? ReceiveLogSectionStart { get; set; }
 
-        public Action<string>? ReceiveLogAllLogAction { get; set; }
 
         public DeploymentCommunicationClient(string baseUrl)
         {
@@ -44,22 +42,24 @@ namespace AWS.Deploy.ServerMode.Client
                 .WithAutomaticReconnect()
                 .Build();
 
-            _connection.On<string>("OnLogDebugLine", (message) =>
+            _connection.On<string>("OnLogDebugMessage", (message) =>
             {
-                ReceiveLogDebugLine?.Invoke(message);
-                ReceiveLogAllLogAction?.Invoke(message);
+                ReceiveLogDebugMessage?.Invoke(message);
             });
 
-            _connection.On<string>("OnLogErrorMessageLine", (message) =>
+            _connection.On<string>("OnLogErrorMessage", (message) =>
             {
-                ReceiveLogErrorMessageLine?.Invoke(message);
-                ReceiveLogAllLogAction?.Invoke(message);
+                ReceiveLogErrorMessage?.Invoke(message);
             });
 
-            _connection.On<string>("OnLogMessageLine", (message) =>
+            _connection.On<string>("OnLogInfoMessage", (message) =>
             {
-                ReceiveLogMessageLineAction?.Invoke(message);
-                ReceiveLogAllLogAction?.Invoke(message);
+                ReceiveLogInfoMessage?.Invoke(message);
+            });
+
+            _connection.On<string, string>("OnLogSectionStart", (message, description) =>
+            {
+                ReceiveLogSectionStart?.Invoke(message, description);
             });
         }
 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Services/InMemoryInteractiveService.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Services/InMemoryInteractiveService.cs
@@ -169,17 +169,22 @@ namespace AWS.Deploy.CLI.IntegrationTests.Services
             }
         }
 
-        public void LogErrorMessageLine(string message)
+        public void LogSectionStart(string message, string description)
         {
             WriteLine(message);
         }
 
-        public void LogMessageLine(string message)
+        public void LogErrorMessage(string message)
         {
             WriteLine(message);
         }
 
-        public void LogDebugLine(string message)
+        public void LogInfoMessage(string message)
+        {
+            WriteLine(message);
+        }
+
+        public void LogDebugMessage(string message)
         {
             WriteLine(message);
         }

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
@@ -65,10 +65,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
                 await signalRClient.JoinSession(sessionId);
 
                 var logOutput = new StringBuilder();
-                signalRClient.ReceiveLogAllLogAction = (line) =>
-                {
-                    logOutput.AppendLine(line);
-                };
+                AWS.Deploy.CLI.IntegrationTests.ServerModeTests.RegisterSignalRMessageCallbacks(signalRClient, logOutput);
 
                 await restClient.SetDeploymentTargetAsync(sessionId, new SetDeploymentTargetInput
                 {

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
@@ -12,6 +12,7 @@ using AWS.Deploy.CLI.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Helpers;
 using AWS.Deploy.CLI.IntegrationTests.Services;
+using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
@@ -48,6 +49,12 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
+            var awsClientFactory = serviceProvider.GetService<IAWSClientFactory>();
+            awsClientFactory.ConfigureAWSOptions((options) =>
+            {
+                options.Region = Amazon.RegionEndpoint.USWest2;
+            });
+
             App = serviceProvider.GetService<App>();
             Assert.NotNull(App);
 
@@ -76,7 +83,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
             EnvironmentName = $"environment{suffix}";
             VersionLabel = $"v-{suffix}";
 
-            EBHelper = new ElasticBeanstalkHelper(new AmazonElasticBeanstalkClient(), AWSResourceQueryer, ToolInteractiveService);
+            EBHelper = new ElasticBeanstalkHelper(new AmazonElasticBeanstalkClient(Amazon.RegionEndpoint.USWest2), AWSResourceQueryer, ToolInteractiveService);
             IAMHelper = new IAMHelper(new AmazonIdentityManagementServiceClient(), AWSResourceQueryer, ToolInteractiveService);
         }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
@@ -192,7 +192,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
                     InputStream = stream
                 };
 
-                var s3Client = new AmazonS3Client();
+                var s3Client = new AmazonS3Client(Amazon.RegionEndpoint.USWest2);
                 await new TransferUtility(s3Client).UploadAsync(request);
             }
         }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -232,7 +232,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
             var signalRClient = new DeploymentCommunicationClient(baseUrl);
             await signalRClient.JoinSession(sessionId);
 
-            signalRClient.ReceiveLogAllLogAction = (line) => { logOutput.AppendLine(line); };
+            AWS.Deploy.CLI.IntegrationTests.ServerModeTests.RegisterSignalRMessageCallbacks(signalRClient, logOutput);
         }
 
         private async Task<RecommendationSummary> GetRecommendationsAndSelectAppRunner(RestAPIClient restClient, string sessionId)

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -187,10 +187,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
                 await signalRClient.JoinSession(sessionId);
 
                 var logOutput = new StringBuilder();
-                signalRClient.ReceiveLogAllLogAction = (line) =>
-                {
-                    logOutput.AppendLine(line);
-                };
+                RegisterSignalRMessageCallbacks(signalRClient, logOutput);
 
                 var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
                 Assert.NotEmpty(getRecommendationOutput.Recommendations);
@@ -212,7 +209,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
                 Assert.Equal(StackStatus.CREATE_COMPLETE, stackStatus);
 
                 Assert.True(logOutput.Length > 0);
-                Assert.Contains("Initiating deployment", logOutput.ToString());
+                Assert.Contains("Pushing container image", logOutput.ToString());
 
                 var redeploymentSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
                 {
@@ -308,6 +305,24 @@ namespace AWS.Deploy.CLI.IntegrationTests
             {
                 cancelSource.Cancel();
             }
+        }
+
+        internal static void RegisterSignalRMessageCallbacks(DeploymentCommunicationClient signalRClient, StringBuilder logOutput)
+        {
+            signalRClient.ReceiveLogSectionStart = (message, description) =>
+            {
+                logOutput.AppendLine(new string('*', message.Length));
+                logOutput.AppendLine(message);
+                logOutput.AppendLine(new string('*', message.Length));
+            };
+            signalRClient.ReceiveLogInfoMessage = (message) =>
+            {
+                logOutput.AppendLine(message);
+            };
+            signalRClient.ReceiveLogErrorMessage = (message) =>
+            {
+                logOutput.AppendLine(message);
+            };
         }
 
         private async Task<DeploymentStatus> WaitForDeployment(RestAPIClient restApiClient, string sessionId)

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolOrchestratorInteractiveService.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolOrchestratorInteractiveService.cs
@@ -8,12 +8,14 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
 {
     public class TestToolOrchestratorInteractiveService : IOrchestratorInteractiveService
     {
+        public IList<string> SectionStartMessages { get; } = new List<string>();
         public IList<string> DebugMessages { get; } = new List<string>();
         public IList<string> OutputMessages { get; } = new List<string>();
         public IList<string> ErrorMessages { get; } = new List<string>();
 
-        public void LogDebugLine(string message) => DebugMessages.Add(message);
-        public void LogErrorMessageLine(string message) => ErrorMessages.Add(message);
-        public void LogMessageLine(string message) => OutputMessages.Add(message);
+        public void LogSectionStart(string message, string description) => SectionStartMessages.Add(message);
+        public void LogDebugMessage(string message) => DebugMessages.Add(message);
+        public void LogErrorMessage(string message) => ErrorMessages.Add(message);
+        public void LogInfoMessage(string message) => OutputMessages.Add(message);
     }
 }


### PR DESCRIPTION
*Description of changes:*

For the log output during a deployment write section headers along with descriptions that explain what is happening at this stage of deployment.

Here is what the headers look like using the CLI.
![LoggingHeaders3](https://user-images.githubusercontent.com/1653751/165228000-f95e316d-e1ce-4fe3-8090-a915efa6c25b.gif)

For the VS toolkit there is a new message sent through the SignalR hub that the toolkit can use to get notified when new sections are started. The toolkit can either add the section headers in the output window or create category based UI control.

Notes for PR
* Renamed the logging methods on `IOrchestratorInteractiveService` and the SignalR client `IDeploymentCommunicationHub` to make the names consisted. I have discussed this with the IDE team so and they are fine adapting to the change when the adopt the new version.
* On SignalR client removed the `ReceiveLogMessageLineAction` callback. This also meant the toolkit was displaying debug messages and it didn't make sense to add the new header names in this callback. Toolkit will update to add callback to the Info and Error messages.
* Fix up the deploy to existing beanstalk integration test to make sure the testing stack is deployed to `us-west-2` since the integration test that look for the existing environment was failing on my machine which didn't have `us-west-2` as the default region.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
