### PR TITLE
feat: add new OptionSetting validator to check for conflict with existing resources

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,5 +1,3 @@
-
-
 ** AWSSDK.AppRunner; version 3.7.3.11 -- https://www.nuget.org/packages/AWSSDK.AppRunner/
 ** AWSSDK.CloudFront; version 3.7.3.10 -- https://www.nuget.org/packages/AWSSDK.CloudFront/
 ** AWSSDK.CloudWatchEvents; version 3.7.3.14 -- https://www.nuget.org/packages/AWSSDK.CloudWatchEvents/
@@ -18,10 +16,11 @@
 ** AWSSDK.Extensions.NETCore.Setup; version 3.7.1 -- https://www.nuget.org/packages/AWSSDK.Extensions.NETCore.Setup
 ** AWSSDK.IdentityManagement; version 3.7.2.25 -- https://www.nuget.org/packages/AWSSDK.IdentityManagement
 ** AWSSDK.SecurityToken; version 3.7.1.35 -- https://www.nuget.org/packages/AWSSDK.SecurityToken
-** AWSSDK.SimpleSystemsManagement; version 3.7.16 -- https://www.nuget.org/packages/AWSSDK.SimpleSystemsManagement
 ** Constructs; version 10.0.0 -- https://www.nuget.org/packages/Constructs
 ** Amazon.CDK.Lib; version 2.13.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
 ** Amazon.JSII.Runtime; version 1.54.0 -- https://www.nuget.org/packages/Amazon.JSII.Runtime
+** AWSSDK.CloudControlApi; version 3.7.2 -- https://www.nuget.org/packages/AWSSDK.CloudControlApi/
+** AWSSDK.SimpleSystemsManagement; version 3.7.16 -- https://www.nuget.org/packages/AWSSDK.SimpleSystemsManagement/
  
 Apache License
 Version 2.0, January 2004
@@ -250,6 +249,36 @@ limitations under the License.
 * For Amazon.JSII.Runtime see also this required NOTICE:
     AWS Cloud Development Kit (AWS CDK)
     Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.CloudControlApi see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.SimpleSystemsManagement see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+------
+
+** Material for MkDocs; version 8.2.9 -- https://github.com/squidfunk/mkdocs-material
+Copyright (c) 2016-2022 Martin Donath <martin.donath@squidfunk.com>
+ 
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
@@ -351,9 +380,7 @@ Copyright (c) 2016 Richard Morris
 Copyright (c) 2016 Richard Morris
 ** Swashbuckle.AspNetCore.SwaggerGen ; version 6.1.2 -- https://www.nuget.org/packages/Swashbuckle.AspNetCore.SwaggerGen/
 Copyright (c) 2016 Richard Morris
-** mkdocs-material; version 8.2.9 -- https://pypi.org/project/mkdocs-material/
-Copyright (c) 2016-2022 Martin Donath
-
+ 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -26,6 +26,7 @@ using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.CLI.Commands
 {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkApplicationCommand.cs
@@ -2,16 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
-using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
 {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/BeanstalkEnvironmentCommand.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: buildArgs => ValidateBuildArgs(buildArgs))
+                    validators: async buildArgs => await ValidateBuildArgs(buildArgs))
                 .ToString()
                 .Replace("\"", "\"\"");
 
@@ -45,17 +45,17 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         /// </summary>
         /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
         /// <param name="dockerBuildArgs">Arguments to be passed when performing a Docker build</param>
-        public void OverrideValue(Recommendation recommendation, string dockerBuildArgs)
+        public async Task OverrideValue(Recommendation recommendation, string dockerBuildArgs)
         {
-            var resultString = ValidateBuildArgs(dockerBuildArgs);
+            var resultString = await ValidateBuildArgs(dockerBuildArgs);
             if (!string.IsNullOrEmpty(resultString))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerBuildArgs, resultString);
             recommendation.DeploymentBundle.DockerBuildArgs = dockerBuildArgs;
         }
 
-        private string ValidateBuildArgs(string buildArgs)
+        private async Task<string> ValidateBuildArgs(string buildArgs)
         {
-            var validationResult = new DockerBuildArgsValidator().Validate(buildArgs);
+            var validationResult = await new DockerBuildArgsValidator().Validate(buildArgs);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
@@ -35,7 +35,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: executionDirectory => ValidateExecutionDirectory(executionDirectory));
+                    validators: async executionDirectory => await ValidateExecutionDirectory(executionDirectory));
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = settingValue;
             return Task.FromResult<object>(settingValue);
@@ -47,17 +47,17 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         /// </summary>
         /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
         /// <param name="executionDirectory">The directory specified for Docker execution.</param>
-        public void OverrideValue(Recommendation recommendation, string executionDirectory)
+        public async Task OverrideValue(Recommendation recommendation, string executionDirectory)
         {
-            var resultString = ValidateExecutionDirectory(executionDirectory);
+            var resultString = await ValidateExecutionDirectory(executionDirectory);
             if (!string.IsNullOrEmpty(resultString))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerExecutionDirectory, resultString);
             recommendation.DeploymentBundle.DockerExecutionDirectory = executionDirectory;
         }
 
-        private string ValidateExecutionDirectory(string executionDirectory)
+        private async Task<string> ValidateExecutionDirectory(string executionDirectory)
         {
-            var validationResult = new DirectoryExistsValidator(_directoryManager).Validate(executionDirectory);
+            var validationResult = await new DirectoryExistsValidator(_directoryManager).Validate(executionDirectory);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: publishArgs => ValidateDotnetPublishArgs(publishArgs))
+                    validators: async publishArgs => await ValidateDotnetPublishArgs(publishArgs))
                 .ToString()
                 .Replace("\"", "\"\"");
 
@@ -46,17 +46,17 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         /// </summary>
         /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
         /// <param name="publishArgs">The user specified Dotnet build arguments.</param>
-        public void OverrideValue(Recommendation recommendation, string publishArgs)
+        public async Task OverrideValue(Recommendation recommendation, string publishArgs)
         {
-            var resultString = ValidateDotnetPublishArgs(publishArgs);
+            var resultString = await ValidateDotnetPublishArgs(publishArgs);
             if (!string.IsNullOrEmpty(resultString))
                 throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDotnetPublishArgs, resultString);
             recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments = publishArgs.Replace("\"", "\"\"");
         }
 
-        private string ValidateDotnetPublishArgs(string publishArgs)
+        private async Task<string> ValidateDotnetPublishArgs(string publishArgs)
         {
-            var validationResult = new DotnetPublishArgsValidator().Validate(publishArgs);
+            var validationResult = await new DotnetPublishArgsValidator().Validate(publishArgs);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DynamoDBTableCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DynamoDBTableCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EC2KeyPairCommand.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Amazon.EC2.Model;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ECRRepositoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ECRRepositoryCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.ECR.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ECSClusterCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ECSClusterCommand.cs
@@ -8,6 +8,7 @@ using Amazon.ECS.Model;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingApplicationLoadBalancerCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingApplicationLoadBalancerCommand.cs
@@ -8,6 +8,7 @@ using Amazon.ECS.Model;
 using Amazon.ElasticLoadBalancingV2;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSecurityGroupsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSecurityGroupsCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.EC2.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSubnetsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSubnetsCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.EC2.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.EC2.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcConnectorCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcConnectorCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.AppRunner.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/IAMRoleCommand.cs
@@ -8,6 +8,7 @@ using Amazon.ECS.Model;
 using Amazon.IdentityManagement.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/InstanceTypeCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/InstanceTypeCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.EC2.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/S3BucketNameCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/S3BucketNameCommand.cs
@@ -10,6 +10,7 @@ using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;
 using Amazon.S3.Model;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
 {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
@@ -9,6 +9,7 @@ using AWS.Deploy.Common;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
 {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
@@ -67,7 +68,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.ExistingVpcConnector,  ActivatorUtilities.CreateInstance<ExistingVpcConnectorCommand>(serviceProvider) },
                 { OptionSettingTypeHint.ExistingSubnets,  ActivatorUtilities.CreateInstance<ExistingSubnetsCommand>(serviceProvider) },
                 { OptionSettingTypeHint.ExistingSecurityGroups, ActivatorUtilities.CreateInstance<ExistingSecurityGroupsCommand>(serviceProvider) },
-                { OptionSettingTypeHint.VPCConnector, ActivatorUtilities.CreateInstance<VPCConnectorCommand>(serviceProvider) }
+                { OptionSettingTypeHint.VPCConnector, ActivatorUtilities.CreateInstance<VPCConnectorCommand>(serviceProvider) },
             };
         }
 

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VPCConnectorCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VPCConnectorCommand.cs
@@ -8,6 +8,7 @@ using Amazon.AppRunner.Model;
 using Amazon.EC2.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/VpcCommand.cs
