### PR TITLE
fix: Security Group option setting in App Runner recipe has an invalid name

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -452,7 +452,7 @@
                 },
                 {
                     "Id": "SecurityGroups",
-                    "Name": "SecurityGroups",
+                    "Name": "Security Groups",
                     "Description": "A list of IDs of security groups that App Runner should use for access to AWS resources under the specified subnets. If not specified, App Runner uses the default security group of the Amazon VPC. The default security group allows all outbound traffic.",
                     "Type": "List",
                     "TypeHint": "ExistingSecurityGroups",


### PR DESCRIPTION
*Description of changes:*
Security Group option setting in App Runner recipe has an invalid name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
