### PR TITLE
feat: Skip executing "cdk deploy" if CDKToolkit stack already exists

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -18,6 +18,7 @@
 ** AWSSDK.Extensions.NETCore.Setup; version 3.7.1 -- https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup
 ** AWSSDK.IdentityManagement; version 3.7.2.25 -- https://www.nuget.org/packages/AWSSDK.IdentityManagement
 ** AWSSDK.SecurityToken; version 3.7.1.35 -- https://www.nuget.org/packages/AWSSDK.SecurityToken
+** AWSSDK.SimpleSystemsManagement; version 3.7.16 -- https://www.nuget.org/packages/AWSSDK.SimpleSystemsManagement
 ** Constructs; version 10.0.0 -- https://www.nuget.org/packages/Constructs
 ** Amazon.CDK.Lib; version 2.13.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
 ** Amazon.JSII.Runtime; version 1.54.0 -- https://www.nuget.org/packages/Amazon.JSII.Runtime

--- a/src/AWS.Deploy.Constants/CDK.cs
+++ b/src/AWS.Deploy.Constants/CDK.cs
@@ -27,5 +27,15 @@ namespace AWS.Deploy.Constants
         /// The file path of the CDK bootstrap template to be used
         /// </summary>
         public static string CDKBootstrapTemplatePath => Path.Combine(DeployToolWorkspaceDirectoryRoot, "CDKBootstrapTemplate.yaml");
+
+        /// <summary>
+        /// The version number CDK bootstrap specified in CDKBootstrapTemplate.yaml
+        /// </summary>
+        public const int CDKTemplateVersion = 12;
+
+        /// <summary>
+        /// The name of the CDK bootstrap CloudFormation stack
+        /// </summary>
+        public const string CDKBootstrapStackName = "CDKToolkit";
     }
 }

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.7.14" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.1.17" />
     <PackageReference Include="AWSSDK.AppRunner" Version="3.7.3.11" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.16" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="5.0.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="5.0.1" />

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -36,6 +36,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticLoadBalancingV2.Model.Listener>> DescribeElasticLoadBalancerListeners(string loadBalancerArn) => throw new NotImplementedException();
         public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
+        public Task<Stack> GetCloudFormationStack(string stackName) => throw new NotImplementedException();
         public Task<List<AuthorizationData>> GetECRAuthorizationToken() => throw new NotImplementedException();
         public Task<List<Repository>> GetECRRepositories(List<string> repositoryNames) => throw new NotImplementedException();
         public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns() => throw new NotImplementedException();
@@ -63,5 +64,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
         public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
+        public Task<string?> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -28,6 +28,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
         public Task<Repository> CreateECRRepository(string repositoryName) => throw new NotImplementedException();
         public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
