### PR TITLE
fix: Consolidate implementations of CreateDeploymentBundle

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -674,59 +674,41 @@ namespace AWS.Deploy.CLI.Commands
 
         private async Task CreateDeploymentBundle(Orchestrator orchestrator, Recommendation selectedRecommendation, CloudApplication cloudApplication)
         {
-            if (selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.Container)
+            try
             {
-                _orchestratorInteractiveService.LogSectionStart("Creating deployment image",
-                    "Using the docker CLI to perform a docker build to create a container image.");
-
-                while (!await orchestrator.CreateContainerDeploymentBundle(cloudApplication, selectedRecommendation))
+                await orchestrator.CreateDeploymentBundle(cloudApplication, selectedRecommendation);
+            }
+            catch(FailedToCreateDeploymentBundleException ex) when (ex.ErrorCode == DeployToolErrorCode.FailedToCreateContainerDeploymentBundle)
+            {
+                if (_toolInteractiveService.DisableInteractive)
                 {
-                    if (_toolInteractiveService.DisableInteractive)
-                    {
-                        var errorMessage = "Failed to build Docker Image." + Environment.NewLine;
-                        errorMessage += "Docker builds usually fail due to executing them from a working directory that is incompatible with the Dockerfile." + Environment.NewLine;
-                        errorMessage += "Specify a valid Docker execution directory as part of the deployment settings file and try again.";
-                        throw new DockerBuildFailedException(DeployToolErrorCode.DockerBuildFailed, errorMessage);
-                    }
+                    var errorMessage = "Failed to build Docker Image." + Environment.NewLine;
+                    errorMessage += "Docker builds usually fail due to executing them from a working directory that is incompatible with the Dockerfile." + Environment.NewLine;
+                    errorMessage += "Specify a valid Docker execution directory as part of the deployment settings file and try again.";
+                    throw new DockerBuildFailedException(DeployToolErrorCode.DockerBuildFailed, errorMessage);
+                }
 
-                    _toolInteractiveService.WriteLine(string.Empty);
-                    var answer = _consoleUtilities.AskYesNoQuestion("Do you want to go back and modify the current configuration?", "false");
-                    if (answer == YesNo.Yes)
+                _toolInteractiveService.WriteLine(string.Empty);
+                var answer = _consoleUtilities.AskYesNoQuestion("Do you want to go back and modify the current configuration?", "false");
+                if (answer == YesNo.Yes)
+                {
+                    string dockerExecutionDirectory;
+                    do
                     {
-                        var dockerExecutionDirectory =
-                        _consoleUtilities.AskUserForValue(
+                        dockerExecutionDirectory = _consoleUtilities.AskUserForValue(
                             "Enter the docker execution directory where the docker build command will be executed from:",
                             selectedRecommendation.DeploymentBundle.DockerExecutionDirectory,
                             allowEmpty: true);
 
                         if (!_directoryManager.Exists(dockerExecutionDirectory))
-                            continue;
-
-                        selectedRecommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;
-                    }
-                    else
-                    {
-                        if (!selectedRecommendation.ProjectDefinition.HasDockerFile)
                         {
-                            var projectDirectory = _directoryManager.GetDirectoryInfo(selectedRecommendation.ProjectPath).Parent.FullName;
-                            var dockerfilePath = Path.Combine(projectDirectory, "Dockerfile");
-                            var errorMessage = $"Failed to create a container image from generated Docker file. " +
-                                $"Please edit the Dockerfile at {dockerfilePath} to correct the required build steps for the project. Common errors are missing project dependencies not included in the Dockerfile.";
-
-                            throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile, errorMessage);
+                            _toolInteractiveService.WriteErrorLine($"Error, directory does not exist \"{dockerExecutionDirectory}\"");
                         }
-                        throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundle, "Failed to create a deployment bundle");
-                    }
-                }
-            }
-            else if (selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.DotnetPublishZipFile)
-            {
-                _orchestratorInteractiveService.LogSectionStart("Creating deployment zip bundle",
-                    "Using the dotnet CLI build the project and zip the publish artifacts.");
+                    } while (!_directoryManager.Exists(dockerExecutionDirectory));
 
