### PR TITLE
fix: Handle invalid project paths with appropriate exception

### DIFF
--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -62,7 +62,14 @@ namespace AWS.Deploy.Common
 
             if (!_fileManager.Exists(projectPath))
             {
-                throw new ProjectFileNotFoundException(DeployToolErrorCode.ProjectPathNotFound, $"A project was not found at the path {projectPath}.");
+                throw new ProjectFileNotFoundException(DeployToolErrorCode.ProjectPathNotFound, $"Failed to find a valid .csproj or .fsproj file at path {projectPath}");
+            }
+
+            var extension = Path.GetExtension(projectPath);
+            if (!string.Equals(extension, ".csproj") && !string.Equals(extension, ".fsproj"))
+            {
+                var errorMeesage = $"Invalid project path {projectPath}. The project path must point to a .csproj or .fsproj file";
+                throw new ProjectFileNotFoundException(DeployToolErrorCode.ProjectPathNotFound, errorMeesage);
             }
 
             var xmlProjectFile = new XmlDocument();

--- a/test/AWS.Deploy.CLI.UnitTests/ProjectParserUtilityTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ProjectParserUtilityTests.cs
@@ -12,10 +12,11 @@ using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using Xunit;
 using Should;
+using AWS.Deploy.CLI.Utilities;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
-    public class ProjectDefinitionParserTest
+    public class ProjectParserUtilityTests
     {
         [Theory]
         [InlineData("WebAppWithDockerFile", "WebAppWithDockerFile.csproj")]
@@ -36,9 +37,11 @@ namespace AWS.Deploy.CLI.UnitTests
             var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
             var relativeProjectDirectoryPath = Path.GetRelativePath(currrentWorkingDirectory, absoluteProjectDirectoryPath);
             var projectSolutionPath = SystemIOUtilities.ResolvePathToSolution();
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectParserUtility = new ProjectParserUtility(projectDefinitionParser, new DirectoryManager());
 
             // Act
-            var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(relativeProjectDirectoryPath);
+            var projectDefinition = await projectParserUtility.Parse(relativeProjectDirectoryPath);
 
             // Assert
             projectDefinition.ShouldNotBeNull();
@@ -63,14 +66,30 @@ namespace AWS.Deploy.CLI.UnitTests
             var absoluteProjectDirectoryPath = new DirectoryInfo(projectDirectoryPath).FullName;
             var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
             var projectSolutionPath = SystemIOUtilities.ResolvePathToSolution();
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectParserUtility = new ProjectParserUtility(projectDefinitionParser, new DirectoryManager());
 
             // Act
-            var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(absoluteProjectDirectoryPath);
+            var projectDefinition = await projectParserUtility.Parse(absoluteProjectPath);
 
             // Assert
             projectDefinition.ShouldNotBeNull();
             Assert.Equal(absoluteProjectPath, projectDefinition.ProjectPath);
             Assert.Equal(projectSolutionPath, projectDefinition.ProjectSolutionPath);
+        }
+
+        [Theory]
+        [InlineData("C:\\MyProject\\doesNotExistSrc")]
+        [InlineData("C:\\MyProject\\src\\doesNotExist.csproj")]
+        public async Task Throws_FailedToFindDeployableTargetException_WithInvalidProjectPaths(string projectPath)
+        {
+            // Arrange
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectParserUtility = new ProjectParserUtility(projectDefinitionParser, new DirectoryManager());
+
+            // Act and Assert
+            var ex = await Assert.ThrowsAsync<FailedToFindDeployableTargetException>(async () => await projectParserUtility.Parse(projectPath));
+            Assert.Equal($"Failed to find a valid .csproj or .fsproj file at path {projectPath}", ex.Message);
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-deploy/issues/515

*Description of changes:*
Currently, when an invalid/non-existent project path is provided, the deploy tool crashes with an unhandled exception.

This PR ensures that the appropriate exception with an actionable error message is thrown incase of an invalid/non-existent project path


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
