### PR TITLE
chore: Improve error handling when creation of deployment bundle fails

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -110,8 +110,7 @@ namespace AWS.Deploy.Common
         FailedToRunCDKDiff = 10009000,
         FailedToCreateCDKProject = 10009100,
         ResourceQuery = 10009200,
-        FailedToCreateContainerDeploymentBundleFromGeneratedDockerFile = 10009300,
-        FailedToRetrieveStackId = 10009400
+        FailedToRetrieveStackId = 10009300
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -62,7 +62,13 @@ namespace AWS.Deploy.Orchestration
             var result = await _commandLineWrapper.TryRunWithResult(dockerBuildCommand, dockerExecutionDirectory, streamOutputToInteractiveService: true);
             if (result.ExitCode != 0)
             {
-                throw new DockerBuildFailedException(DeployToolErrorCode.DockerBuildFailed, result.StandardError ?? "");
+                var errorMessage = "We were unable to build the docker image.";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"We were unable to build the docker image due to the following error:{Environment.NewLine}{result.StandardError}";
+
+                errorMessage += $"{Environment.NewLine}Docker builds usually fail due to executing them from a working directory that is incompatible with the Dockerfile.";
+                errorMessage += $"{Environment.NewLine}You can try setting the 'Docker Execution Directory' in the option settings.";
+                throw new DockerBuildFailedException(DeployToolErrorCode.DockerBuildFailed, errorMessage);
             }
         }
 
@@ -115,7 +121,11 @@ namespace AWS.Deploy.Orchestration
             var result = await _commandLineWrapper.TryRunWithResult(publishCommand, streamOutputToInteractiveService: true);
             if (result.ExitCode != 0)
             {
-                throw new DotnetPublishFailedException(DeployToolErrorCode.DotnetPublishFailed, result.StandardError ?? "");
+                var errorMessage = "We were unable to package the application using 'dotnet publish'";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"We were unable to package the application using 'dotnet publish' due to the following error:{Environment.NewLine}{result.StandardError}";
+
+                throw new DotnetPublishFailedException(DeployToolErrorCode.DotnetPublishFailed, errorMessage);
             }
 
             var zipFilePath = $"{publishDirectoryInfo.FullName}.zip";
@@ -200,7 +210,12 @@ namespace AWS.Deploy.Orchestration
             var result = await _commandLineWrapper.TryRunWithResult(dockerLoginCommand, streamOutputToInteractiveService: true);
 
             if (result.ExitCode != 0)
-                throw new DockerLoginFailedException(DeployToolErrorCode.DockerLoginFailed, "Failed to login to Docker");
+            {
+                var errorMessage = "Failed to login to Docker";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"Failed to login to Docker due to the following reason:{Environment.NewLine}{result.StandardError}";
+                throw new DockerLoginFailedException(DeployToolErrorCode.DockerLoginFailed, errorMessage);
+            }
         }
 
         private async Task<Repository> SetupECRRepository(string ecrRepositoryName)
@@ -223,7 +238,12 @@ namespace AWS.Deploy.Orchestration
             var result = await _commandLineWrapper.TryRunWithResult(dockerTagCommand, streamOutputToInteractiveService: true);
 
             if (result.ExitCode != 0)
-                throw new DockerTagFailedException(DeployToolErrorCode.DockerTagFailed, "Failed to tag Docker image");
+            {
+                var errorMessage = "Failed to tag Docker image";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"Failed to tag Docker Image due to the following reason:{Environment.NewLine}{result.StandardError}";
+                throw new DockerTagFailedException(DeployToolErrorCode.DockerTagFailed, errorMessage);
+            }
         }
 
         private async Task PushDockerImage(string targetTagName)
@@ -232,7 +252,12 @@ namespace AWS.Deploy.Orchestration
             var result = await _commandLineWrapper.TryRunWithResult(dockerPushCommand, streamOutputToInteractiveService: true);
 
             if (result.ExitCode != 0)
-                throw new DockerPushFailedException(DeployToolErrorCode.DockerPushFailed, "Failed to push Docker Image");
+            {
+                var errorMessage = "Failed to push Docker Image";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"Failed to push Docker Image due to the following reason:{Environment.NewLine}{result.StandardError}";
+                throw new DockerPushFailedException(DeployToolErrorCode.DockerPushFailed, errorMessage);
+            }
         }
     }
 }

--- a/src/AWS.Deploy.Orchestration/Utilities/ZipFileManager.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/ZipFileManager.cs
@@ -62,7 +62,14 @@ namespace AWS.Deploy.Orchestration.Utilities
             var command = $"{zipCLI} {args}";
             var result = await _commandLineWrapper.TryRunWithResult(command, sourceDirectoryName);
             if (result.ExitCode != 0)
-                throw new FailedToCreateZipFileException(DeployToolErrorCode.ZipUtilityFailedToZip, "\"zip\" utility program has failed to create a zip archive.");
+            {
+                var errorMessage = "We were unable to create a zip archive of the packaged application.";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"We were unable to create a zip archive of the packaged application due to the following reason:{Environment.NewLine}{result.StandardError}";
+
+                errorMessage += $"{Environment.NewLine}Normally this indicates a problem running the \"zip\" utility. Make sure that application is installed and available in your PATH.";
+                throw new FailedToCreateZipFileException(DeployToolErrorCode.ZipUtilityFailedToZip, errorMessage);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5923

*Description of changes:*
Currently, we may encounter numerous exceptions while creating the deployment bundle. However, these exceptions are being swallowed and a generic `FailedToCreateDeploymentBundleException` is thrown.

This PR mitigates the above issue by bubbling up all the `DeployToolException` encountered while creating the deployment bundle. The error codes and error messages from these exceptions are captured and encapsulated inside `FailedToCreateDeploymentBundleException`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