@@ -8,6 +8,7 @@ using Amazon.EC2.Model;
 using Amazon.ECS.Model;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration;

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -5,6 +5,7 @@ using AWS.Deploy.CLI.Commands;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.CLI.Utilities;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.IO;

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -33,6 +33,7 @@ using AWS.Deploy.CLI.Commands;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.ServiceHandlers;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.CLI.ServerMode.Controllers
 {
@@ -228,7 +229,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
         [SwaggerResponse(200, type: typeof(ApplyConfigSettingsOutput))]
         [ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Authorize]
-        public IActionResult ApplyConfigSettings(string sessionId, [FromBody] ApplyConfigSettingsInput input)
+        public async Task<IActionResult> ApplyConfigSettings(string sessionId, [FromBody] ApplyConfigSettingsInput input)
         {
             var state = _stateServer.Get(sessionId);
             if (state == null)
@@ -251,7 +252,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 try
                 {
                     var setting = optionSettingHandler.GetOptionSetting(state.SelectedRecommendation, updatedSetting.Key);
-                    optionSettingHandler.SetOptionSettingValue(state.SelectedRecommendation, setting, updatedSetting.Value);
+                    await optionSettingHandler.SetOptionSettingValue(state.SelectedRecommendation, setting, updatedSetting.Value);
                 }
                 catch (Exception ex)
                 {
@@ -425,7 +426,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 else
                     previousSettings = await deployedApplicationQueryer.GetPreviousSettings(existingDeployment);
 
-                state.SelectedRecommendation = orchestrator.ApplyRecommendationPreviousSettings(state.SelectedRecommendation, previousSettings);
+                state.SelectedRecommendation = await orchestrator.ApplyRecommendationPreviousSettings(state.SelectedRecommendation, previousSettings);
 
                 state.ApplicationDetails.Name = existingDeployment.Name;
                 state.ApplicationDetails.UniqueIdentifier = existingDeployment.UniqueIdentifier;
@@ -535,6 +536,17 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             if (state.SelectedRecommendation == null)
                 throw new SelectedRecommendationIsNullException("The selected recommendation is null or invalid.");
+
+            var optionSettingHandler = serviceProvider.GetRequiredService<IOptionSettingHandler>();
+            var settingValidatorFailedResults = optionSettingHandler.RunOptionSettingValidators(state.SelectedRecommendation);
+            if (settingValidatorFailedResults.Any())
+            {
+                var settingValidationErrorMessage = $"The deployment configuration needs to be adjusted before it can be deployed:{Environment.NewLine}";
+                foreach (var result in settingValidatorFailedResults)
+                    settingValidationErrorMessage += $" - {result.ValidationFailedMessage}{Environment.NewLine}{Environment.NewLine}";
+                settingValidationErrorMessage += $"{Environment.NewLine}Please adjust your settings";
+                return Problem(settingValidationErrorMessage);
+            }
 
             var systemCapabilityEvaluator = serviceProvider.GetRequiredService<ISystemCapabilityEvaluator>();
 

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -8,10 +8,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.5.10" />
+    <PackageReference Include="AWSSDK.CloudControlApi" Version="3.7.2" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.7.19.1" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.35" />
+    <PackageReference Include="AWSSDK.AppRunner" Version="3.7.3.11" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.7.14" />
+    <PackageReference Include="AWSSDK.CloudFront" Version="3.7.3.10" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.83" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.7.0.45" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.7.2.20" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.1.17" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.16" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.53" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.25" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.45" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" Version="3.7.0.48" />
   </ItemGroup>
 
 </Project>

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.AppRunner.Model;
+using Amazon.CloudFormation.Model;
+using Amazon.CloudFront.Model;
+using Amazon.CloudWatchEvents.Model;
+using Amazon.EC2.Model;
+using Amazon.ECR.Model;
+using Amazon.ECS.Model;
+using Amazon.ElasticBeanstalk.Model;
+using Amazon.ElasticLoadBalancingV2;
+using Amazon.IdentityManagement.Model;
+using Amazon.S3.Model;
+using Amazon.SecurityToken.Model;
+using LoadBalancer = Amazon.ElasticLoadBalancingV2.Model.LoadBalancer;
+using Listener = Amazon.ElasticLoadBalancingV2.Model.Listener;
+using Amazon.CloudControlApi.Model;
+
+namespace AWS.Deploy.Common.Data
+{
+    public interface IAWSResourceQueryer
+    {
+        Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier);
+        Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName);
+        Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes();
+        Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
+        Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
+        Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentName);
+        Task<LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn);
+        Task<List<Listener>> DescribeElasticLoadBalancerListeners(string loadBalancerArn);
+        Task<DescribeRuleResponse> DescribeCloudWatchRule(string ruleName);
+        Task<string> GetS3BucketLocation(string bucketName);
+        Task<Amazon.S3.Model.WebsiteConfiguration> GetS3BucketWebSiteConfiguration(string bucketName);
+        Task<List<Cluster>> ListOfECSClusters(string? ecsClusterName = null);
+        Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications(string? applicationName = null);
+        Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName = null, string? environmentName = null);
+        Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn);
+        Task<List<KeyPairInfo>> ListOfEC2KeyPairs();
+        Task<string> CreateEC2KeyPair(string keyName, string saveLocation);
+        Task<List<Role>> ListOfIAMRoles(string? servicePrincipal);
+        Task<List<Vpc>> GetListOfVpcs();
+        Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns();
+        Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn();
+        Task<List<AuthorizationData>> GetECRAuthorizationToken();
+        Task<List<Repository>> GetECRRepositories(List<string>? repositoryNames = null);
+        Task<Repository> CreateECRRepository(string repositoryName);
+        Task<List<Stack>> GetCloudFormationStacks();
+        Task<Stack?> GetCloudFormationStack(string stackName);
+        Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion);
+        Task<List<LoadBalancer>> ListOfLoadBalancers(LoadBalancerTypeEnum loadBalancerType);
+        Task<Distribution> GetCloudFrontDistribution(string distributionId);
+        Task<List<string>> ListOfDyanmoDBTables();
+        Task<List<string>> ListOfSQSQueuesUrls();
+        Task<List<string>> ListOfSNSTopicArns();
+        Task<List<S3Bucket>> ListOfS3Buckets();
+        Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentName);
+        Task<Repository> DescribeECRRepository(string respositoryName);
+        Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors();
+        Task<List<Subnet>> DescribeSubnets(string? vpcID = null);
+        Task<List<SecurityGroup>> DescribeSecurityGroups(string? vpcID = null);
+        Task<string?> GetParameterStoreTextValue(string parameterName);
+    }
+}

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -114,7 +114,9 @@ namespace AWS.Deploy.Common
         ResourceQuery = 10009200,
         FailedToRetrieveStackId = 10009300,
         FailedToGetECRAuthorizationToken = 10009400,
-        InvalidCloudApplicationName = 10009500
+        InvalidCloudApplicationName = 10009500,
+        SelectedValueIsNotAllowed = 10009600,
+        MissingValidatorConfiguration = 10009700
     }
 
     public class ProjectFileNotFoundException : DeployToolException
