### PR TITLE
fix: Add ProducesResponseType for the possible error codes in ServerMode API

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -121,6 +121,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/recommendations")]
         [SwaggerOperation(OperationId = "GetRecommendations")]
         [SwaggerResponse(200, type: typeof(GetRecommendationsOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public async Task<IActionResult> GetRecommendations(string sessionId)
         {
@@ -162,6 +163,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/settings")]
         [SwaggerOperation(OperationId = "GetConfigSettings")]
         [SwaggerResponse(200, type: typeof(GetOptionSettingsOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public IActionResult GetConfigSettings(string sessionId)
         {
@@ -222,6 +224,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpPut("session/<sessionId>/settings")]
         [SwaggerOperation(OperationId = "ApplyConfigSettings")]
         [SwaggerResponse(200, type: typeof(ApplyConfigSettingsOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public IActionResult ApplyConfigSettings(string sessionId, [FromBody] ApplyConfigSettingsInput input)
         {
@@ -260,6 +263,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/settings/<configSettingId>/resources")]
         [SwaggerOperation(OperationId = "GetConfigSettingResources")]
         [SwaggerResponse(200, type: typeof(GetConfigSettingResourcesOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public async Task<IActionResult> GetConfigSettingResources(string sessionId, string configSettingId)
         {
@@ -302,6 +306,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/deployments")]
         [SwaggerOperation(OperationId = "GetExistingDeployments")]
         [SwaggerResponse(200, type: typeof(GetExistingDeploymentsOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public async Task<IActionResult> GetExistingDeployments(string sessionId)
         {
@@ -353,6 +358,8 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         /// </summary>
         [HttpPost("session/<sessionId>")]
         [SwaggerOperation(OperationId = "SetDeploymentTarget")]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status400BadRequest)]
         [Authorize]
         public async Task<IActionResult> SetDeploymentTarget(string sessionId, [FromBody] SetDeploymentTargetInput input)
         {
@@ -434,6 +441,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpPost("session/<sessionId>/compatiblity")]
         [SwaggerOperation(OperationId = "GetCompatibility")]
         [SwaggerResponse(200, type: typeof(GetCompatibilityOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public async Task<IActionResult> GetCompatibility(string sessionId)
         {
@@ -470,6 +478,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/cftemplate")]
         [SwaggerOperation(OperationId = "GenerateCloudFormationTemplate")]
         [SwaggerResponse(200, type: typeof(GenerateCloudFormationTemplateOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public async Task<IActionResult> GenerateCloudFormationTemplate(string sessionId)
         {
@@ -505,6 +514,8 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         /// </summary>
         [HttpPost("session/<sessionId>/execute")]
         [SwaggerOperation(OperationId = "StartDeployment")]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status424FailedDependency)]
         [Authorize]
         public async Task<IActionResult> StartDeployment(string sessionId)
         {
@@ -534,7 +545,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             }
 
             if (capabilities.Any())
-                return Problem($"Unable to start deployment due to missing system capabilities.{Environment.NewLine}{missingCapabilitiesMessage}");
+                return Problem($"Unable to start deployment due to missing system capabilities.{Environment.NewLine}{missingCapabilitiesMessage}", statusCode: Microsoft.AspNetCore.Http.StatusCodes.Status424FailedDependency);
 
             var task = new DeployRecommendationTask(orchestratorSession, orchestrator, state.ApplicationDetails, state.SelectedRecommendation);
             state.DeploymentTask = task.Execute();
@@ -548,6 +559,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/execute")]
         [SwaggerOperation(OperationId = "GetDeploymentStatus")]
         [SwaggerResponse(200, type: typeof(GetDeploymentStatusOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public IActionResult GetDeploymentStatus(string sessionId)
         {
@@ -591,6 +603,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("session/<sessionId>/details")]
         [SwaggerOperation(OperationId = "GetDeploymentDetails")]
         [SwaggerResponse(200, type: typeof(GetDeploymentDetailsOutput))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
         public async Task<IActionResult> GetDeploymentDetails(string sessionId)
         {

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/RecipeController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/RecipeController.cs
@@ -35,6 +35,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [HttpGet("{recipeId}")]
         [SwaggerOperation(OperationId = "GetRecipe")]
         [SwaggerResponse(200, type: typeof(RecipeSummary))]
+        [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetRecipe(string recipeId, [FromQuery] string? projectPath = null)
         {
             if (string.IsNullOrEmpty(recipeId))

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -41,13 +41,11 @@ namespace AWS.Deploy.ServerMode.Client
         System.Threading.Tasks.Task CloseDeploymentSessionAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
         /// <summary>Set the target recipe and name for the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task SetDeploymentTargetAsync(string sessionId, SetDeploymentTargetInput body);
     
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>Set the target recipe and name for the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task SetDeploymentTargetAsync(string sessionId, SetDeploymentTargetInput body, System.Threading.CancellationToken cancellationToken);
     
@@ -133,13 +131,11 @@ namespace AWS.Deploy.ServerMode.Client
         System.Threading.Tasks.Task<GenerateCloudFormationTemplateOutput> GenerateCloudFormationTemplateAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
         /// <summary>Begin execution of the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task StartDeploymentAsync(string sessionId);
     
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>Begin execution of the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task StartDeploymentAsync(string sessionId, System.Threading.CancellationToken cancellationToken);
     
@@ -394,7 +390,6 @@ namespace AWS.Deploy.ServerMode.Client
         }
     
         /// <summary>Set the target recipe and name for the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public System.Threading.Tasks.Task SetDeploymentTargetAsync(string sessionId, SetDeploymentTargetInput body)
         {
@@ -403,7 +398,6 @@ namespace AWS.Deploy.ServerMode.Client
     
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>Set the target recipe and name for the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public async System.Threading.Tasks.Task SetDeploymentTargetAsync(string sessionId, SetDeploymentTargetInput body, System.Threading.CancellationToken cancellationToken)
         {
@@ -447,7 +441,27 @@ namespace AWS.Deploy.ServerMode.Client
                         ProcessResponse(client_, response_);
     
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 200 || status_ == 204)
                         {
                             return;
                         }
@@ -533,6 +547,16 @@ namespace AWS.Deploy.ServerMode.Client
                             return objectResponse_.Object;
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -612,6 +636,16 @@ namespace AWS.Deploy.ServerMode.Client
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -702,6 +736,16 @@ namespace AWS.Deploy.ServerMode.Client
                             return objectResponse_.Object;
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -785,6 +829,16 @@ namespace AWS.Deploy.ServerMode.Client
                             return objectResponse_.Object;
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -864,6 +918,16 @@ namespace AWS.Deploy.ServerMode.Client
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -946,6 +1010,16 @@ namespace AWS.Deploy.ServerMode.Client
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -1031,6 +1105,16 @@ namespace AWS.Deploy.ServerMode.Client
                             return objectResponse_.Object;
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -1051,7 +1135,6 @@ namespace AWS.Deploy.ServerMode.Client
         }
     
         /// <summary>Begin execution of the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public System.Threading.Tasks.Task StartDeploymentAsync(string sessionId)
         {
@@ -1060,7 +1143,6 @@ namespace AWS.Deploy.ServerMode.Client
     
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>Begin execution of the deployment.</summary>
-        /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public async System.Threading.Tasks.Task StartDeploymentAsync(string sessionId, System.Threading.CancellationToken cancellationToken)
         {
@@ -1102,7 +1184,27 @@ namespace AWS.Deploy.ServerMode.Client
                         ProcessResponse(client_, response_);
     
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 424)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Client Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 200 || status_ == 204)
                         {
                             return;
                         }
@@ -1188,6 +1290,16 @@ namespace AWS.Deploy.ServerMode.Client
                             return objectResponse_.Object;
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -1267,6 +1379,16 @@ namespace AWS.Deploy.ServerMode.Client
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -1428,6 +1550,16 @@ namespace AWS.Deploy.ServerMode.Client
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -1890,6 +2022,36 @@ namespace AWS.Deploy.ServerMode.Client
     
         [Newtonsoft.Json.JsonProperty("childOptionSettings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<OptionSettingItemSummary> ChildOptionSettings { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class ProblemDetails 
+    {
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Type { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Title { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Status { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("detail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Detail { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("instance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Instance { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
     
     
     }


### PR DESCRIPTION
*Description of changes:*
Add the `ProducesResponseType` attribute to all of the REST APIs in server mode. This allows the client code generator to generate a `ProblemDetails` type that the toolkit can use to get the error message for the bad error code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