-                var dotnetPublishDeploymentBundleResult = await orchestrator.CreateDotnetPublishDeploymentBundle(selectedRecommendation);
-                if (!dotnetPublishDeploymentBundleResult)
-                    throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateDotnetPublishDeploymentBundle, "Failed to create a deployment bundle");
+                    selectedRecommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;
+                    await CreateDeploymentBundle(orchestrator, selectedRecommendation, cloudApplication);
+                }
             }
         }
 

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -468,15 +468,13 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             var cdkProjectHandler = CreateCdkProjectHandler(state, serviceProvider);
 
-            var directoryManager = new DirectoryManager();
-
             if (state.SelectedRecommendation == null)
                 throw new SelectedRecommendationIsNullException("The selected recommendation is null or invalid.");
 
             if (!state.SelectedRecommendation.Recipe.DeploymentType.Equals(Common.Recipes.DeploymentTypes.CdkProject))
                 throw new SelectedRecommendationIsIncompatibleException($"We cannot generate a CloudFormation template for the selected recommendation as it is not of type '{nameof(Models.DeploymentTypes.CloudFormationStack)}'.");
 
-            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation, directoryManager);
+            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation);
             var cloudFormationTemplate = await task.GenerateCloudFormationTemplate(cdkProjectHandler);
             var output = new GenerateCloudFormationTemplateOutput(cloudFormationTemplate);
 
@@ -503,8 +501,6 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             var orchestrator = CreateOrchestrator(state, serviceProvider);
 
-            var directoryManager = new DirectoryManager();
-
             if (state.SelectedRecommendation == null)
                 throw new SelectedRecommendationIsNullException("The selected recommendation is null or invalid.");
 
@@ -521,7 +517,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             if (capabilities.Any())
                 return Problem($"Unable to start deployment due to missing system capabilities.{Environment.NewLine}{missingCapabilitiesMessage}");
 
-            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation, directoryManager);
+            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation);
             state.DeploymentTask = task.Execute();
 
             return Ok();

--- a/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Tasks/DeployRecommendationTask.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
-using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration;
 
@@ -19,20 +17,18 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
         private readonly Orchestrator _orchestrator;
         private readonly OrchestratorSession _orchestratorSession;
         private readonly Recommendation _selectedRecommendation;
-        private readonly IDirectoryManager _directoryManager;
 
-        public DeployRecommendationTask(OrchestratorSession orchestratorSession, Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation selectedRecommendation, IDirectoryManager directoryManager)
+        public DeployRecommendationTask(OrchestratorSession orchestratorSession, Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation selectedRecommendation)
         {
             _orchestratorSession = orchestratorSession;
             _orchestrator = orchestrator;
             _cloudApplication = cloudApplication;
             _selectedRecommendation = selectedRecommendation;
-            _directoryManager = directoryManager;
         }
 
         public async Task Execute()
         {
-            await CreateDeploymentBundle();
+            await _orchestrator.CreateDeploymentBundle(_cloudApplication, _selectedRecommendation);
             await _orchestrator.DeployRecommendation(_cloudApplication, _selectedRecommendation);
         }
 
@@ -46,7 +42,8 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
             if (cdkProjectHandler == null)
                 throw new FailedToCreateCDKProjectException(DeployToolErrorCode.FailedToCreateCDKProject, $"We could not create a CDK deployment project due to a missing dependency '{nameof(cdkProjectHandler)}'.");
 