@@ -209,6 +211,14 @@ namespace AWS.Deploy.Common
     public class ValidationFailedException : DeployToolException
     {
         public ValidationFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Thrown if Option Setting Item Validator has missing or invalid configuration.
+    /// </summary>
+    public class MissingValidatorConfigurationException : DeployToolException
+    {
+        public MissingValidatorConfigurationException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>

--- a/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
+++ b/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.Recipes.Validation;
+
 namespace AWS.Deploy.Common.Recipes
 {
     /// <summary>
@@ -9,11 +13,18 @@ namespace AWS.Deploy.Common.Recipes
     public interface IOptionSettingHandler
     {
         /// <summary>
+        /// This method runs all the option setting validators for the configurable settings.
+        /// In case of a first time deployment, all settings and validators are run.
+        /// In case of a redeployment, only the updatable settings are considered.
+        /// </summary>
+        List<ValidationResult> RunOptionSettingValidators(Recommendation recommendation, IEnumerable<OptionSettingItem>? optionSettings = null);
+
+        /// <summary>
         /// This method is used to set values for <see cref="OptionSettingItem"/>.
         /// Due to different validations that could be put in place, access to other services may be needed.
         /// This method is meant to control access to those services and determine the value to be set.
         /// </summary>
-        void SetOptionSettingValue(Recommendation recommendation, OptionSettingItem optionSettingItem, object value);
+        Task SetOptionSettingValue(Recommendation recommendation, OptionSettingItem optionSettingItem, object value, bool skipValidation = false);
 
         /// <summary>
         /// This method retrieves the <see cref="OptionSettingItem"/> related to a specific <see cref="Recommendation"/>.

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AWS.Deploy.Common.Recipes.Validation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -42,7 +43,8 @@ namespace AWS.Deploy.Common.Recipes
         /// <param name="value">Value to set</param>
         /// <param name="validators">Validators for this item</param>
         /// <param name="recommendation">Selected recommendation</param>
-        void SetValue(IOptionSettingHandler optionSettingHandler, object value, IOptionSettingItemValidator[] validators, Recommendation recommendation);
+        /// <param name="skipValidation">Enables or disables running validators specified in <paramref name="validators"/></param>
+        Task SetValue(IOptionSettingHandler optionSettingHandler, object value, IOptionSettingItemValidator[] validators, Recommendation recommendation, bool skipValidation);
     }
 
     /// <summary>
@@ -120,7 +122,7 @@ namespace AWS.Deploy.Common.Recipes
         /// The allowed values for the setting.
         /// </summary>
         public IList<string> AllowedValues { get; set; } = new List<string>();
-
+        
         /// <summary>
         /// The value mapping for allowed values. The key of the dictionary is what is sent to services
         /// and the value is the display value shown to users.

--- a/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
@@ -10,6 +12,6 @@ namespace AWS.Deploy.Common.Recipes.Validation
     /// </summary>
     public interface IOptionSettingItemValidator
     {
-        ValidationResult Validate(object input);
+        Task<ValidationResult> Validate(object input);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
@@ -10,6 +12,6 @@ namespace AWS.Deploy.Common.Recipes.Validation
     /// </summary>
     public interface IRecipeValidator
     {
-        ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext);
+        Task<ValidationResult> Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -28,6 +28,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paried with <see cref="DotnetPublishArgsValidator"/>
         /// </summary>
-        DotnetPublishArgs
+        DotnetPublishArgs,
+        /// <summary>
+        /// Must be paired with <see cref="ExistingResourceValidator"/>
+        /// </summary>
+        ExistingResource
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
 using AWS.Deploy.Common.IO;
 
 namespace AWS.Deploy.Common.Recipes.Validation
@@ -23,14 +24,14 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Path to validate</param>
         /// <returns>Valid if the directory exists, invalid otherwise</returns>
-        public ValidationResult Validate(object input)
+        public Task<ValidationResult> Validate(object input)
         {
             var executionDirectory = (string)input;
 
             if (!string.IsNullOrEmpty(executionDirectory) && !_directoryManager.Exists(executionDirectory))
-                return ValidationResult.Failed("The specified directory does not exist.");
+                return ValidationResult.FailedAsync("The specified directory does not exist.");
             else
-                return ValidationResult.Valid();
+                return ValidationResult.ValidAsync();
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Threading.Tasks;
 
 namespace AWS.Deploy.Common.Recipes.Validation
 {
@@ -16,14 +17,14 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Proposed Docker build args</param>
         /// <returns>Valid if the options do not contain those set by the deploy tool, invalid otherwise</returns>
-        public ValidationResult Validate(object input)
+        public Task<ValidationResult> Validate(object input)
         {
             var buildArgs = Convert.ToString(input);
             var errorMessage = string.Empty;
 
             if (string.IsNullOrEmpty(buildArgs))
             {
-                return ValidationResult.Valid();
+                return ValidationResult.ValidAsync();
             }
 
             if (buildArgs.Contains("-t ") || buildArgs.Contains("--tag "))
@@ -34,9 +35,9 @@ namespace AWS.Deploy.Common.Recipes.Validation
                 errorMessage += "You must not include -f/--file as an additional argument as it is used internally." + Environment.NewLine;
 
             if (!string.IsNullOrEmpty(errorMessage))
-                return ValidationResult.Failed("Invalid value for additional Docker build options." + Environment.NewLine + errorMessage.Trim());
+                return ValidationResult.FailedAsync("Invalid value for additional Docker build options." + Environment.NewLine + errorMessage.Trim());
 
-            return ValidationResult.Valid();
+            return ValidationResult.ValidAsync();
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Threading.Tasks;
 
 namespace AWS.Deploy.Common.Recipes.Validation
 {
@@ -15,14 +16,14 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Additional publish arguments</param>
         /// <returns>Valid if the arguments don't interfere with the deploy tool, invalid otherwise</returns>
-        public ValidationResult Validate(object input)
+        public Task<ValidationResult> Validate(object input)
         {
             var publishArgs = Convert.ToString(input);
             var errorMessage = string.Empty;
 
             if (string.IsNullOrEmpty(publishArgs))
             {
-                return ValidationResult.Valid();
+                return ValidationResult.ValidAsync();
             }
 
             if (publishArgs.Contains("-o ") || publishArgs.Contains("--output "))
@@ -35,9 +36,9 @@ namespace AWS.Deploy.Common.Recipes.Validation
                 errorMessage += "You must not include --self-contained/--no-self-contained as an additional argument. You can set the self-contained property in the advanced settings." + Environment.NewLine;
 
             if (!string.IsNullOrEmpty(errorMessage))
-                return ValidationResult.Failed("Invalid value for Dotnet Publish Arguments." + Environment.NewLine + errorMessage.Trim());
+                return ValidationResult.FailedAsync("Invalid value for Dotnet Publish Arguments." + Environment.NewLine + errorMessage.Trim());
 
-            return ValidationResult.Valid();
+            return ValidationResult.ValidAsync();
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudControlApi.Model;
+using AWS.Deploy.Common.Data;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    public class ExistingResourceValidator : IOptionSettingItemValidator
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        /// <summary>
+        /// The Cloud Control API resource type that will be used to query Cloud Control API for the existance of a resource.
+        /// </summary>
+        public string? ResourceType { get; set; }
+
+        public ExistingResourceValidator(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<ValidationResult> Validate(object input)
+        {
+            if (string.IsNullOrEmpty(ResourceType))
+                throw new MissingValidatorConfigurationException(DeployToolErrorCode.MissingValidatorConfiguration, $"The validator of type '{typeof(ExistingResourceValidator)}' is missing the configuration property '{nameof(ResourceType)}'.");
+            var resourceName = input.ToString();
+            if (string.IsNullOrEmpty(resourceName))
+                return ValidationResult.Failed($"The resource name is empty and cannot be validated.");
+
+            switch (ResourceType)
+            {
+                case "AWS::ElasticBeanstalk::Application":
+                    var beanstalkApplications = await _awsResourceQueryer.ListOfElasticBeanstalkApplications(input.ToString());
+                    if (beanstalkApplications.Any(x => x.ApplicationName.Equals(input.ToString())))
+                        return ValidationResult.Failed($"An Elastic Beanstalk application already exists with the name '{input.ToString()}'. Check the AWS Console for more information on the existing resource.");
+                    break;
+
+                case "AWS::ElasticBeanstalk::Environment":
+                    var beanstalkEnvironments = await _awsResourceQueryer.ListOfElasticBeanstalkEnvironments(environmentName: input.ToString());
+                    if (beanstalkEnvironments.Any(x => x.EnvironmentName.Equals(input.ToString())))
+                        return ValidationResult.Failed($"An Elastic Beanstalk environment already exists with the name '{input.ToString()}'. Check the AWS Console for more information on the existing resource.");
+                    break;
+
+                default:
+                    try
+                    {
+                        var resource = await _awsResourceQueryer.GetCloudControlApiResource(ResourceType, resourceName);
+                        return ValidationResult.Failed($"A resource of type '{ResourceType}' and name '{resourceName}' already exists. Check the AWS Console for more information on the existing resource.");
+                    }
+                    catch (ResourceQueryException ex) when (ex.InnerException is ResourceNotFoundException)
+                    {
+                        break;
+                    }
+            }
+
+            return ValidationResult.Valid();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
@@ -22,16 +24,16 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
         public bool AllowEmptyString { get; set; }
 
-        public ValidationResult Validate(object input)
+        public Task<ValidationResult> Validate(object input)
         {
             if (AllowEmptyString && string.IsNullOrEmpty(input?.ToString()))
-                return ValidationResult.Valid();
+                return ValidationResult.ValidAsync();
 
             if (int.TryParse(input?.ToString(), out var result) &&
                 result >= Min &&
                 result <= Max)
             {
-                return ValidationResult.Valid();
+                return ValidationResult.ValidAsync();
             }
 
             var message =
@@ -39,7 +41,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
                     .Replace("{{Min}}", Min.ToString())
                     .Replace("{{Max}}", Max.ToString());
 
-            return ValidationResult.Failed(message);
+            return ValidationResult.FailedAsync(message);
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using AWS.Deploy.Common.Extensions;
 
 namespace AWS.Deploy.Common.Recipes.Validation
@@ -21,7 +22,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
         public bool AllowEmptyString { get; set; }
 
-        public ValidationResult Validate(object input)
+        public Task<ValidationResult> Validate(object input)
         {
             var regex = new Regex(Regex);
 
@@ -34,24 +35,24 @@ namespace AWS.Deploy.Common.Recipes.Validation
                 {
                     var valid = regex.IsMatch(item) || (AllowEmptyString && string.IsNullOrEmpty(item));
                     if (!valid)
-                        return new ValidationResult
+                        return Task.FromResult<ValidationResult>(new ValidationResult
                         {
                             IsValid = false,
                             ValidationFailedMessage = message
-                        };
+                        });
                 }
-                return new ValidationResult
+                return Task.FromResult<ValidationResult>(new ValidationResult
                 {
                     IsValid = true,
                     ValidationFailedMessage = message
-                };
+                });
             }
 
-            return new ValidationResult
+            return Task.FromResult<ValidationResult>(new ValidationResult
             {
                 IsValid = regex.IsMatch(input?.ToString() ?? "") || (AllowEmptyString && string.IsNullOrEmpty(input?.ToString())),
                 ValidationFailedMessage = message
-            };
+            });
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RequiredValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RequiredValidator.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
@@ -11,11 +13,11 @@ namespace AWS.Deploy.Common.Recipes.Validation
         private static readonly string defaultValidationFailedMessage = "Value can not be empty";
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
 
-        public ValidationResult Validate(object input) =>
-            new()
+        public Task<ValidationResult> Validate(object input) =>
+            Task.FromResult<ValidationResult>(new()
             {
                 IsValid = !string.IsNullOrEmpty(input?.ToString()),
                 ValidationFailedMessage = ValidationFailedMessage
-            };
+            });
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/FargateTaskCpuMemorySizeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/FargateTaskCpuMemorySizeValidator.cs
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace AWS.Deploy.Common.Recipes.Validation
 {
@@ -58,7 +60,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string? InvalidCpuValueValidationFailedMessage { get; set; }
 
         /// <inheritdoc cref="FargateTaskCpuMemorySizeValidator"/>
-        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
+        public Task<ValidationResult> Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
         {
             string cpu;
             string memory;
@@ -70,8 +72,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
             }
             catch (OptionSettingItemDoesNotExistException)
             {
-                return ValidationResult.Failed("Could not find a valid value for Task CPU or Task Memory " +
-                    "as part of of the ECS Fargate deployment configuration. Please provide a valid value and try again.");
+                return Task.FromResult<ValidationResult>(ValidationResult.Failed("Could not find a valid value for Task CPU or Task Memory " +
+                    "as part of of the ECS Fargate deployment configuration. Please provide a valid value and try again."));
             }
 
             if (!_cpuMemoryMap.ContainsKey(cpu))
@@ -81,14 +83,14 @@ namespace AWS.Deploy.Common.Recipes.Validation
                 // or the UX flow calling in here doesn't enforce AllowedValues.
                 var message = InvalidCpuValueValidationFailedMessage?.Replace("{{cpu}}", cpu);
 
-                return ValidationResult.Failed(message?? "Cpu validation failed");
+                return Task.FromResult<ValidationResult>(ValidationResult.Failed(message?? "Cpu validation failed"));
             }
 
             var validMemoryValues = _cpuMemoryMap[cpu];
 
             if (validMemoryValues.Contains(memory))
             {
-                return ValidationResult.Valid();
+                return Task.FromResult<ValidationResult>(ValidationResult.Valid());
             }
 
             var failed =
@@ -97,7 +99,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
                     .Replace("{{memory}}", memory)
                     .Replace("{{memoryList}}", string.Join(", ", validMemoryValues));
 
-            return ValidationResult.Failed(failed);
+            return Task.FromResult<ValidationResult>(ValidationResult.Failed(failed));
 
         }
     }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/MinMaxConstraintValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/MinMaxConstraintValidator.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string MaxValueOptionSettingsId { get; set; } = string.Empty;
         public string ValidationFailedMessage { get; set; } = "The value specified for {{MinValueOptionSettingsId}} must be less than or equal to the value specified for {{MaxValueOptionSettingsId}}";
 
-        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
+        public Task<ValidationResult> Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
         {
             double minVal;
             double maxValue;
@@ -33,18 +35,18 @@ namespace AWS.Deploy.Common.Recipes.Validation
             }
             catch (OptionSettingItemDoesNotExistException)
             {
-                return ValidationResult.Failed($"Could not find a valid value for {MinValueOptionSettingsId} or {MaxValueOptionSettingsId}. Please provide a valid value and try again.");
+                return Task.FromResult<ValidationResult>(ValidationResult.Failed($"Could not find a valid value for {MinValueOptionSettingsId} or {MaxValueOptionSettingsId}. Please provide a valid value and try again."));
             }
 
             if (minVal <= maxValue)
-                return ValidationResult.Valid();
+                return Task.FromResult<ValidationResult>(ValidationResult.Valid());
 
             var failureMessage =
                 ValidationFailedMessage
                     .Replace("{{MinValueOptionSettingsId}}", MinValueOptionSettingsId)
                     .Replace("{{MaxValueOptionSettingsId}}", MaxValueOptionSettingsId);
 
-            return ValidationResult.Failed(failureMessage);
+            return Task.FromResult<ValidationResult>(ValidationResult.Failed(failureMessage));
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidationResult.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidationResult.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     public class ValidationResult
@@ -17,12 +19,22 @@ namespace AWS.Deploy.Common.Recipes.Validation
             };
         }
 
+        public static Task<ValidationResult> FailedAsync(string message)
+        {
+            return Task.FromResult<ValidationResult>(Failed(message));
+        }
+
         public static ValidationResult Valid()
         {
             return new ValidationResult
             {
                 IsValid = true
             };
+        }
+
+        public static Task<ValidationResult> ValidAsync()
+        {
+            return Task.FromResult<ValidationResult>(Valid());
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -20,8 +20,9 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// Builds the validators that apply to the given option
         /// </summary>
         /// <param name="optionSettingItem">Option to validate</param>
+        /// <param name="filter">Applies a filter to the list of validators</param>
         /// <returns>Array of validators for the given option</returns>
-        IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem);
+        IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem, Func<OptionSettingItemValidatorConfig, bool>? filter = null);
 
         /// <summary>
         /// Builds the validators that apply to the given recipe
@@ -51,17 +52,19 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.DirectoryExists, typeof(DirectoryExistsValidator) },
             { OptionSettingItemValidatorList.DockerBuildArgs, typeof(DockerBuildArgsValidator) },
             { OptionSettingItemValidatorList.DotnetPublishArgs, typeof(DotnetPublishArgsValidator) },
+            { OptionSettingItemValidatorList.ExistingResource, typeof(ExistingResourceValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()
         {
             { RecipeValidatorList.FargateTaskSizeCpuMemoryLimits, typeof(FargateTaskCpuMemorySizeValidator) },
-            { RecipeValidatorList.MinMaxConstraint, typeof(MinMaxConstraintValidator) }
+            { RecipeValidatorList.MinMaxConstraint, typeof(MinMaxConstraintValidator) },
         };
 
-        public IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem)
+        public IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem, Func<OptionSettingItemValidatorConfig, bool>? filter = null)
         {
             return optionSettingItem.Validators
+                .Where(validator => filter != null ? filter(validator) : true)
                 .Select(v => Activate(v.ValidatorType, v.Configuration, _optionSettingItemValidatorTypeMapping))
                 .OfType<IOptionSettingItemValidator>()
                 .ToArray();

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.CloudControlApi" Version="3.7.2" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.83" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.1.25" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.53" />

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Amazon.ECR.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/AppRunnerServiceResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/AppRunnerServiceResource.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/CloudFrontDistributionResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/CloudFrontDistributionResource.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using AWS.Deploy.Orchestration.Data;
 
 using Amazon.CloudFront.Model;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources
 {

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/CloudWatchEventResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/CloudWatchEventResource.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourceCommandFactory.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourceCommandFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourcesHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourcesHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AWS.Deploy.Orchestration.Data;
 using System.Linq;
 using AWS.Deploy.Orchestration.DeploymentCommands;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources
 {

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticBeanstalkEnvironmentResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticBeanstalkEnvironmentResource.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticLoadBalancerResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/ElasticLoadBalancerResource.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.ElasticLoadBalancingV2;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/S3BucketResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/S3BucketResource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.Orchestration.DisplayedResources

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
@@ -145,7 +146,7 @@ namespace AWS.Deploy.Orchestration
         /// <summary>
         /// Creates a deep copy of the recommendation object and applies the previous settings to that recommendation.
         /// </summary>
-        public Recommendation ApplyRecommendationPreviousSettings(Recommendation recommendation, IDictionary<string, object> previousSettings)
+        public async Task<Recommendation> ApplyRecommendationPreviousSettings(Recommendation recommendation, IDictionary<string, object> previousSettings)
         {
             if (_optionSettingHandler == null)
                 throw new InvalidOperationException($"{nameof(_optionSettingHandler)} is null as part of the orchestartor object");
@@ -157,7 +158,7 @@ namespace AWS.Deploy.Orchestration
             {
                 if (previousSettings.TryGetValue(optionSetting.Id, out var value))
                 {
-                    _optionSettingHandler.SetOptionSettingValue(recommendationCopy, optionSetting, value);
+                    await  _optionSettingHandler.SetOptionSettingValue(recommendationCopy, optionSetting, value, skipValidation: true);
                 }
             }
 

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -9,6 +9,7 @@ using Amazon.CloudFormation;
 using Amazon.ElasticBeanstalk;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Data;

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -172,6 +172,12 @@
                                 "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens, underscores and can't be longer than 255 character in length."
                             }
+                        },
+                        {
+                            "ValidatorType": "ExistingResource",
+                            "Configuration": {
+                                "ResourceType": "AWS::ECS::Cluster"
+                            }
                         }
                     ],
                     "DependsOn": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -125,6 +125,7 @@
             "Order": 100
         }
     ],
+
     "OptionSettings": [
         {
             "Id": "BeanstalkApplication",
@@ -166,6 +167,12 @@
                                 "Regex": "^[^/]{1,100}$",
                                 "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid Application Name. The Application name can contain up to 100 Unicode characters, not including forward slash (/)."
+                            }
+                        },
+                        {
+                            "ValidatorType": "ExistingResource",
+                            "Configuration": {
+                                "ResourceType": "AWS::ElasticBeanstalk::Application"
                             }
                         }
                     ]
