### PR TITLE
fix: Add new error code to indicate deployment bundle creation failure from a generate docker file

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -706,6 +706,15 @@ namespace AWS.Deploy.CLI.Commands
                     }
                     else
                     {
+                        if (!selectedRecommendation.ProjectDefinition.HasDockerFile)
+                        {
+                            var projectDirectory = _directoryManager.GetDirectoryInfo(selectedRecommendation.ProjectPath).Parent.FullName;
+                            var dockerfilePath = Path.Combine(projectDirectory, "Dockerfile");
+                            var errorMessage = $"Failed to create a container image from generated Docker file. " +
+                                $"Please edit the Dockerfile at {dockerfilePath} to correct the required build steps for the project. Common errors are missing project dependencies not included in the Dockerfile.";
+
+                            throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile, errorMessage);
+                        }
                         throw new FailedToCreateDeploymentBundleException(DeployToolErrorCode.FailedToCreateContainerDeploymentBundle, "Failed to create a deployment bundle");
                     }
                 }

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -468,13 +468,15 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             var cdkProjectHandler = CreateCdkProjectHandler(state, serviceProvider);
 
+            var directoryManager = new DirectoryManager();
+
             if (state.SelectedRecommendation == null)
                 throw new SelectedRecommendationIsNullException("The selected recommendation is null or invalid.");
 
             if (!state.SelectedRecommendation.Recipe.DeploymentType.Equals(Common.Recipes.DeploymentTypes.CdkProject))
                 throw new SelectedRecommendationIsIncompatibleException($"We cannot generate a CloudFormation template for the selected recommendation as it is not of type '{nameof(Models.DeploymentTypes.CloudFormationStack)}'.");
 
-            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation);
+            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation, directoryManager);
             var cloudFormationTemplate = await task.GenerateCloudFormationTemplate(cdkProjectHandler);
             var output = new GenerateCloudFormationTemplateOutput(cloudFormationTemplate);
 
@@ -501,6 +503,8 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             var orchestrator = CreateOrchestrator(state, serviceProvider);
 
+            var directoryManager = new DirectoryManager();
+
             if (state.SelectedRecommendation == null)
                 throw new SelectedRecommendationIsNullException("The selected recommendation is null or invalid.");
 
@@ -517,7 +521,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             if (capabilities.Any())
                 return Problem($"Unable to start deployment due to missing system capabilities.{Environment.NewLine}{missingCapabilitiesMessage}");
 
-            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation);
+            var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation, directoryManager);
             state.DeploymentTask = task.Execute();
 
             return Ok();

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -109,7 +109,8 @@ namespace AWS.Deploy.Common
         FailedToGetCredentialsForProfile = 10008900,
         FailedToRunCDKDiff = 10009000,
         FailedToCreateCDKProject = 10009100,
-        ResourceQuery = 10009200
+        ResourceQuery = 10009200,
+        FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile = 10009300
     }
 
     public class ProjectFileNotFoundException : DeployToolException


### PR DESCRIPTION
*Description of changes:*
This PR adds a new error code to distinguish `FailedToCreateDeploymentBundleException` when using a generated Docker file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
