### PR TITLE
fix: Add stack name validation in server mode

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -505,7 +505,7 @@ namespace AWS.Deploy.CLI.Commands
                 if (_cloudApplicationNameGenerator.IsValidName(applicationName))
                     return applicationName;
 
-                PrintInvalidApplicationNameMessage();
+                PrintInvalidApplicationNameMessage(applicationName);
                 throw new InvalidCliArgumentException(DeployToolErrorCode.InvalidCliArguments, "Found invalid CLI arguments");
             }
 
@@ -515,7 +515,7 @@ namespace AWS.Deploy.CLI.Commands
                 if (_cloudApplicationNameGenerator.IsValidName(userDeploymentSettings.ApplicationName))
                     return userDeploymentSettings.ApplicationName;
 
-                PrintInvalidApplicationNameMessage();
+                PrintInvalidApplicationNameMessage(userDeploymentSettings.ApplicationName);
                 throw new InvalidUserDeploymentSettingsException(DeployToolErrorCode.UserDeploymentInvalidStackName, "Please provide a valid cloud application name and try again.");
             }
 
@@ -603,7 +603,7 @@ namespace AWS.Deploy.CLI.Commands
                         defaultAskValuePrompt: inputPrompt);
 
                 if (string.IsNullOrEmpty(cloudApplicationName) || !_cloudApplicationNameGenerator.IsValidName(cloudApplicationName))
-                    PrintInvalidApplicationNameMessage();
+                    PrintInvalidApplicationNameMessage(cloudApplicationName);
                 else if (deployedApplications.Any(x => x.Name.Equals(cloudApplicationName)))
                     PrintApplicationNameAlreadyExistsMessage();
                 else
@@ -645,12 +645,10 @@ namespace AWS.Deploy.CLI.Commands
             return selectedRecommendation;
         }
 
-        private void PrintInvalidApplicationNameMessage()
+        private void PrintInvalidApplicationNameMessage(string name)
         {
             _toolInteractiveService.WriteLine();
-            _toolInteractiveService.WriteErrorLine(
-                "Invalid application name. The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
-                "It must start with an alphabetic character and can't be longer than 128 characters");
+            _toolInteractiveService.WriteErrorLine(_cloudApplicationNameGenerator.InvalidNameMessage(name));
         }
 
         private void PrintApplicationNameAlreadyExistsMessage()

--- a/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
@@ -26,6 +26,11 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
         /// </summary>
         bool IsValidName(string name);
+
+        /// <summary>
+        /// The message that should be displayed when an invalid name is passed
+        /// </summary>
+        string InvalidNameMessage(string name);
     }
 
     public class CloudApplicationNameGenerator : ICloudApplicationNameGenerator
@@ -94,5 +99,11 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
         /// </remarks>>
         public bool IsValidName(string name) => _validatorRegex.IsMatch(name);
+
+        public string InvalidNameMessage(string name)
+        {
+            return $"Invalid cloud application name {name}. The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
+                "It must start with an alphabetic character and can't be longer than 128 characters";
+        }
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -316,6 +316,61 @@ namespace AWS.Deploy.CLI.IntegrationTests
             }
         }
 
+        [Theory]
+        [InlineData("1234MyAppStack")] // cannot start with a number
+        [InlineData("MyApp@Stack/123")] // cannot contain special characters
+        [InlineData("")] // cannot be empty
+        [InlineData("stackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstackstack")] // cannot contain more than 128 characters
+        public async Task InvalidStackName_ThrowsException(string invalidStackName)
+        {
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
+            var portNumber = 4012;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await WaitTillServerModeReady(restClient);
+
+                var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
+                {
+                    AwsRegion = _awsRegion,
+                    ProjectPath = projectPath
+                });
+
+                var sessionId = startSessionOutput.SessionId;
+                var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
+                var fargateRecommendation = getRecommendationOutput.Recommendations.FirstOrDefault(x => string.Equals(x.RecipeId, "AspNetAppEcsFargate"));
+
+                try
+                {
+                    await restClient.SetDeploymentTargetAsync(sessionId, new SetDeploymentTargetInput
+                    {
+                        NewDeploymentName = invalidStackName,
+                        NewDeploymentRecipeId = fargateRecommendation.RecipeId
+                    });
+                }
+                catch (ApiException ex)
+                {
+                    Assert.Equal(400, ex.StatusCode);
+
+                    var errorMessage = $"Invalid cloud application name {invalidStackName}. The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
+                        "It must start with an alphabetic character and can't be longer than 128 characters";
+                    Assert.Contains(errorMessage, ex.Response);
+                }
+            }
+            finally
+            {
+                cancelSource.Cancel();
+            }
+        }
+
         internal static void RegisterSignalRMessageCallbacks(IDeploymentCommunicationClient signalRClient, StringBuilder logOutput)
         {
             signalRClient.ReceiveLogSectionStart = (message, description) =>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5895

*Description of changes:*
This PR adds the stack name validation logic to server mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