@@ -223,6 +230,12 @@
                             "Configuration": {
                                 "Regex": "^[a-zA-Z0-9][a-zA-Z0-9-]{2,38}[a-zA-Z0-9]$",
                                 "ValidationFailedMessage": "Invalid Environment Name. The Environment Name Must be from 4 to 40 characters in length. The name can contain only letters, numbers, and hyphens. It can't start or end with a hyphen."
+                            }
+                        },
+                        {
+                            "ValidatorType": "ExistingResource",
+                            "Configuration": {
+                                "ResourceType": "AWS::ElasticBeanstalk::Environment"
                             }
                         }
                     ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -605,7 +605,8 @@
                                     "Required",
                                     "DirectoryExists",
                                     "DockerBuildArgs",
-                                    "DotnetPublishArgs"
+                                    "DotnetPublishArgs",
+                                    "ExistingResource"
                                 ]
                             }
                         },

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -1789,7 +1789,7 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("displayName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string DisplayName { get; set; }
     
-        /// <summary>The order used to sort categories in UI screens. Categories will be showin in sorted descending order.</summary>
+        /// <summary>The order used to sort categories in UI screens. Categories will be shown in sorted descending order.</summary>
         [Newtonsoft.Json.JsonProperty("order", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Order { get; set; }
     

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -6,12 +6,16 @@ using System.IO;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using Amazon.CloudControlApi.Model;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using Moq;
 using Should;
 using Xunit;
+using ResourceNotFoundException = Amazon.CloudControlApi.Model.ResourceNotFoundException;
+using Task = System.Threading.Tasks.Task;
 
 namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
 {
@@ -20,12 +24,17 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         private readonly IOptionSettingHandler _optionSettingHandler;
         private readonly IServiceProvider _serviceProvider;
         private readonly IDirectoryManager _directoryManager;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
 
         public ECSFargateOptionSettingItemValidationTests()
         {
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider.Setup(x => x.GetService(typeof(IDirectoryManager))).Returns(_directoryManager);
+            mockServiceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
             _serviceProvider = mockServiceProvider.Object;
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
@@ -37,11 +46,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:ecs:us-east-1:01234567891:cluster/test", false)] //invalid account ID
         [InlineData("arn:aws:ecs:us-east-1:012345678910:cluster", false)] //no cluster name
         [InlineData("arn:aws:ecs:us-east-1:012345678910:fluster/test", false)] //fluster instead of cluster
-        public void ClusterArnValidationTests(string value, bool isValid)
+        public async Task ClusterArnValidationTests(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:ecs:[^:]*:[0-9]{12}:cluster/.+"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -50,12 +59,12 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("abc12-34-56-XZ", true)] 
         [InlineData("abc_@1323", false)] //invalid characters
         [InlineData("123*&$abc", false)] //invalid characters
-        public void NewClusterNameValidationTests(string value, bool isValid)
+        public async Task NewClusterNameValidationTests(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             //up to 255 letters(uppercase and lowercase), numbers, underscores, and hyphens are allowed.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^([A-Za-z0-9-]{1,255})$"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -64,12 +73,12 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("abc12-34-56_XZ", true)]
         [InlineData("abc_@1323", false)] //invalid character "@"
         [InlineData("123*&$_abc_", false)] //invalid characters
-        public void ECSServiceNameValidationTests(string value, bool isValid)
+        public async Task ECSServiceNameValidationTests(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             // Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^([A-Za-z0-9_-]{1,255})$"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -78,11 +87,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData(-1, false)]
         [InlineData(6000, false)]
         [InlineData(1000, true)]
-        public void DesiredCountValidationTests(int value, bool isValid)
+        public async Task DesiredCountValidationTests(int value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(GetRangeValidatorConfig(1, 5000));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -92,11 +101,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:iam::123456789012:role/S3Access", true)]
         [InlineData("arn:aws:IAM::123456789012:role/S3Access", false)] //invalid uppercase IAM
         [InlineData("arn:aws:iam::1234567890124354:role/S3Access", false)] //invalid account ID
-        public void RoleArnValidationTests(string value, bool isValid)
+        public async Task RoleArnValidationTests(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:.+:iam::[0-9]{12}:.+"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -107,13 +116,13 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("ipc-456678", false)] //invalid prefix
         [InlineData("vpc-zzzzzzzz", false)] //invalid character z
         [InlineData("vpc-ffffffffaaaabbbb12", false)] //suffix length greater than 17
-        public void VpcIdValidationTests(string value, bool isValid)
+        public async Task VpcIdValidationTests(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             //must start with the \"vpc-\" prefix,
             //followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^vpc-([0-9a-f]{8}|[0-9a-f]{17})$"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -122,11 +131,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:elasticloadbalancing:012345678910:elasticloadbalancing:loadbalancer/my-load-balancer", false)] //missing region
         [InlineData("arn:aws:elasticloadbalancing:012345678910:elasticloadbalancing:loadbalancer", false)] //missing resource path
         [InlineData("arn:aws:elasticloadbalancing:01234567891:elasticloadbalancing:loadbalancer", false)] //11 digit account ID
-        public void LoadBalancerArnValidationTest(string value, bool isValid)
+        public async Task LoadBalancerArnValidationTest(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:elasticloadbalancing:[^:]*:[0-9]{12}:loadbalancer/.+"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -135,11 +144,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("/Api/Path/&*$-/@", true)]
         [InlineData("Api/Path", false)] // does not start with '/'
         [InlineData("/Api/Path/<dsd<>", false)] // contains invalid character '<' and '>'
-        public void ListenerConditionPathPatternValidationTest(string value, bool isValid)
+        public async Task ListenerConditionPathPatternValidationTest(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^/[a-zA-Z0-9*?&_\\-.$/~\"'@:+]{0,127}$"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Theory]
@@ -148,11 +157,30 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("MyRepo", false)] // cannot contain uppercase letters
         [InlineData("myrepo123@", false)] // cannot contain @
         [InlineData("myrepo123.a//b", false)] // cannot contain consecutive slashes.
-        public void ECRRepositoryNameValidationTest(string value, bool isValid)
+        public async Task ECRRepositoryNameValidationTest(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$"));
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
+        }
+
+        [Fact]
+        public async Task ECSClusterNameValidationTest_Valid()
+        {
+            _awsResourceQueryer.Setup(x => x.GetCloudControlApiResource(It.IsAny<string>(), It.IsAny<string>())).Throws(new ResourceQueryException(DeployToolErrorCode.ResourceQuery, "", new ResourceNotFoundException("")));
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ECS::Cluster"));
+            await Validate(optionSettingItem, "WebApp1", true);
+        }
+
+        [Fact]
+        public async Task ECSClusterNameValidationTest_Invalid()
+        {
+            var resource = new ResourceDescription { Identifier = "WebApp1" };
+            _awsResourceQueryer.Setup(x => x.GetCloudControlApiResource(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(resource);
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ECS::Cluster"));
+            await Validate(optionSettingItem, "WebApp1", false);
         }
 
         [Theory]
@@ -162,7 +190,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("--tag name:tag", false)]
         [InlineData("-f file", false)]
         [InlineData("--file file", false)]
-        public void DockerBuildArgsValidationTest(string value, bool isValid)
+        public async Task DockerBuildArgsValidationTest(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
@@ -170,11 +198,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 ValidatorType = OptionSettingItemValidatorList.DockerBuildArgs
             });
 
-            Validate(optionSettingItem, value, isValid);
+            await Validate(optionSettingItem, value, isValid);
         }
 
         [Fact]
-        public void DockerExecutionDirectory_AbsoluteExists()
+        public async Task DockerExecutionDirectory_AbsoluteExists()
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
@@ -184,11 +212,11 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
 
             _directoryManager.CreateDirectory(Path.Join("C:", "project"));
 
-            Validate(optionSettingItem, Path.Join("C:", "project"), true);
+            await Validate(optionSettingItem, Path.Join("C:", "project"), true);
         }
 
         [Fact]
-        public void DockerExecutionDirectory_AbsoluteDoesNotExist()
+        public async Task DockerExecutionDirectory_AbsoluteDoesNotExist()
         {
             var optionSettingItem = new OptionSettingItem("id", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
@@ -196,7 +224,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 ValidatorType = OptionSettingItemValidatorList.DirectoryExists,
             });
 
-            Validate(optionSettingItem, Path.Join("C:", "other_project"), false);
+            await Validate(optionSettingItem, Path.Join("C:", "other_project"), false);
         }
 
         private OptionSettingItemValidatorConfig GetRegexValidatorConfig(string regex)
@@ -210,6 +238,19 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 }
             };
             return regexValidatorConfig;
+        }
+
+        private OptionSettingItemValidatorConfig GetExistingResourceValidatorConfig(string type)
+        {
+            var existingResourceValidatorConfig = new OptionSettingItemValidatorConfig
+            {
+                ValidatorType = OptionSettingItemValidatorList.ExistingResource,
+                Configuration = new ExistingResourceValidator(_awsResourceQueryer.Object)
+                {
+                    ResourceType = type
+                }
+            };
+            return existingResourceValidatorConfig;
         }
 
         private OptionSettingItemValidatorConfig GetRangeValidatorConfig(int min, int max)
@@ -226,12 +267,12 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             return rangeValidatorConfig;
         }
 
-        private void Validate<T>(OptionSettingItem optionSettingItem, T value, bool isValid)
+        private async Task Validate<T>(OptionSettingItem optionSettingItem, T value, bool isValid)
         {
             ValidationFailedException exception = null;
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, value);
+                await _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, value);
             }
             catch (ValidationFailedException e)
             {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Amazon.Runtime.Internal;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -27,16 +28,24 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         private readonly IOptionSettingHandler _optionSettingHandler;
         private readonly IServiceProvider _serviceProvider;
         private readonly IValidatorFactory _validatorFactory;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
 
         public ValidatorFactoryTests()
         {
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
             _optionSettingHandler = new Mock<IOptionSettingHandler>().Object;
 
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider.Setup(x => x.GetService(typeof(IOptionSettingHandler))).Returns(_optionSettingHandler);
             mockServiceProvider.Setup(x => x.GetService(typeof(IDirectoryManager))).Returns(new TestDirectoryManager());
             _serviceProvider = mockServiceProvider.Object;
+            mockServiceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
             _validatorFactory = new ValidatorFactory(_serviceProvider);
+            mockServiceProvider
+                .Setup(x => x.GetService(typeof(IValidatorFactory)))
+                .Returns(_validatorFactory);
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
@@ -13,6 +13,7 @@ using AWS.Deploy.CLI.IntegrationTests.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Helpers;
 using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
@@ -11,6 +11,7 @@ using Amazon.ElasticBeanstalk;
 using Amazon.ElasticBeanstalk.Model;
 using Amazon.S3;
 using Amazon.S3.Transfer;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Data;
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/IAMHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/IAMHelper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Helpers

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -229,6 +229,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 
         private async Task<Orchestrator> GetOrchestrator(string targetApplicationProjectPath)
         {
+            var awsResourceQueryer = new TestToolAWSResourceQueryer();
             var directoryManager = new DirectoryManager();
             var fileManager = new FileManager();
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
@@ -237,13 +238,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 
             var projectDefinition = await new ProjectDefinitionParser(fileManager, directoryManager).Parse(targetApplicationProjectPath);
             var session = new OrchestratorSession(projectDefinition);
+            var serviceProvider = new Mock<IServiceProvider>();
 
             return new Orchestrator(session,
                 _inMemoryInteractiveService,
                 new Mock<ICdkProjectHandler>().Object,
                 new Mock<ICDKManager>().Object,
                 new Mock<ICDKVersionDetector>().Object,
-                new TestToolAWSResourceQueryer(),
+                awsResourceQueryer,
                 new Mock<IDeploymentBundleHandler>().Object,
                 localUserSettingsEngine,
                 new Mock<IDockerEngine>().Object,

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Amazon.AppRunner.Model;
+using Amazon.CloudControlApi.Model;
 using Amazon.CloudFormation.Model;
 using Amazon.CloudFront.Model;
 using Amazon.CloudWatchEvents.Model;
@@ -17,6 +18,7 @@ using Amazon.ElasticLoadBalancingV2;
 using Amazon.IdentityManagement.Model;
 using Amazon.Runtime;
 using Amazon.SecurityToken.Model;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Utilities
@@ -44,9 +46,9 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<string> GetS3BucketLocation(string bucketName) => throw new NotImplementedException();
         public Task<Amazon.S3.Model.WebsiteConfiguration> GetS3BucketWebSiteConfiguration(string bucketName) => throw new NotImplementedException();
         public Task<List<KeyPairInfo>> ListOfEC2KeyPairs() => throw new NotImplementedException();
-        public Task<List<Cluster>> ListOfECSClusters() => throw new NotImplementedException();
-        public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications() => throw new NotImplementedException();
-        public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName) => throw new NotImplementedException();
+        public Task<List<Cluster>> ListOfECSClusters(string ecsClusterName) => throw new NotImplementedException();
+        public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications(string applicationName) => throw new NotImplementedException();
+        public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName, string environmentName) => throw new NotImplementedException();
         public Task<List<Role>> ListOfIAMRoles(string servicePrincipal) => throw new NotImplementedException();
         public Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer>> ListOfLoadBalancers(LoadBalancerTypeEnum loadBalancerType) => throw new NotImplementedException();
@@ -65,5 +67,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
         public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
+        public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
@@ -19,20 +19,27 @@ using Xunit;
 using Assert = Should.Core.Assertions.Assert;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.Data;
+using Amazon.CloudControlApi.Model;
+using Amazon.ElasticBeanstalk.Model;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
     public class ApplyPreviousSettingsTests
     {
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
         private readonly IOptionSettingHandler _optionSettingHandler;
         private readonly Orchestrator _orchestrator;
-        private readonly IServiceProvider _serviceProvider;
-
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public ApplyPreviousSettingsTests()
         {
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
             _orchestrator = new Orchestrator(null, null, null, null, null, null, null, null, null, null, null, null, null, null, _optionSettingHandler);
         }
 
@@ -77,7 +84,7 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(serializedSettings);
 
-            beanstalkRecommendation = _orchestrator.ApplyRecommendationPreviousSettings(beanstalkRecommendation, settings);
+            beanstalkRecommendation = await _orchestrator.ApplyRecommendationPreviousSettings(beanstalkRecommendation, settings);
 
             var applicationIAMRoleOptionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ApplicationIAMRole"));
             var typeHintResponse = _optionSettingHandler.GetOptionSettingValue<IAMRoleTypeHintResponse>(beanstalkRecommendation, applicationIAMRoleOptionSetting);
@@ -111,13 +118,95 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(serializedSettings);
 
-            fargateRecommendation = _orchestrator.ApplyRecommendationPreviousSettings(fargateRecommendation, settings);
+            fargateRecommendation = await _orchestrator.ApplyRecommendationPreviousSettings(fargateRecommendation, settings);
 
             var vpcOptionSetting = fargateRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("Vpc"));
 
             Assert.Equal(isDefault, _optionSettingHandler.GetOptionSettingValue(fargateRecommendation, vpcOptionSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("IsDefault"))));
             Assert.Equal(createNew, _optionSettingHandler.GetOptionSettingValue(fargateRecommendation, vpcOptionSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("CreateNew"))));
             Assert.Equal(vpcId, _optionSettingHandler.GetOptionSettingValue(fargateRecommendation, vpcOptionSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("VpcId"))));
+        }
+
+        [Fact]
+        public async Task ApplyECSClusterNamePreviousSettings()
+        {
+            _awsResourceQueryer.Setup(x => x.GetCloudControlApiResource(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new ResourceDescription { Identifier = "WebApp" });
+            var engine = await BuildRecommendationEngine("WebAppWithDockerFile");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var fargateRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_ASPNET_CORE_FARGATE_RECIPE_ID);
+
+            var serializedSettings = @$"
+            {{
+                ""ECSCluster"": {{
+                    ""CreateNew"": true,
+                    ""NewClusterName"": ""WebApp""
+                }}
+            }}";
+
+            var settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(serializedSettings);
+
+            fargateRecommendation = await _orchestrator.ApplyRecommendationPreviousSettings(fargateRecommendation, settings);
+
+            var ecsClusterSetting = fargateRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ECSCluster"));
+
+            Assert.Equal(true, _optionSettingHandler.GetOptionSettingValue(fargateRecommendation, ecsClusterSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("CreateNew"))));
+            Assert.Equal("WebApp", _optionSettingHandler.GetOptionSettingValue(fargateRecommendation, ecsClusterSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("NewClusterName"))));
+        }
+
+        [Fact]
+        public async Task ApplyBeanstalkApplicationNamePreviousSettings()
+        {
+            _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkApplications(It.IsAny<string>())).ReturnsAsync(new List<ApplicationDescription> { new ApplicationDescription { ApplicationName = "WebApp" } });
+            var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            var serializedSettings = @$"
+            {{
+                ""BeanstalkApplication"": {{
+                    ""CreateNew"": true,
+                    ""ApplicationName"": ""WebApp""
+                }}
+            }}";
+
+            var settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(serializedSettings);
+
+            beanstalkRecommendation = await _orchestrator.ApplyRecommendationPreviousSettings(beanstalkRecommendation, settings);
+
+            var applicationSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("BeanstalkApplication"));
+
+            Assert.Equal(true, _optionSettingHandler.GetOptionSettingValue(beanstalkRecommendation, applicationSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("CreateNew"))));
+            Assert.Equal("WebApp", _optionSettingHandler.GetOptionSettingValue(beanstalkRecommendation, applicationSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("ApplicationName"))));
+        }
+
+        [Fact]
+        public async Task ApplyBeanstalkEnvironmentNamePreviousSettings()
+        {
+            _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new List<EnvironmentDescription> { new EnvironmentDescription { EnvironmentName = "WebApp" } });
+            var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            var serializedSettings = @$"
+            {{
+                ""BeanstalkEnvironment"": {{
+                    ""EnvironmentName"": ""WebApp""
+                }}
+            }}";
+
+            var settings = JsonConvert.DeserializeObject<Dictionary<string, object>>(serializedSettings);
+
+            beanstalkRecommendation = await _orchestrator.ApplyRecommendationPreviousSettings(beanstalkRecommendation, settings);
+
+            var environmentSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("BeanstalkEnvironment"));
+
+            Assert.Equal("WebApp", _optionSettingHandler.GetOptionSettingValue(beanstalkRecommendation, environmentSetting.ChildOptionSettings.First(optionSetting => optionSetting.Id.Equals("EnvironmentName"))));
         }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -17,6 +17,7 @@ using AWS.Deploy.Orchestration;
 using Moq;
 using Should;
 using Xunit;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -24,13 +25,18 @@ namespace AWS.Deploy.CLI.UnitTests
     {
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public ConsoleUtilitiesTests()
         {
-            _serviceProvider = new Mock<IServiceProvider>().Object;
             _directoryManager = new TestDirectoryManager();
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         private readonly List<OptionItem> _options = new List<OptionItem>

--- a/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Amazon.Runtime;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -24,6 +25,7 @@ namespace AWS.Deploy.CLI.UnitTests
     {
         private readonly List<Recommendation> _recommendations;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
         private readonly IServiceProvider _serviceProvider;
 
         public SetOptionSettingTests()
@@ -44,12 +46,26 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var engine = new RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() }, session);
             _recommendations = engine.ComputeRecommendations().GetAwaiter().GetResult();
-
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider.Setup(x => x.GetService(typeof(IDirectoryManager))).Returns(directoryManager);
+            mockServiceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
             _serviceProvider = mockServiceProvider.Object;
 
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+        }
+
+        [Fact]
+        public async Task SetOptionSettingTests_DisallowedValues()
+        {
+            var beanstalkApplication = new List<Amazon.ElasticBeanstalk.Model.ApplicationDescription> { new Amazon.ElasticBeanstalk.Model.ApplicationDescription { ApplicationName = "WebApp1"} };
+            _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkApplications(It.IsAny<string>())).ReturnsAsync(beanstalkApplication);
+            var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
+
+            var optionSetting = _optionSettingHandler.GetOptionSetting(recommendation, "BeanstalkApplication.ApplicationName");
+            await Assert.ThrowsAsync<ValidationFailedException>(() => _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, "WebApp1"));
         }
 
         /// <summary>