-            await CreateDeploymentBundle();
+            await _orchestrator.CreateDeploymentBundle(_cloudApplication, _selectedRecommendation);
+
             var cdkProject = await cdkProjectHandler.ConfigureCdkProject(_orchestratorSession, _cloudApplication, _selectedRecommendation);
             try
             {
@@ -55,33 +52,6 @@ namespace AWS.Deploy.CLI.ServerMode.Tasks
             finally
             {
                 cdkProjectHandler.DeleteTemporaryCdkProject(cdkProject);
-            }
-        }
-
-        private async Task CreateDeploymentBundle()
-        {
-            if (_selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.Container)
-            {
-                var dockerBuildDeploymentBundleResult = await _orchestrator.CreateContainerDeploymentBundle(_cloudApplication, _selectedRecommendation);
-                if (!dockerBuildDeploymentBundleResult)
-                {
-                    if (!_selectedRecommendation.ProjectDefinition.HasDockerFile)
-                    {
-                        var projectDirectory = _directoryManager.GetDirectoryInfo(_selectedRecommendation.ProjectPath).Parent.FullName;
-                        var dockerfilePath = Path.Combine(projectDirectory, "Dockerfile");
-                        var errorMessage = $"Failed to create a container image from generated Docker file. " +
-                            $"Please edit the Dockerfile at {dockerfilePath} to correct the required build steps for the project. Common errors are missing project dependencies not included in the Dockerfile.";
-
-                        throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile, errorMessage);
-                    }
-                    throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundle, "Failed to create a deployment bundle");
-                }
-            }
-            else if (_selectedRecommendation.Recipe.DeploymentBundle == DeploymentBundleTypes.DotnetPublishZipFile)
-            {
-                var dotnetPublishDeploymentBundleResult = await _orchestrator.CreateDotnetPublishDeploymentBundle(_selectedRecommendation);
-                if (!dotnetPublishDeploymentBundleResult)
-                    throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateDotnetPublishDeploymentBundle, "Failed to create a deployment bundle");
             }
         }
     }

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/CLITests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/CLITests.cs
@@ -24,7 +24,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
         public async Task DeployToExistingBeanstalkEnvironment()
         {
             var projectPath = _fixture.TestAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _fixture.EnvironmentName, "--diagnostics", "--silent" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _fixture.EnvironmentName, "--diagnostics", "--silent", "--region", "us-west-2" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _fixture.App.Run(deployArgs));
 
             var environmentDescription = await _fixture.AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(_fixture.EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
@@ -30,7 +30,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
         public async Task DeployToExistingBeanstalkEnvironment()
         {
             var projectPath = _fixture.TestAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
-            var portNumber = 4001;
+            var portNumber = 4031;
             using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_fixture.ToolInteractiveService, portNumber, null, true);

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -79,7 +79,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
             _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
-            var portNumber = 4001;
+            var portNumber = 4021;
             using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -162,7 +162,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             _stackName = $"ServerModeWebFargate{Guid.NewGuid().ToString().Split('-').Last()}";
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
-            var portNumber = 4001;
+            var portNumber = 4011;
             using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
@@ -211,6 +211,11 @@ namespace AWS.Deploy.CLI.IntegrationTests
                 Assert.Equal(StackStatus.CREATE_COMPLETE, stackStatus);
 
                 Assert.True(logOutput.Length > 0);
+
+                // Make sure section header is return to output log
+                Assert.Contains("Creating deployment image", logOutput.ToString());
+
+                // Make sure normal log messages are returned to output log
                 Assert.Contains("Pushing container image", logOutput.ToString());
 
                 var redeploymentSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
@@ -334,13 +339,21 @@ namespace AWS.Deploy.CLI.IntegrationTests
             // Do an initial delay to avoid a race condition of the status being checked before the deployment has kicked off.
             await Task.Delay(TimeSpan.FromSeconds(3));
 
+            GetDeploymentStatusOutput output = null;
+
             await WaitUntilHelper.WaitUntil(async () =>
             {
-                DeploymentStatus status = (await restApiClient.GetDeploymentStatusAsync(sessionId)).Status; ;
-                return status != DeploymentStatus.Executing;
+                output = (await restApiClient.GetDeploymentStatusAsync(sessionId));
+
+                return output.Status != DeploymentStatus.Executing;
             }, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(15));
 
-            return (await restApiClient.GetDeploymentStatusAsync(sessionId)).Status;
+            if (output.Exception != null)
+            {
+                throw new Exception("Error waiting on stack status: " + output.Exception.Message);
+            }
+
+            return output.Status;
         }
 
 


### PR DESCRIPTION
*Description of changes:*
The CLI and ServerMode had separate `CreateDeploymentBundle` method implementations. This caused issues with the recent new change to add new logging section headers because only the CLI version had the section header.

This PR pushes the `CreateDeploymentBundle` into the Orchestrator so both the CLI and ServerMode can use the same implementation. The CLI implementation did have the interactive part to ask the user if they want to change the Docker execution directory if the build failed. I kept that logic in the CLI but it only prompts if `CreateDeploymentBundle` in the Orchestrator throws an exception with the container build error code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
