### PR TITLE
fix: Add the new ReceiveLogSectionStart callback to the IDeploymentCommunicationClient

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/DeploymentCommunicationClient.cs
+++ b/src/AWS.Deploy.ServerMode.Client/DeploymentCommunicationClient.cs
@@ -18,6 +18,8 @@ namespace AWS.Deploy.ServerMode.Client
 
         Action<string>? ReceiveLogInfoMessage { get; set; }
 
+        Action<string, string>? ReceiveLogSectionStart { get; set; }
+
         Task JoinSession(string sessionId);
     }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -311,7 +311,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             }
         }
 
-        internal static void RegisterSignalRMessageCallbacks(DeploymentCommunicationClient signalRClient, StringBuilder logOutput)
+        internal static void RegisterSignalRMessageCallbacks(IDeploymentCommunicationClient signalRClient, StringBuilder logOutput)
         {
             signalRClient.ReceiveLogSectionStart = (message, description) =>
             {


### PR DESCRIPTION
*Description of changes:*
In the previous **0.42.10** release we added a new Action callback called `ReceiveLogSectionStart` on the SignalR client but we forgot to add `ReceiveLogSectionStart` to the interface of the client. This PR adds the missing `ReceiveLogSectionStart` callback to the interface.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