@@ -57,12 +73,12 @@ namespace AWS.Deploy.CLI.UnitTests
         /// The values in AllowedValues are the only values allowed to be set.
         /// </summary>
         [Fact]
-        public void SetOptionSettingTests_AllowedValues()
+        public async Task SetOptionSettingTests_AllowedValues()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var optionSetting = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals("EnvironmentType"));
-            _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, optionSetting.AllowedValues.First());
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, optionSetting.AllowedValues.First());
 
             Assert.Equal(optionSetting.AllowedValues.First(), _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting));
         }
@@ -74,46 +90,46 @@ namespace AWS.Deploy.CLI.UnitTests
         /// in AllowedValues can be set. Any other value will throw an exception.
         /// </summary>
         [Fact]
-        public void SetOptionSettingTests_MappedValues()
+        public async Task SetOptionSettingTests_MappedValues()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var optionSetting = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals("EnvironmentType"));
-            Assert.Throws<InvalidOverrideValueException>(() => _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, optionSetting.ValueMapping.Values.First()));
+            await Assert.ThrowsAsync<InvalidOverrideValueException>(async () => await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, optionSetting.ValueMapping.Values.First()));
         }
 
         [Fact]
-        public void SetOptionSettingTests_KeyValueType()
+        public async Task SetOptionSettingTests_KeyValueType()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var optionSetting = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals("ElasticBeanstalkEnvironmentVariables"));
             var values = new Dictionary<string, string>() { { "key", "value" } };
