### PR TITLE
chore: improve error handling for failed first time deployments

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -110,7 +110,8 @@ namespace AWS.Deploy.Common
         FailedToRunCDKDiff = 10009000,
         FailedToCreateCDKProject = 10009100,
         ResourceQuery = 10009200,
-        FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile = 10009300
+        FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile = 10009300,
+        FailedToRetrieveStackId = 10009400
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
 using AWS.Deploy.Common;
@@ -12,6 +13,7 @@ using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.Recipes.CDK.Common;
+using Stack = Amazon.CloudFormation.Model.Stack;
 
 namespace AWS.Deploy.Orchestration
 {
@@ -124,20 +126,48 @@ namespace AWS.Deploy.Orchestration
             _interactiveService.LogSectionStart("Deploying AWS CDK project",
                 "Use the CDK project to create or update the AWS CloudFormation stack and deploy the project to the AWS resources in the stack.");
 
-            var deploymentStartDate = DateTime.Now;
             // Handover to CDK command line tool
             // Use a CDK Context parameter to specify the settings file that has been serialized.
-            var cdkDeploy = await _commandLineWrapper.TryRunWithResult($"npx cdk deploy --require-approval never -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
+            var cdkDeployTask = _commandLineWrapper.TryRunWithResult( $"npx cdk deploy --require-approval never -c {Constants.CloudFormationIdentifier.SETTINGS_PATH_CDK_CONTEXT_PARAMETER}=\"{appSettingsFilePath}\"",
                 workingDirectory: cdkProjectPath,
                 environmentVariables: environmentVariables,
                 needAwsCredentials: true,
                 redirectIO: true,
                 streamOutputToInteractiveService: true);
 
-            await CheckCdkDeploymentFailure(cloudApplication, deploymentStartDate);
+            var cancellationTokenSource = new CancellationTokenSource();
+            var retrieveStackIdTask = RetrieveStackId(cloudApplication, cancellationTokenSource.Token);
 
+            var deploymentStartDate = DateTime.UtcNow;
+            var firstCompletedTask = await Task.WhenAny(cdkDeployTask, retrieveStackIdTask);
+            // Deployment end date is captured at this point after 1 of the 2 running tasks yields.
+            var deploymentEndDate = DateTime.UtcNow;
+
+            TryRunResult? cdkDeploy = null;
+            if (firstCompletedTask == retrieveStackIdTask)
+            {
+                // If retrieveStackIdTask completes first, that means a stack was created and exists in CloudFormation.
+                // We can proceed with checking for deployment failures.
+                var stackId = cloudApplication.Name;
+                if (!retrieveStackIdTask.IsFaulted)
+                    stackId = retrieveStackIdTask.Result;
+                cdkDeploy = await cdkDeployTask;
+                // We recapture the deployment end date at this point after the deployment task completes.
+                deploymentEndDate = DateTime.UtcNow;
+                await CheckCdkDeploymentFailure(stackId, deploymentStartDate, deploymentEndDate);
+            }
+            else
+            {
+                // If cdkDeployTask completes first, that means 'cdk deploy' failed before creating a stack in CloudFormation.
+                // In this case, we skip checking for deployment failures since a stack does not exist.
+
+                cdkDeploy = cdkDeployTask.Result;
+                cancellationTokenSource.Cancel();
+            }
+
+            var deploymentTotalTime = Math.Round((deploymentEndDate - deploymentStartDate).TotalSeconds, 2);
             if (cdkDeploy.ExitCode != 0)
-                throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToDeployCdkApplication, "We had an issue deploying your application to AWS. Check the deployment output for more details.");
+                throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToDeployCdkApplication, $"We had an issue deploying your application to AWS. Check the deployment output for more details. Deployment took {deploymentTotalTime}s.");
         }
 
         public async Task<bool> DetermineIfCDKBootstrapShouldRun()
@@ -168,17 +198,41 @@ namespace AWS.Deploy.Orchestration
             return false;
         }
 
