### PR TITLE
ci: update PR build to use AWS CodeBuild & GitHub OpenID Connector

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -2,9 +2,13 @@ name: AWS CodeBuild CI
 
 on:
   pull_request:
+  push:
     branches:
       - main
       - dev
+
+permissions:
+  id-token: write
 
 jobs:
   build:
@@ -13,10 +17,15 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_AWS_ACCESS_KEY_SECRET }}
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Run CodeBuild
+        id: codebuild
         uses: aws-actions/aws-codebuild-run-build@v1.0.3
         with:
-          project-name: aws-dotnet-deploy-ci
+          project-name: ${{ secrets.CI_AWS_CODE_BUILD_PROJECT_NAME }}
+      - name: CodeBuild Link
+        shell: pwsh
+        run: |
+          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          echo $buildId

--- a/buildtools/README.md
+++ b/buildtools/README.md
@@ -1,0 +1,19 @@
+# Setup
+
+1. Create CF template using `buildtools/ci.template`
+2. Copy output `CodeBuildProjectName` & `OidcRole` output variables.
+3. Create `CI_AWS_ROLE_ARN` repository secret with `OidcRole` value and
+   `CI_AWS_CODE_BUILD_PROJECT_NAME` repository secret with `CodeBuildProjectName`
+   value.
+4. Voila!
+
+# Troubleshooting
+
+## thumbprint rotation
+```
+Error: OpenIDConnect provider's HTTPS certificate doesn't match configured thumbprint
+```
+
+This can happen if GitHub has rotated the thumbprint of the certificate. Follow [this guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html) to generate new thumbprint.
+
+Redeploy the ci.template with the new thumbprint. Additionally, contact https://github.com/aws-actions/configure-aws-credentials/issues for the thumbprint rotation.

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -1,0 +1,37 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 12
+    commands:
+      # install .NET SDK
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 5.0
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0
+      - export PATH="$PATH:$HOME/.dotnet"
+  pre_build:
+    commands:
+      - export ORIGINAL_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+      - export ORIGINAL_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+      - export ORIGINAL_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
+      - export DOTNET_CLI_TELEMETRY_OPTOUT=1
+      - eval $(aws sts assume-role --role-arn arn:aws:iam::610240510716:role/aws-dotnet-deploy-ci-test-runner --role-session-name test | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
+
+  build:
+    commands:
+      - dotnet build AWS.Deploy.sln -c Release
+      - dotnet test AWS.Deploy.sln -c Release --no-build --logger trx --results-directory ./testresults
+  post_build:
+    commands:
+      - export AWS_ACCESS_KEY_ID=${ORIGINAL_AWS_ACCESS_KEY_ID}
+      - export AWS_SECRET_ACCESS_KEY=${ORIGINAL_AWS_SECRET_ACCESS_KEY}
+      - export AWS_SESSION_TOKEN=${ORIGINAL_AWS_SESSION_TOKEN}
+      - unset ORIGINAL_AWS_ACCESS_KEY_ID
+      - unset ORIGINAL_AWS_SECRET_ACCESS_KEY
+      - unset ORIGINAL_AWS_SESSION_TOKEN
+reports:
+    aws-dotnet-deploy-tests:
+        file-format: VisualStudioTrx
+        files:
+            - '**/*'
+        base-directory: './testresults'

--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -1,0 +1,168 @@
+Parameters:
+  GitHubOrg:
+    Type: String
+    Default: "aws"
+    Description: The GitHub organization to use for the repository.
+  GitHubRepositoryName:
+    Description: The name of the GitHub repository to create the role template in and to use for the CodeBuild.
+    Type: String
+    Default: "aws-dotnet-deploy"
+  OIDCProviderArn:
+    Description: Arn for the GitHub OIDC Provider.  Leave blank to create a new one or provide an existing Provider.  There can only be one GitHub OIDC Provider per GitHubOrg per AWS Account.  Example arn:aws:iam::665544332211:oidc-provider/token.actions.githubusercontent.com
+    Default: ""
+    Type: String
+  CodeBuildProjectName:
+    Description: Name of the CodeBuild project.
+    Default: "aws-dotnet-deploy-ci"
+    Type: String
+  CodeBuildArtifactsBucketName:
+    Description: Name of the buckets where the CodeBuild artifacts will be stored.
+    Default: "aws-dotnet-deploy-codebuild-artifacts"
+    Type: String
+  TestRunnerRoleArn:
+    Description: Role to assume when running tests.  This role must already exsit.  Role can be a different account.  Example arn:aws:iam:112233445566::role/awsdotnet-deploy-ci-test-runner
+    Default: ""
+    Type: String
+  OidcRoleRoleName:
+    Description: Name of the role to use for the OIDC provider.
+    Default: "aws-dotnet-deploy-ci-role"
+    Type: String
+
+
+Conditions:
+  CreateOIDCProvider: !Equals
+    - !Ref OIDCProviderArn
+    - ""
+
+Resources:
+  OidcRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref OidcRoleRoleName
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !If
+                - CreateOIDCProvider
+                - !Ref GithubOidc
+                - !Ref OIDCProviderArn
+            Condition:
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${GitHubRepositoryName}:*
+      Policies:
+        - PolicyName: !Sub "${AWS::StackName}-OIDC-Policy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuilds
+                Resource:
+                  - !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildProjectName}
+              - Effect: Allow
+                Action:
+                  - logs:GetLogEvents
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}:*
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                Resource:
+                  - !Sub "${CodeBuildArtifactsBucket.Arn}/*"
+
+  GithubOidc:
+    Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub ${CodeBuildProjectName}
+      ServiceRole: !GetAtt CodeBuildProjectRole.Arn
+      Environment:
+        PrivilegedMode: true
+        ComputeType: BUILD_GENERAL1_LARGE
+        Type: LINUX_CONTAINER
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+        - Name: TEST_RUNNER_ROLE_ARN
+          Type: PLAINTEXT
+          Value: !Ref TestRunnerRoleArn
+      Source:
+        Type: GITHUB
+        Location: !Sub https://github.com/${GitHubOrg}/${GitHubRepositoryName}
+        BuildSpec: buildtools/ci.buildspec.yml
+      Artifacts:
+        Type: S3
+        Packaging: ZIP
+        Location: !GetAtt CodeBuildArtifactsBucket.Arn
+        OverrideArtifactName: true
+
+
+  CodeBuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${CodeBuildProjectName}-codebuild-service-role
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [codebuild.amazonaws.com]
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+        - PolicyName: !Sub "${AWS::StackName}-codebuild-service-role-policy"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                - 'logs:CreateLogGroup'
+                - 'logs:PutLogEvents'
+                - 'logs:CreateLogStream'
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}:*"
+              - Action:
+                - 'sts:AssumeRole'
+                Effect: Allow
+                Resource:
+                  - !Ref TestRunnerRoleArn
+              - Action:
+                - codebuild:BatchPutTestCases
+                - codebuild:CreateReport
+                - codebuild:CreateReportGroup
+                - codebuild:UpdateReport
+                - codebuild:UpdateReportGroup
+                Effect: Allow
+                Resource:
+                  - !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/*
+              - Action:
+                - 's3:PutObject'
+                Effect: Allow
+                Resource:
+                  - !Sub "${CodeBuildArtifactsBucket.Arn}/*"
+
+  CodeBuildArtifactsBucket:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Ref CodeBuildArtifactsBucketName
+
+Outputs:
+  OidcRole:
+    Value: !GetAtt OidcRole.Arn
+  CodeBuildProjectName:
+    Value: !Sub ${CodeBuildProjectName}


### PR DESCRIPTION
*Issue #, if available:*

### Description of changes:
1. Changes GitHub Action for PRs [codebuild-ci.yml](https://github.com/aws/aws-dotnet-deploy/blob/main/.github/workflows/codebuild-ci.yml) to pass credentials via a (pre-configured) OpenID Connector.  GitHub repository will be pre-authorized to access credentials.  This replaces current strategy of storing access key id and secret as a GitHub Repository Secret.

1. Adds Cloud Formation template (infrastructure as code) to define the Backing CodeBuild job for [codebuild-ci.yml](https://github.com/aws/aws-dotnet-deploy/blob/main/.github/workflows/codebuild-ci.yml).

### Deployment Notes:

As part of accepting this PR:

1.  create a new Cloud Formation template using _/buildtools/ci.template.yml_
2. Store the outputs of the Cloud Formation as GitHub Repository Secrets:
> Create `CI_AWS_ROLE_ARN` repository secret with `OidcRole` value and
   `CI_AWS_CODE_BUILD_PROJECT_NAME` repository secret with `CodeBuildProjectName`
   value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