-            _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, values);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, values);
 
             Assert.Equal(values, _optionSettingHandler.GetOptionSettingValue<Dictionary<string, string>>(recommendation, optionSetting));
         }
 
         [Fact]
-        public void SetOptionSettingTests_KeyValueType_String()
+        public async Task SetOptionSettingTests_KeyValueType_String()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var optionSetting = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals("ElasticBeanstalkEnvironmentVariables"));
             var dictionary = new Dictionary<string, string>() { { "key", "value" } };
             var dictionaryString = JsonConvert.SerializeObject(dictionary);
-            _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, dictionaryString);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, dictionaryString);
 
             Assert.Equal(dictionary, _optionSettingHandler.GetOptionSettingValue<Dictionary<string, string>>(recommendation, optionSetting));
         }
 
         [Fact]
-        public void SetOptionSettingTests_KeyValueType_Error()
+        public async Task SetOptionSettingTests_KeyValueType_Error()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var optionSetting = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals("ElasticBeanstalkEnvironmentVariables"));
-            Assert.Throws<JsonReaderException>(() => _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, "string"));
+            await Assert.ThrowsAsync<JsonReaderException>(async () => await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, "string"));
         }
 
         /// <summary>
@@ -121,14 +137,14 @@ namespace AWS.Deploy.CLI.UnitTests
         /// also sets the corresponding value in recommendation.DeploymentBundle
         /// </summary>
         [Fact]