+        public Task<Stack> GetCloudFormationStack(string stackName) => throw new NotImplementedException();
 
         public Task<List<AuthorizationData>> GetECRAuthorizationToken()
         {
@@ -88,5 +89,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
         public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
+        public Task<string?> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKProjectHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKProjectHandlerTests.cs
@@ -1,0 +1,125 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Orchestration.CDK;
+using AWS.Deploy.Orchestration.Data;
+using AWS.Deploy.Orchestration.Utilities;
+using Moq;
+using Xunit;
+using Amazon.CloudFormation.Model;
+using System.Collections.Generic;
+
+namespace AWS.Deploy.Orchestration.UnitTests.CDK
+{
+    public class CDKProjectHandlerTests
+    {
+        [Fact]
+        public async Task CheckCDKBootstrap_DoesNotExist()
+        {
+            var interactiveService = new Mock<IOrchestratorInteractiveService>();
+            var commandLineWrapper = new Mock<ICommandLineWrapper>();
+            var fileManager = new Mock<IFileManager>();
+
+            var awsResourceQuery = new Mock<IAWSResourceQueryer>();
+            awsResourceQuery.Setup(x => x.GetCloudFormationStack(It.IsAny<string>())).Returns(Task.FromResult<Stack>(null));
+
+
+            var cdkProjectHandler = new CdkProjectHandler(interactiveService.Object, commandLineWrapper.Object, awsResourceQuery.Object, fileManager.Object);
+
+            Assert.True(await cdkProjectHandler.DetermineIfCDKBootstrapShouldRun());
+        }
+
+        [Fact]
+        public async Task CheckCDKBootstrap_NoCFParameter()
+        {
+            var interactiveService = new Mock<IOrchestratorInteractiveService>();
+            var commandLineWrapper = new Mock<ICommandLineWrapper>();
+            var fileManager = new Mock<IFileManager>();
+
+            var awsResourceQuery = new Mock<IAWSResourceQueryer>();
+            awsResourceQuery.Setup(x => x.GetCloudFormationStack(It.IsAny<string>())).Returns(Task.FromResult<Stack>(new Stack { Parameters = new List<Parameter>() }));
+
+
+            var cdkProjectHandler = new CdkProjectHandler(interactiveService.Object, commandLineWrapper.Object, awsResourceQuery.Object, fileManager.Object);
+
+            Assert.True(await cdkProjectHandler.DetermineIfCDKBootstrapShouldRun());
+        }
+
+        [Fact]
+        public async Task CheckCDKBootstrap_NoSSMParameter()
+        {
+            var interactiveService = new Mock<IOrchestratorInteractiveService>();
+            var commandLineWrapper = new Mock<ICommandLineWrapper>();
+            var fileManager = new Mock<IFileManager>();
+
+            var awsResourceQuery = new Mock<IAWSResourceQueryer>();
+            awsResourceQuery.Setup(x => x.GetCloudFormationStack(It.IsAny<string>())).Returns(Task.FromResult<Stack>(
+                new Stack { Parameters = new List<Parameter>() { new Parameter { ParameterKey = "Qualifier", ParameterValue = "q1" } } }));
+
+
+            var cdkProjectHandler = new CdkProjectHandler(interactiveService.Object, commandLineWrapper.Object, awsResourceQuery.Object, fileManager.Object);
+
+            Assert.True(await cdkProjectHandler.DetermineIfCDKBootstrapShouldRun());
+        }
+
+        [Fact]
+        public async Task CheckCDKBootstrap_SSMParameterOld()
+        {
+            var interactiveService = new Mock<IOrchestratorInteractiveService>();
+            var commandLineWrapper = new Mock<ICommandLineWrapper>();
+            var fileManager = new Mock<IFileManager>();
+
+            var awsResourceQuery = new Mock<IAWSResourceQueryer>();
+            awsResourceQuery.Setup(x => x.GetCloudFormationStack(It.IsAny<string>())).Returns(Task.FromResult<Stack>(
+                new Stack { Parameters = new List<Parameter>() { new Parameter { ParameterKey = "Qualifier", ParameterValue = "q1" } } }));
+
+            awsResourceQuery.Setup(x => x.GetParameterStoreTextValue(It.IsAny<string>())).Returns(Task.FromResult<string>("1"));
+
+
+            var cdkProjectHandler = new CdkProjectHandler(interactiveService.Object, commandLineWrapper.Object, awsResourceQuery.Object, fileManager.Object);
+
+            Assert.True(await cdkProjectHandler.DetermineIfCDKBootstrapShouldRun());
+        }
+
+        [Fact]
+        public async Task CheckCDKBootstrap_SSMParameterNewer()
+        {
+            var interactiveService = new Mock<IOrchestratorInteractiveService>();
+            var commandLineWrapper = new Mock<ICommandLineWrapper>();
+            var fileManager = new Mock<IFileManager>();
+
+            var awsResourceQuery = new Mock<IAWSResourceQueryer>();
+            awsResourceQuery.Setup(x => x.GetCloudFormationStack(It.IsAny<string>())).Returns(Task.FromResult<Stack>(
+                new Stack { Parameters = new List<Parameter>() { new Parameter { ParameterKey = "Qualifier", ParameterValue = "q1" } } }));
+
+            awsResourceQuery.Setup(x => x.GetParameterStoreTextValue(It.IsAny<string>())).Returns(Task.FromResult<string>("100"));
+
+
+            var cdkProjectHandler = new CdkProjectHandler(interactiveService.Object, commandLineWrapper.Object, awsResourceQuery.Object, fileManager.Object);
+
+            Assert.False(await cdkProjectHandler.DetermineIfCDKBootstrapShouldRun());
+        }
+
+        [Fact]
+        public async Task CheckCDKBootstrap_SSMParameterSame()
+        {
+            var interactiveService = new Mock<IOrchestratorInteractiveService>();
+            var commandLineWrapper = new Mock<ICommandLineWrapper>();
+            var fileManager = new Mock<IFileManager>();
+
+            var awsResourceQuery = new Mock<IAWSResourceQueryer>();
+            awsResourceQuery.Setup(x => x.GetCloudFormationStack(It.IsAny<string>())).Returns(Task.FromResult<Stack>(
+                new Stack { Parameters = new List<Parameter>() { new Parameter { ParameterKey = "Qualifier", ParameterValue = "q1" } } }));
+
+            awsResourceQuery.Setup(x => x.GetParameterStoreTextValue(It.IsAny<string>())).Returns(Task.FromResult<string>(AWS.Deploy.Constants.CDK.CDKTemplateVersion.ToString()));
+
+
+            var cdkProjectHandler = new CdkProjectHandler(interactiveService.Object, commandLineWrapper.Object, awsResourceQuery.Object, fileManager.Object);
+
+            Assert.False(await cdkProjectHandler.DetermineIfCDKBootstrapShouldRun());
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Before executing "cdk bootstrap" command to make create the CDK bootstrap CloudFormation stack check to see if the stack already exists. If it does exist and its version checked in parameter store is at least the version that the deploy uses then skip calling out to the CDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
