### PR TITLE
feat: Add persisted project details to API; Add debugger display hints for servermode clients

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -142,8 +142,10 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                     continue;
 
                 output.Recommendations.Add(new RecommendationSummary(
+                    baseRecipeId: recommendation.Recipe.BaseRecipeId,
                     recipeId: recommendation.Recipe.Id,
                     name: recommendation.Name,
+                    isPersistedDeploymentProject: recommendation.Recipe.PersistedDeploymentProject,
                     shortDescription: recommendation.ShortDescription,
                     description: recommendation.Description,
                     targetService: recommendation.Recipe.TargetService,
@@ -324,8 +326,10 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
                 output.ExistingDeployments.Add(new ExistingDeploymentSummary(
                     name: deployment.Name,
+                    baseRecipeId: recommendation.Recipe.BaseRecipeId,
                     recipeId: deployment.RecipeId,
                     recipeName: recommendation.Name,
+                    isPersistedDeploymentProject: recommendation.Recipe.PersistedDeploymentProject,
                     shortDescription: recommendation.ShortDescription,
                     description: recommendation.Description,
                     targetService: recommendation.Recipe.TargetService,

--- a/src/AWS.Deploy.CLI/ServerMode/Models/ExistingDeploymentSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/ExistingDeploymentSummary.cs
@@ -20,9 +20,13 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public string Name { get; set; }
 
+        public string? BaseRecipeId { get; set; }
+
         public string RecipeId { get; set; }
 
         public string RecipeName { get; set; }
+
+        public bool IsPersistedDeploymentProject { get; set; }
 
         public string ShortDescription { get; set; }
 
@@ -40,8 +44,10 @@ namespace AWS.Deploy.CLI.ServerMode.Models
 
         public ExistingDeploymentSummary(
             string name,
+            string? baseRecipeId,
             string recipeId,
             string recipeName,
+            bool isPersistedDeploymentProject,
             string shortDescription,
             string description,
             string targetService,
@@ -52,8 +58,10 @@ namespace AWS.Deploy.CLI.ServerMode.Models
         )
         {
             Name = name;
+            BaseRecipeId = baseRecipeId;
             RecipeId = recipeId;
             RecipeName = recipeName;
+            IsPersistedDeploymentProject = isPersistedDeploymentProject;
             ShortDescription = shortDescription;
             Description = description;
             TargetService = targetService;

--- a/src/AWS.Deploy.CLI/ServerMode/Models/RecommendationSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/RecommendationSummary.cs
@@ -16,24 +16,30 @@ namespace AWS.Deploy.CLI.ServerMode.Models
             { Common.Recipes.DeploymentTypes.ElasticContainerRegistryImage, DeploymentTypes.ElasticContainerRegistryImage }
         };
 
+        public string? BaseRecipeId { get; set; }
         public string RecipeId { get; set; }
         public string Name { get; set; }
+        public bool IsPersistedDeploymentProject { get; set; }
         public string ShortDescription { get; set; }
         public string Description { get; set; }
         public string TargetService { get; set; }
         public DeploymentTypes DeploymentType { get; set; }
 
         public RecommendationSummary(
+            string? baseRecipeId,
             string recipeId,
             string name,
+            bool isPersistedDeploymentProject,
             string shortDescription,
             string description,
             string targetService,
             Common.Recipes.DeploymentTypes deploymentType
         )
         {
+            BaseRecipeId = baseRecipeId;
             RecipeId = recipeId;
             Name = name;
+            IsPersistedDeploymentProject = isPersistedDeploymentProject;
             ShortDescription = shortDescription;
             Description = description;
             TargetService = targetService;

--- a/src/AWS.Deploy.ServerMode.Client/AnnotatedModels.cs
+++ b/src/AWS.Deploy.ServerMode.Client/AnnotatedModels.cs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+
+namespace AWS.Deploy.ServerMode.Client
+{
+    /// <summary>
+    /// This file provides a place to add annotations to partial classes that are auto-generated in RestAPI.cs.
+    /// The annotations are intended for use by clients like the AWS Toolkit.
+    /// </summary>
+
+    [DebuggerDisplay(value: "{DeploymentType}: {RecipeId} | {Name}")]
+    public partial class ExistingDeploymentSummary
+    {
+    }
+
+    [DebuggerDisplay(value: "Recipe: {RecipeId}, Base: ({BaseRecipeId})")]
+    public partial class RecommendationSummary
+    {
+    }
+}

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1716,11 +1716,17 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("baseRecipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BaseRecipeId { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("recipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RecipeId { get; set; }
     
         [Newtonsoft.Json.JsonProperty("recipeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RecipeName { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("isPersistedDeploymentProject", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsPersistedDeploymentProject { get; set; }
     
         [Newtonsoft.Json.JsonProperty("shortDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ShortDescription { get; set; }
@@ -1921,11 +1927,17 @@ namespace AWS.Deploy.ServerMode.Client
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class RecommendationSummary 
     {
+        [Newtonsoft.Json.JsonProperty("baseRecipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BaseRecipeId { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("recipeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RecipeId { get; set; }
     
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("isPersistedDeploymentProject", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsPersistedDeploymentProject { get; set; }
     
         [Newtonsoft.Json.JsonProperty("shortDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ShortDescription { get; set; }

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
@@ -58,6 +58,8 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
 
                 Assert.Equal(_fixture.EnvironmentName, existingDeployment.Name);
                 Assert.Equal(BEANSTALK_ENVIRONMENT_RECIPE_ID, existingDeployment.RecipeId);
+                Assert.Null(existingDeployment.BaseRecipeId);
+                Assert.False(existingDeployment.IsPersistedDeploymentProject);
                 Assert.Equal(_fixture.EnvironmentId, existingDeployment.ExistingDeploymentId);
                 Assert.Equal(DeploymentTypes.BeanstalkEnvironment, existingDeployment.DeploymentType);
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -89,6 +89,8 @@ namespace AWS.Deploy.CLI.IntegrationTests
                 Assert.NotEmpty(getRecommendationOutput.Recommendations);
                 var beanstalkRecommendation = getRecommendationOutput.Recommendations.FirstOrDefault();
                 Assert.Equal("AspNetAppElasticBeanstalkLinux", beanstalkRecommendation.RecipeId);
+                Assert.Null(beanstalkRecommendation.BaseRecipeId);
+                Assert.False(beanstalkRecommendation.IsPersistedDeploymentProject);
                 Assert.NotNull(beanstalkRecommendation.ShortDescription);
                 Assert.NotNull(beanstalkRecommendation.Description);
                 Assert.True(beanstalkRecommendation.ShortDescription.Length < beanstalkRecommendation.Description.Length);
@@ -227,6 +229,8 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
                 Assert.Equal(_stackName, existingDeployment.Name);
                 Assert.Equal(fargateRecommendation.RecipeId, existingDeployment.RecipeId);
+                Assert.Null(fargateRecommendation.BaseRecipeId);
+                Assert.False(fargateRecommendation.IsPersistedDeploymentProject);
                 Assert.Equal(fargateRecommendation.Name, existingDeployment.RecipeName);
                 Assert.Equal(fargateRecommendation.ShortDescription, existingDeployment.ShortDescription);
                 Assert.Equal(fargateRecommendation.Description, existingDeployment.Description);

--- a/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
@@ -132,8 +132,10 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var existingDeploymentSummary = new ExistingDeploymentSummary(
                 "name",
+                "baseRecipeId",
                 "recipeId",
                 "recipeName",
+                false,
                 "shortDescription",
                 "description",
                 "targetService",
@@ -151,8 +153,10 @@ namespace AWS.Deploy.CLI.UnitTests
         public void RecommendationSummary_ContainsCorrectDeploymentType(Deploy.Common.Recipes.DeploymentTypes deploymentType, DeploymentTypes expectedDeploymentType)
         {
             var recommendationSummary = new RecommendationSummary(
+                "baseRecipeId",
                 "recipeId",
                 "name",
+                false,
                 "shortDescription",
                 "description",
                 "targetService",


### PR DESCRIPTION
*Description of changes:*
Based on Chris's PR https://github.com/aws/aws-dotnet-deploy/pull/520

This change adds a recipe's BaseRecipeId, and whether or not the project is a Persisted Project (generated through the deploy tool) to the Rest API. This allows clients like the Toolkit to identify the source recipe that is used with persisted projects.

This change also introduces some DebuggerDisplay attributes, to help Toolkit development when working with models exposed through the Rest API.

DebuggerDisplay example
![image](https://user-images.githubusercontent.com/39839589/164749553-31d37be6-ba55-45b5-965e-d69724353257.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