-        public void DeploymentBundleWriteThrough_Docker()
+        public async Task DeploymentBundleWriteThrough_Docker()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
 
             var dockerExecutionDirectory = SystemIOUtilities.ResolvePath("WebAppNoDockerFile");
             var dockerBuildArgs = "arg1=val1, arg2=val2";
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DockerExecutionDirectory"), dockerExecutionDirectory);
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DockerBuildArgs"), dockerBuildArgs);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DockerExecutionDirectory"), dockerExecutionDirectory);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DockerBuildArgs"), dockerBuildArgs);
 
             Assert.Equal(dockerExecutionDirectory, recommendation.DeploymentBundle.DockerExecutionDirectory);
             Assert.Equal(dockerBuildArgs, recommendation.DeploymentBundle.DockerBuildArgs);
@@ -139,16 +155,16 @@ namespace AWS.Deploy.CLI.UnitTests
         /// also sets the corresponding value in recommendation.DeploymentBundle
         /// </summary>
         [Fact]
-        public void DeploymentBundleWriteThrough_Dotnet()
+        public async Task DeploymentBundleWriteThrough_Dotnet()
         {
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var dotnetBuildConfiguration = "Debug";
             var dotnetPublishArgs = "--force --nologo";
             var selfContainedBuild = true;
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DotnetBuildConfiguration"), dotnetBuildConfiguration);
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DotnetPublishArgs"), dotnetPublishArgs);
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "SelfContainedBuild"), selfContainedBuild);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DotnetBuildConfiguration"), dotnetBuildConfiguration);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "DotnetPublishArgs"), dotnetPublishArgs);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "SelfContainedBuild"), selfContainedBuild);
 
             Assert.Equal(dotnetBuildConfiguration, recommendation.DeploymentBundle.DotnetPublishBuildConfiguration);
             Assert.Equal(dotnetPublishArgs, recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments);

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
@@ -9,6 +9,7 @@ using Amazon.EC2.Model;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -24,14 +25,19 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public ExistingSecurityGroubsCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSubnetsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSubnetsCommandTest.cs
@@ -9,6 +9,7 @@ using Amazon.EC2.Model;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -24,14 +25,19 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public ExistingSubnetsCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingVpcCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingVpcCommandTest.cs
@@ -9,6 +9,7 @@ using Amazon.EC2.Model;
 using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -24,14 +25,17 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public ExistingVpcCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_mockAWSResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
