### PR TITLE
fix: Fixed issue with Beanstalk Application and Environment name

### DIFF
--- a/src/AWS.Deploy.CLI/TypeHintResponses/BeanstalkApplicationTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/BeanstalkApplicationTypeHintResponse.cs
@@ -12,16 +12,21 @@ namespace AWS.Deploy.CLI.TypeHintResponses
     public class BeanstalkApplicationTypeHintResponse : IDisplayable
     {
         public bool CreateNew { get; set; }
-        public string ApplicationName { get; set; }
+        public string? ApplicationName { get; set; }
+        public string? ExistingApplicationName { get; set; }
 
         public BeanstalkApplicationTypeHintResponse(
-            bool createNew,
-            string applicationName)
+            bool createNew)
         {
             CreateNew = createNew;
-            ApplicationName = applicationName;
         }
 
-        public string ToDisplayString() => ApplicationName;
+        public string ToDisplayString()
+        {
+            if (CreateNew)
+                return ApplicationName!;
+            else
+                return ExistingApplicationName!;
+        }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/BeanstalkApplicationConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/BeanstalkApplicationConfiguration.cs
@@ -12,7 +12,8 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
     public partial class BeanstalkApplicationConfiguration
     {
         public bool CreateNew { get; set; }
-        public string ApplicationName { get; set; }
+        public string? ApplicationName { get; set; }
+        public string? ExistingApplicationName { get; set; }
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
@@ -25,11 +26,9 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
 #nullable restore warnings
 
         public BeanstalkApplicationConfiguration(
-            bool createNew,
-            string applicationName)
+            bool createNew)
         {
             CreateNew = createNew;
-            ApplicationName = applicationName;
         }
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/BeanstalkEnvironmentConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/BeanstalkEnvironmentConfiguration.cs
@@ -11,7 +11,6 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
 {
     public partial class BeanstalkEnvironmentConfiguration
     {
-        public bool CreateNew { get; set; }
         public string EnvironmentName { get; set; }
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
@@ -25,10 +24,8 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
 #nullable restore warnings
 
         public BeanstalkEnvironmentConfiguration(
-            bool createNew,
             string environmentName)
         {
-            CreateNew = createNew;
             EnvironmentName = environmentName;
         }
     }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -98,15 +98,47 @@
                     "Name": "Application Name",
                     "Description": "The Elastic Beanstalk application name.",
                     "Type": "String",
+                    "DefaultValue": "{StackName}",
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "BeanstalkApplication.CreateNew",
+                            "Value": true
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^[^/]{1,100}$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid Application Name. The Application name can contain up to 100 Unicode characters, not including forward slash (/)."
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "ExistingApplicationName",
+                    "Name": "Application Name",
+                    "Description": "The Elastic Beanstalk application name.",
+                    "Type": "String",
                     "TypeHint": "ExistingBeanstalkApplication",
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "BeanstalkApplication.CreateNew",
+                            "Value": false
+                        }
+                    ],
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
-                            "Configuration" : {
+                            "Configuration": {
                                 "Regex": "^[^/]{1,100}$",
+                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid Application Name. The Application name can contain up to 100 Unicode characters, not including forward slash (/)."
                             }
                         }
@@ -120,26 +152,15 @@
             "Name": "Environment Name",
             "Description": "The Elastic Beanstalk environment name.",
             "Type": "Object",
-            "TypeHint": "BeanstalkEnvironment",
             "AdvancedSetting": false,
             "Updatable": false,
             "ChildOptionSettings": [
-                {
-                    "Id": "CreateNew",
-                    "Name": "Create new Elastic Beanstalk environment",
-                    "Description": "Do you want to create a new environment?",
-                    "Type": "Bool",
-                    "DefaultValue": true,
-                    "AdvancedSetting": false,
-                    "Updatable": false
-                },
                 {
                     "Id": "EnvironmentName",
                     "ParentSettingId": "BeanstalkApplication.ApplicationName",
                     "Name": "Environment Name",
                     "Description": "The Elastic Beanstalk environment name.",
                     "Type": "String",
-                    "TypeHint": "BeanstalkEnvironment",
                     "DefaultValue": "{StackName}-dev",
                     "AdvancedSetting": false,
                     "Updatable": false,

--- a/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
+++ b/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
@@ -7,7 +7,6 @@
             "ApplicationName": "MyApplication{Suffix}"
         },
         "BeanstalkEnvironment": {
-            "CreateNew": true,
             "EnvironmentName": "MyEnvironment{Suffix}"
         },
         "EnvironmentType": "LoadBalanced",


### PR DESCRIPTION
*Description of changes:*
The Beanstalk recipe had 2 issues with the settings.

* **Application Name** - This is a object setting with a **CreateNew** child setting. In the original version the **ApplicationName** setting was incorrectly being used for either new application names or existing application names. This has been fixed to have a separate **ExistingApplicationName** for existing application names. The **ExistingApplicationName** has the type hint telling and the **ApplicationName** is just a pure text entry. 
* **Environment Name** - This object setting incorrectly had a **CreateNew** setting that would allow selecting an existing Beanstalk environment name. The CDK project doesn't support using a Beanstalk environment that doesn't belong to the stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