-        private async Task CheckCdkDeploymentFailure(CloudApplication cloudApplication, DateTime deploymentStartDate)
+        private async Task<string> RetrieveStackId(CloudApplication cloudApplication, CancellationToken cancellationToken)
+        {
+            Stack? stack = null;
+            await WaitUntilHelper.WaitUntil(async () =>
+            {
+                try
+                {
+                    stack = await _awsResourceQueryer.GetCloudFormationStack(cloudApplication.Name);
+                    return stack != null;
+                }
+                catch (ResourceQueryException exception) when (exception.InnerException != null && exception.InnerException.Message.Equals($"Stack with id {cloudApplication.Name} does not exist"))
+                {
+                    return false;
+                }
+            }, TimeSpan.FromSeconds(3), TimeSpan.FromMinutes(5), cancellationToken);
+
+            return stack?.StackId ?? throw new ResourceQueryException(DeployToolErrorCode.FailedToRetrieveStackId, "We were unable to retrieve the CloudFormation stack identifier.");
+        }
+
+        private async Task CheckCdkDeploymentFailure(string stackId, DateTime deploymentStartDate, DateTime deploymentEndDate)
         {
             try
             {
-                var stackEvents = await _awsResourceQueryer.GetCloudFormationStackEvents(cloudApplication.Name);
-                
+                var stackEvents = await _awsResourceQueryer.GetCloudFormationStackEvents(stackId);
+
                 var failedEvents = stackEvents
-                    .Where(x => x.Timestamp >= deploymentStartDate)
+                    .Where(x => x.Timestamp.ToUniversalTime() >= deploymentStartDate)
                     .Where(x =>
                         x.ResourceStatus.Equals(ResourceStatus.CREATE_FAILED) ||
-                        x.ResourceStatus.Equals(ResourceStatus.UPDATE_FAILED)
+                        x.ResourceStatus.Equals(ResourceStatus.DELETE_FAILED) ||
+                        x.ResourceStatus.Equals(ResourceStatus.UPDATE_FAILED) ||
+                        x.ResourceStatus.Equals(ResourceStatus.IMPORT_FAILED) ||
+                        x.ResourceStatus.Equals(ResourceStatus.IMPORT_ROLLBACK_FAILED) ||
+                        x.ResourceStatus.Equals(ResourceStatus.UPDATE_ROLLBACK_FAILED) ||
+                        x.ResourceStatus.Equals(ResourceStatus.ROLLBACK_FAILED)
                     );
                 if (failedEvents.Any())
                 {
@@ -186,9 +240,10 @@ namespace AWS.Deploy.Orchestration
                     throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToDeployCdkApplication, errors);
                 }
             }
-            catch (AmazonCloudFormationException exception) when (exception.ErrorCode.Equals("ValidationError") && exception.Message.Equals($"Stack [{cloudApplication.Name}] does not exist"))
+            catch (ResourceQueryException exception) when (exception.InnerException != null && exception.InnerException.Message.Equals($"Stack [{stackId}] does not exist"))
             {
-                throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToCreateCdkStack, "A CloudFormation stack was not created. Check the deployment output for more details.");
+                var deploymentTotalTime = Math.Round((deploymentEndDate - deploymentStartDate).TotalSeconds, 2);
+                throw new FailedToDeployCDKAppException(DeployToolErrorCode.FailedToCreateCdkStack, $"A CloudFormation stack was not created. Check the deployment output for more details. Deployment took {deploymentTotalTime}s.");
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -163,12 +163,15 @@ namespace AWS.Deploy.Orchestration.Data
         public async Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName)
         {
             var cfClient = _awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
-            var listInstanceTypesPaginator = cfClient.Paginators.DescribeStackEvents(new DescribeStackEventsRequest
+            var request = new DescribeStackEventsRequest
             {
                 StackName = stackName
-            });
+            };
 
-            return await HandleException(async () => await listInstanceTypesPaginator.StackEvents.ToListAsync());
+            return await HandleException(async () => await cfClient.Paginators
+                .DescribeStackEvents(request)
+                .StackEvents
+                .ToListAsync());
         }
 
         public async Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes()

--- a/src/AWS.Deploy.Orchestration/Utilities/WaitUntilHelper.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/WaitUntilHelper.cs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
-namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+namespace AWS.Deploy.Orchestration.Utilities
 {
     public static class WaitUntilHelper
     {
@@ -15,11 +16,11 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
         /// <param name="frequency">Interval between the two executions of the task</param>
         /// <param name="timeout">Interval for timeout, if timeout passes, methods throws <see cref="TimeoutException"/></param>
         /// <exception cref="TimeoutException">Throws when timeout passes</exception>
-        public static async Task WaitUntil(Func<Task<bool>> predicate, TimeSpan frequency, TimeSpan timeout)
+        public static async Task WaitUntil(Func<Task<bool>> predicate, TimeSpan frequency, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             var waitTask = Task.Run(async () =>
             {
-                while (!await predicate())
+                while (!cancellationToken.IsCancellationRequested && !await predicate())
                 {
                     await Task.Delay(frequency);
                 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ServerModeTests.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using AWS.Deploy.CLI.Commands;
-using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.ServerMode.Client;
 using Xunit;
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/HttpHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/HttpHelper.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.Utilities;
 using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Helpers

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -17,6 +17,7 @@ using AWS.Deploy.CLI.IntegrationTests.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Helpers;
 using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.CLI.ServerMode;
+using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.ServerMode.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -64,6 +64,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
         public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
-        public Task<string?> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
+        public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -89,6 +89,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors() => throw new NotImplementedException();
         public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
-        public Task<string?> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
+        public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5899
DOTNET-5896

*Description of changes:*
* Added missing CloudFormation event statuses to capture all failed events
* Added ability to retrieve unique stack id to retrieve stack events even after deployment finishes (whether the stack is deleted or not)
* Added metric to check deployment time which will help in analysis of errors in telemetry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