@@ -11,6 +11,7 @@ using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -27,15 +28,18 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly IDirectoryManager _directoryManager;
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public VPCConnectorCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
             _toolInteractiveService = new TestToolInteractiveServiceImpl();
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_mockAWSResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
@@ -22,18 +22,24 @@ using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 using Moq;
 using Xunit;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
     public class TypeHintTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public TypeHintTests()
         {
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.AppRunner.Model;
+using Amazon.CloudControlApi.Model;
 using Amazon.CloudFormation.Model;
 using Amazon.CloudFront.Model;
 using Amazon.CloudWatchEvents.Model;
@@ -16,6 +17,7 @@ using Amazon.IdentityManagement.Model;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SecurityToken.Model;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 
@@ -62,9 +64,9 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns() => throw new NotImplementedException();
         public Task<List<Vpc>> GetListOfVpcs() => throw new NotImplementedException();
         public Task<List<KeyPairInfo>> ListOfEC2KeyPairs() => throw new NotImplementedException();
-        public Task<List<Amazon.ECS.Model.Cluster>> ListOfECSClusters() => throw new NotImplementedException();
-        public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications() => throw new NotImplementedException();
-        public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName) => throw new NotImplementedException();
+        public Task<List<Amazon.ECS.Model.Cluster>> ListOfECSClusters(string ecsClusterName) => throw new NotImplementedException();
+        public Task<List<ApplicationDescription>> ListOfElasticBeanstalkApplications(string applicationName) => throw new NotImplementedException();
+        public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string applicationName, string environmentName) => throw new NotImplementedException();
         public Task<List<Role>> ListOfIAMRoles(string servicePrincipal) => throw new NotImplementedException();
         public Task<List<StackResource>> DescribeCloudFormationResources(string stackName) => throw new NotImplementedException();
         public Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentId) => throw new NotImplementedException();
@@ -90,5 +92,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<Subnet>> DescribeSubnets(string vpcID = null) => throw new NotImplementedException();
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
         public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
+        public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKProjectHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKProjectHandlerTests.cs
@@ -13,18 +13,24 @@ using Amazon.CloudFormation.Model;
 using System.Collections.Generic;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.Orchestration.UnitTests.CDK
 {
     public class CDKProjectHandlerTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public CDKProjectHandlerTests()
         {
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
@@ -11,6 +11,7 @@ using Amazon.CloudFormation.Model;
 using Amazon.ElasticBeanstalk;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Data;
@@ -55,7 +56,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(new List<Stack>() { stack }));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new List<EnvironmentDescription>()));
 
             var deployedApplicationQueryer = new DeployedApplicationQueryer(
@@ -100,7 +101,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(stacks));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new List<EnvironmentDescription>()));
 
             var deployedApplicationQueryer = new DeployedApplicationQueryer(
@@ -163,7 +164,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(stacks));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                .Returns(Task.FromResult(new List<EnvironmentDescription>()));
 
             var deployedApplicationQueryer = new DeployedApplicationQueryer(
@@ -220,7 +221,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(new List<Stack>() { stack }));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new List<EnvironmentDescription>()));
 
             var deployedApplicationQueryer = new DeployedApplicationQueryer(
@@ -271,7 +272,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(new List<Stack>()));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(environments));
 
             _mockAWSResourceQueryer
@@ -324,7 +325,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(new List<Stack>()));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(environments));
 
             _mockAWSResourceQueryer
@@ -385,7 +386,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(new List<Stack>()));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>()))
+                .Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(environments));
 
             _mockAWSResourceQueryer

--- a/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
@@ -8,6 +8,7 @@ using Amazon.CloudFormation.Model;
 using Amazon.ElasticBeanstalk.Model;
 using Amazon.Runtime;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.DisplayedResources;

--- a/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Amazon.ElasticBeanstalk.Model;
 using Amazon.Runtime;
 using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
@@ -23,12 +24,17 @@ namespace AWS.Deploy.Orchestration.UnitTests
     public class ElasticBeanstalkHandlerTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly Mock<IAWSResourceQueryer> _awsResourceQueryer;
+        private readonly Mock<IServiceProvider> _serviceProvider;
 
         public ElasticBeanstalkHandlerTests()
         {
-            _serviceProvider = new Mock<IServiceProvider>().Object;
-            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+            _awsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_awsResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 
         [Fact]
@@ -90,10 +96,10 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 new Mock<IFileManager>().Object,
                 _optionSettingHandler);
 
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.EnhancedHealthReportingOptionId), "basic");
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.HealthCheckURLOptionId), "/url");
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.ProxyOptionId), "none");
-            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.XRayTracingOptionId), "true");
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.EnhancedHealthReportingOptionId), "basic");
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.HealthCheckURLOptionId), "/url");
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.ProxyOptionId), "none");
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.XRayTracingOptionId), "true");
 
             // ACT
             var optionSettings = elasticBeanstalkHandler.GetEnvironmentConfigurationSettings(recommendation);


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5892

*Description of changes:*
* Added new ExistingResourceValidator is defined on the Recipe level which accepts a CloudFormation resource type and uses Cloud Control API to check if a resource exists. Elastic beanstalk resources are not yet supported, so custom logic is added for those.
* Added new recipe validators to perform final checks on existing resources

![image](https://user-images.githubusercontent.com/53088140/168098641-52af6241-762e-4551-840b-5ed41e712baf.png)

* Added new recipe validators for beanstalk and fargate that does a final pass on resources to make sure we are not using values for existing resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
