### PR TITLE
chore: Add constructor injection support to option and recipe validators

### DIFF
--- a/docs/OptionSettingsItems-input-validation.md
+++ b/docs/OptionSettingsItems-input-validation.md
@@ -141,18 +141,24 @@ In the `RangeValidator` example above, a recipe author can customize `Validation
 
 ### Dependencies
 
-Because Validators will be deserialized as part of a `RecipeDefinition` they need to have parameterless constructors and therefore can't use Constructor Injection.
+Validators may require other services during validation. For example, an option that selects a file path may need an `IFileManager` to validate that it exists.
 
-Validators are currently envisoned to be relatively simple to the point where they shouldn't need any dependencies.  If dependencies in are needed in the future, we can explore adding an `Initialize` method that uses the ServiceLocation (anti-)pattern:
+When deserializing and initializing validators from the `RecipeDefinition` we shall inject any required services into their constructor via an `IServiceProvider` created from the collection of the Deploy Tool's custom services.
 
 ```csharp
-public interface IOptionSettingItemValidator
+public class FileExistsValidator : IOptionSettingItemValidator
 {
-    /// <summary>
-    /// One possibile solution if we need to create a Validator that needs 
-    /// dependencies.
-    /// </summary>
-    void Initialize(IServiceLocator serviceLocator);
+    private readonly IFileManager _fileManager;
+
+    public FileExistsValidator(IFileManager fileManager)
+    {
+        _fileManager = fileManager;
+    }
+
+    public ValidationResult Validate(object input)
+    {
+        // Validate that the provided file path is valid
+    }
 }
 ```
 

--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -25,6 +25,7 @@ using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.CLI.Commands
 {
@@ -74,6 +75,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ICDKVersionDetector _cdkVersionDetector;
         private readonly IAWSServiceHandler _awsServiceHandler;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IValidatorFactory _validatorFactory;
 
         public CommandFactory(
             IServiceProvider serviceProvider,
@@ -101,7 +103,8 @@ namespace AWS.Deploy.CLI.Commands
             ILocalUserSettingsEngine localUserSettingsEngine,
             ICDKVersionDetector cdkVersionDetector,
             IAWSServiceHandler awsServiceHandler,
-            IOptionSettingHandler optionSettingHandler)
+            IOptionSettingHandler optionSettingHandler,
+            IValidatorFactory validatorFactory)
         {
             _serviceProvider = serviceProvider;
             _toolInteractiveService = toolInteractiveService;
@@ -129,6 +132,7 @@ namespace AWS.Deploy.CLI.Commands
             _cdkVersionDetector = cdkVersionDetector;
             _awsServiceHandler = awsServiceHandler;
             _optionSettingHandler = optionSettingHandler;
+            _validatorFactory = validatorFactory;
         }
 
         public Command BuildRootCommand()
@@ -230,7 +234,8 @@ namespace AWS.Deploy.CLI.Commands
                         _directoryManager,
                         _fileManager,
                         _awsServiceHandler,
-                        _optionSettingHandler);
+                        _optionSettingHandler,
+                        _validatorFactory);
 
                     var deploymentProjectPath = input.DeploymentProject ?? string.Empty;
                     if (!string.IsNullOrEmpty(deploymentProjectPath))

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -52,6 +52,7 @@ namespace AWS.Deploy.CLI.Commands
         private readonly ICDKVersionDetector _cdkVersionDetector;
         private readonly IAWSServiceHandler _awsServiceHandler;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IValidatorFactory _validatorFactory;
 
         public DeployCommand(
             IServiceProvider serviceProvider,
@@ -76,7 +77,8 @@ namespace AWS.Deploy.CLI.Commands
             IDirectoryManager directoryManager,
             IFileManager fileManager,
             IAWSServiceHandler awsServiceHandler,
-            IOptionSettingHandler optionSettingHandler)
+            IOptionSettingHandler optionSettingHandler,
+            IValidatorFactory validatorFactory)
         {
             _serviceProvider = serviceProvider;
             _toolInteractiveService = toolInteractiveService;
@@ -101,6 +103,7 @@ namespace AWS.Deploy.CLI.Commands
             _systemCapabilityEvaluator = systemCapabilityEvaluator;
             _awsServiceHandler = awsServiceHandler;
             _optionSettingHandler = optionSettingHandler;
+            _validatorFactory = validatorFactory;
         }
 
         public async Task ExecuteAsync(string applicationName, string deploymentProjectPath, UserDeploymentSettings? userDeploymentSettings = null)
@@ -458,9 +461,8 @@ namespace AWS.Deploy.CLI.Commands
             }
 
             var validatorFailedResults =
-                        recommendation.Recipe
-                            .BuildValidators()
-                            .Select(validator => validator.Validate(recommendation, _session, _optionSettingHandler))
+                _validatorFactory.BuildValidators(recommendation.Recipe)
+                            .Select(validator => validator.Validate(recommendation, _session))
                             .Where(x => !x.IsValid)
                             .ToList();
 
@@ -768,9 +770,8 @@ namespace AWS.Deploy.CLI.Commands
                 if (string.IsNullOrEmpty(input))
                 {
                     var validatorFailedResults =
-                        recommendation.Recipe
-                            .BuildValidators()
-                            .Select(validator => validator.Validate(recommendation, _session, _optionSettingHandler))
+                        _validatorFactory.BuildValidators(recommendation.Recipe)
+                            .Select(validator => validator.Validate(recommendation, _session))
                             .Where(x => !x.IsValid)
                             .ToList();
 

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -9,6 +9,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
@@ -64,6 +65,7 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IS3Handler), typeof(AWSS3Handler), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IElasticBeanstalkHandler), typeof(AWSElasticBeanstalkHandler), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IOptionSettingHandler), typeof(OptionSettingHandler), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IValidatorFactory), typeof(ValidatorFactory), lifetime));
 
             var packageJsonTemplate = typeof(PackageJsonGenerator).Assembly.ReadEmbeddedFile(PackageJsonGenerator.TemplateIdentifier);
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IPackageJsonGenerator), (serviceProvider) => new PackageJsonGenerator(packageJsonTemplate), lifetime));

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -92,11 +92,11 @@ namespace AWS.Deploy.Common.Recipes
         /// Thrown if one or more <see cref="Validators"/> determine
         /// <paramref name="valueOverride"/> is not valid.
         /// </exception>
-        public void SetValue(IOptionSettingHandler optionSettingHandler, object valueOverride)
+        public void SetValue(IOptionSettingHandler optionSettingHandler, object valueOverride, IOptionSettingItemValidator[] validators)
         {
             var isValid = true;
             var validationFailedMessage = string.Empty;
-            foreach (var validator in this.BuildValidators())
+            foreach (var validator in validators)
             {
                 var result = validator.Validate(valueOverride);
                 if (!result.IsValid)

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -38,9 +38,10 @@ namespace AWS.Deploy.Common.Recipes
         /// <summary>
         /// Set the value of an <see cref="OptionSettingItem"/> while validating the provided input.
         /// </summary>
-        /// <param name="optionSettingHandler"></param>
-        /// <param name="value"></param>
-        void SetValue(IOptionSettingHandler optionSettingHandler, object value);
+        /// <param name="optionSettingHandler">Handler use to set any child option settings</param>
+        /// <param name="value">Value to set</param>
+        /// /// <param name="validators">Validators for this item</param>
+        void SetValue(IOptionSettingHandler optionSettingHandler, object value, IOptionSettingItemValidator[] validators);
     }
 
     /// <summary>

--- a/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IRecipeValidator.cs
@@ -10,6 +10,6 @@ namespace AWS.Deploy.Common.Recipes.Validation
     /// </summary>
     public interface IRecipeValidator
     {
-        ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext, IOptionSettingHandler optionSettingHandler);
+        ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/FargateTaskCpuMemorySizeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/FargateTaskCpuMemorySizeValidator.cs
@@ -20,6 +20,13 @@ namespace AWS.Deploy.Common.Recipes.Validation
     /// </summary>
     public class FargateTaskCpuMemorySizeValidator : IRecipeValidator
     {
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public FargateTaskCpuMemorySizeValidator(IOptionSettingHandler optionSettingHandler)
+        {
+            _optionSettingHandler = optionSettingHandler;
+        }
+
         private readonly Dictionary<string, string[]> _cpuMemoryMap = new()
         {
             { "256", new[] { "512", "1024", "2048" } },
@@ -51,15 +58,15 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string? InvalidCpuValueValidationFailedMessage { get; set; }
 
         /// <inheritdoc cref="FargateTaskCpuMemorySizeValidator"/>
-        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext, IOptionSettingHandler optionSettingHandler)
+        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
         {
             string cpu;
             string memory;
 
             try
             {
-                cpu = optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSettingHandler.GetOptionSetting(recommendation, CpuOptionSettingsId));
-                memory = optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSettingHandler.GetOptionSetting(recommendation, MemoryOptionSettingsId));
+                cpu = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, CpuOptionSettingsId));
+                memory = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, MemoryOptionSettingsId));
             }
             catch (OptionSettingItemDoesNotExistException)
             {

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/MinMaxConstraintValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/MinMaxConstraintValidator.cs
@@ -10,19 +10,26 @@ namespace AWS.Deploy.Common.Recipes.Validation
     /// </summary>
     public class MinMaxConstraintValidator : IRecipeValidator
     {
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public MinMaxConstraintValidator(IOptionSettingHandler optionSettingHandler)
+        {
+            _optionSettingHandler = optionSettingHandler;
+        }
+
         public string MinValueOptionSettingsId { get; set; } = string.Empty;
         public string MaxValueOptionSettingsId { get; set; } = string.Empty;
         public string ValidationFailedMessage { get; set; } = "The value specified for {{MinValueOptionSettingsId}} must be less than or equal to the value specified for {{MaxValueOptionSettingsId}}";
 
-        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext, IOptionSettingHandler optionSettingHandler)
+        public ValidationResult Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
         {
             double minVal;
             double maxValue;
 
             try
             {
-                minVal = optionSettingHandler.GetOptionSettingValue<double>(recommendation, optionSettingHandler.GetOptionSetting(recommendation, MinValueOptionSettingsId));
-                maxValue = optionSettingHandler.GetOptionSettingValue<double>(recommendation, optionSettingHandler.GetOptionSetting(recommendation, MaxValueOptionSettingsId));
+                minVal = _optionSettingHandler.GetOptionSettingValue<double>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, MinValueOptionSettingsId));
+                maxValue = _optionSettingHandler.GetOptionSettingValue<double>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, MaxValueOptionSettingsId));
             }
             catch (OptionSettingItemDoesNotExistException)
             {

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -4,15 +4,45 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace AWS.Deploy.Common.Recipes.Validation
 {
     /// <summary>
+    /// Factory that builds the validators for a given option or recipe
+    /// </summary>
+    public interface IValidatorFactory
+    {
+        /// <summary>
+        /// Builds the validators that apply to the given option
+        /// </summary>
+        /// <param name="optionSettingItem">Option to validate</param>
+        /// <returns>Array of validators for the given option</returns>
+        IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem);
+
+        /// <summary>
+        /// Builds the validators that apply to the given recipe
+        /// </summary>
+        /// <param name="recipeDefinition">Recipe to validate</param>
+        /// <returns>Array of validators for the given recipe</returns>
+        IRecipeValidator[] BuildValidators(RecipeDefinition recipeDefinition);
+    }
+
+    /// <summary>
     /// Builds <see cref="IOptionSettingItemValidator"/> and <see cref="IRecipeValidator"/> instances.
     /// </summary>
-    public static class ValidatorFactory
+    public class ValidatorFactory : IValidatorFactory
     {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ValidatorFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
         private static readonly Dictionary<OptionSettingItemValidatorList, Type> _optionSettingItemValidatorTypeMapping = new()
         {
             { OptionSettingItemValidatorList.Range, typeof(RangeValidator) },
@@ -26,7 +56,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { RecipeValidatorList.MinMaxConstraint, typeof(MinMaxConstraintValidator) }
         };
 
-        public static IOptionSettingItemValidator[] BuildValidators(this OptionSettingItem optionSettingItem)
+        public IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem)
         {
             return optionSettingItem.Validators
                 .Select(v => Activate(v.ValidatorType, v.Configuration, _optionSettingItemValidatorTypeMapping))
@@ -34,7 +64,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
                 .ToArray();
         }
 
-        public static IRecipeValidator[] BuildValidators(this RecipeDefinition recipeDefinition)
+        public IRecipeValidator[] BuildValidators(RecipeDefinition recipeDefinition)
         {
             return recipeDefinition.Validators
                 .Select(v => Activate(v.ValidatorType, v.Configuration,_recipeValidatorTypeMapping))
@@ -42,11 +72,11 @@ namespace AWS.Deploy.Common.Recipes.Validation
                 .ToArray();
         }
 
-        private static object? Activate<TValidatorList>(TValidatorList validatorType, object? configuration, Dictionary<TValidatorList, Type> typeMappings) where TValidatorList : struct
+        private object? Activate<TValidatorList>(TValidatorList validatorType, object? configuration, Dictionary<TValidatorList, Type> typeMappings) where TValidatorList : struct
         {
             if (null == configuration)
             {
-                var validatorInstance = Activator.CreateInstance(typeMappings[validatorType]);
+                var validatorInstance = ActivatorUtilities.CreateInstance(_serviceProvider, typeMappings[validatorType]);
                 if (validatorInstance == null)
                     throw new InvalidValidatorTypeException(DeployToolErrorCode.UnableToCreateValidatorInstance, $"Could not create an instance of validator type {validatorType}");
                 return validatorInstance;
@@ -54,13 +84,43 @@ namespace AWS.Deploy.Common.Recipes.Validation
 
             if (configuration is JObject jObject)
             {
-                var validatorInstance = jObject.ToObject(typeMappings[validatorType]);
+                var validatorInstance = JsonConvert.DeserializeObject(
+                    JsonConvert.SerializeObject(jObject),
+                    typeMappings[validatorType],
+                    new JsonSerializerSettings
+                    {
+                        ContractResolver = new ServiceContractResolver(_serviceProvider)
+                    });
+
                 if (validatorInstance == null)
                     throw new InvalidValidatorTypeException(DeployToolErrorCode.UnableToCreateValidatorInstance, $"Could not create an instance of validator type {validatorType}");
                 return validatorInstance;
             }
 
             return configuration;
+        }
+    }
+
+    /// <summary>
+    /// Custom contract resolver that can inject services from an IServiceProvider
+    /// into the constructor of the type that is being deserialized from Json
+    /// </summary>
+    public class ServiceContractResolver : DefaultContractResolver
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ServiceContractResolver(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        protected override JsonObjectContract CreateObjectContract(Type objectType)
+        {
+            var contract = base.CreateObjectContract(objectType);
+            
+            contract.DefaultCreator = () => ActivatorUtilities.CreateInstance(_serviceProvider, objectType);
+
+            return contract;
         }
     }
 }

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -6,11 +6,19 @@ using System.Linq;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Orchestration
 {
     public class OptionSettingHandler : IOptionSettingHandler
     {
+        private readonly IValidatorFactory _validatorFactory;
+
+        public OptionSettingHandler(IValidatorFactory validatorFactory)
+        {
+            _validatorFactory = validatorFactory;
+        }
+
         /// <summary>
         /// Assigns a value to the OptionSettingItem.
         /// </summary>
@@ -20,7 +28,7 @@ namespace AWS.Deploy.Orchestration
         /// </exception>
         public void SetOptionSettingValue(OptionSettingItem optionSettingItem, object value)
         {
-            optionSettingItem.SetValue(this, value);
+            optionSettingItem.SetValue(this, value, _validatorFactory.BuildValidators(optionSettingItem));
         }
 
         /// <summary>

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/AppRunnerOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/AppRunnerOptionSettingItemValidationTests.cs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
+using Moq;
 using Should;
 using Xunit;
 
@@ -16,10 +15,12 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
     public class AppRunnerOptionSettingItemValidationTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public AppRunnerOptionSettingItemValidationTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Theory]

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
+using Moq;
 using Should;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,10 +16,12 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
     public class ECSFargateOptionSettingItemValidationTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ECSFargateOptionSettingItemValidationTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Theory]

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
+using Moq;
 using Should;
 using Xunit;
 
@@ -13,10 +15,12 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
     public class ElasticBeanStalkOptionSettingItemValidationTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ElasticBeanStalkOptionSettingItemValidationTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Theory]

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
+using Moq;
 using Should;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,11 +24,13 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
     {
         private readonly ITestOutputHelper _output;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public OptionSettingsItemValidationTests(ITestOutputHelper output)
         {
             _output = output;
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Theory]

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
@@ -5,8 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Runtime.Internal;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using Moq;
 using Newtonsoft.Json;
 using Should;
 using Xunit;
@@ -21,6 +24,20 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
     /// </summary>
     public class ValidatorFactoryTests
     {
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IValidatorFactory _validatorFactory;
+
+        public ValidatorFactoryTests()
+        {
+            _optionSettingHandler = new Mock<IOptionSettingHandler>().Object;
+
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(x => x.GetService(typeof(IOptionSettingHandler))).Returns(_optionSettingHandler);
+            _serviceProvider = mockServiceProvider.Object;
+            _validatorFactory = new ValidatorFactory(_serviceProvider);
+        }
+
         [Fact]
         public void HasABindingForAllOptionSettingItemValidators()
         {
@@ -42,7 +59,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             };
 
             // ACT
-            var validators = optionSettingItem.BuildValidators();
+            var validators = _validatorFactory.BuildValidators(optionSettingItem);
 
             // ASSERT
             validators.Length.ShouldEqual(allValidators.Length);
@@ -70,7 +87,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             };
 
             // ACT
-            var validators = recipeDefinition.BuildValidators();
+            var validators = _validatorFactory.BuildValidators(recipeDefinition);
 
             // ASSERT
             validators.Length.ShouldEqual(allValidators.Length);
@@ -106,7 +123,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             var deserialized = JsonConvert.DeserializeObject<OptionSettingItem>(json);
 
             // ACT
-            var validators = deserialized.BuildValidators();
+            var validators = _validatorFactory.BuildValidators(deserialized);
 
             // ASSERT
             validators.Length.ShouldEqual(1);
@@ -155,7 +172,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             // ACT
             try
             {
-                validators = deserialized.BuildValidators();
+                validators = _validatorFactory.BuildValidators(deserialized);
             }
             catch (Exception e)
             {

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -26,6 +26,7 @@ using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.Orchestration.ServiceHandlers;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 {
@@ -251,7 +252,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
                 fileManager,
                 directoryManager,
                 new Mock<IAWSServiceHandler>().Object,
-                new OptionSettingHandler());
+                new OptionSettingHandler(new Mock<IValidatorFactory>().Object));
         }
 
         private async Task<string> GetCustomRecipeId(string recipeFilePath)

--- a/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using Xunit;
 using Assert = Should.Core.Assertions.Assert;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -25,10 +26,13 @@ namespace AWS.Deploy.CLI.UnitTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
         private readonly Orchestrator _orchestrator;
+        private readonly IServiceProvider _serviceProvider;
+
 
         public ApplyPreviousSettingsTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
             _orchestrator = new Orchestrator(null, null, null, null, null, null, null, null, null, null, null, null, null, null, _optionSettingHandler);
         }
 

--- a/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ConsoleUtilitiesTests.cs
@@ -1,22 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
-using System.Net.Http;
-using Should;
-using AWS.Deploy.Common;
-using Xunit;
-using Amazon.Runtime;
-using AWS.Deploy.CLI.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.EC2.Model;
-using AWS.Deploy.Common.IO;
+using Amazon.Runtime;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.CLI.Utilities;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
+using Moq;
+using Should;
+using Xunit;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -24,11 +24,13 @@ namespace AWS.Deploy.CLI.UnitTests
     {
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ConsoleUtilitiesTests()
         {
+            _serviceProvider = new Mock<IServiceProvider>().Object;
             _directoryManager = new TestDirectoryManager();
-            _optionSettingHandler = new OptionSettingHandler();
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         private readonly List<OptionItem> _options = new List<OptionItem>

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -20,10 +22,12 @@ namespace AWS.Deploy.CLI.UnitTests
     public class GetOptionSettingTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public GetOptionSettingTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         private async Task<RecommendationEngine> BuildRecommendationEngine(string testProjectName)

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -25,11 +27,13 @@ namespace AWS.Deploy.CLI.UnitTests
         private OrchestratorSession _session;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public RecommendationTests()
         {
             _directoryManager = new TestDirectoryManager();
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         private async Task<RecommendationEngine> BuildRecommendationEngine(string testProjectName)

--- a/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -22,6 +24,7 @@ namespace AWS.Deploy.CLI.UnitTests
     {
         private readonly List<Recommendation> _recommendations;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public SetOptionSettingTests()
         {
@@ -40,7 +43,8 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var engine = new RecommendationEngine(new[] { RecipeLocator.FindRecipeDefinitionsPath() }, session);
             _recommendations = engine.ComputeRecommendations().GetAwaiter().GetResult();
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         /// <summary>

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 using Moq;
@@ -22,12 +24,14 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ExistingSecurityGroubsCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSubnetsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSubnetsCommandTest.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 using Moq;
@@ -22,12 +24,14 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ExistingSubnetsCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingVpcCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingVpcCommandTest.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 using Moq;
@@ -22,12 +24,14 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
         private readonly IDirectoryManager _directoryManager;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ExistingVpcCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.Data;
 using Moq;
@@ -25,13 +27,15 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
         private readonly IDirectoryManager _directoryManager;
         private readonly IToolInteractiveService _toolInteractiveService;
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public VPCConnectorCommandTest()
         {
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _directoryManager = new TestDirectoryManager();
             _toolInteractiveService = new TestToolInteractiveServiceImpl();
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
@@ -3,14 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Moq;
-using Xunit;
-
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.S3;
@@ -20,21 +14,26 @@ using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using AWS.Deploy.CLI.Commands.TypeHints;
-using AWS.Deploy.Common;
-using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.Data;
+using Moq;
+using Xunit;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
     public class TypeHintTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public TypeHintTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKProjectHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKProjectHandlerTests.cs
@@ -12,16 +12,19 @@ using Xunit;
 using Amazon.CloudFormation.Model;
 using System.Collections.Generic;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Orchestration.UnitTests.CDK
 {
     public class CDKProjectHandlerTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public CDKProjectHandlerTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]

--- a/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
@@ -11,6 +11,7 @@ using Amazon.Runtime;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Orchestration.UnitTests.Utilities;
 using AWS.Deploy.Recipes;
@@ -22,10 +23,12 @@ namespace AWS.Deploy.Orchestration.UnitTests
     public class ElasticBeanstalkHandlerTests
     {
         private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
 
         public ElasticBeanstalkHandlerTests()
         {
-            _optionSettingHandler = new OptionSettingHandler();
+            _serviceProvider = new Mock<IServiceProvider>().Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
         }
 
         [Fact]


### PR DESCRIPTION
*Issue #, if available:* N/A, this is to support upcoming work to improve validation on deployment bundle settings. https://github.com/aws/aws-dotnet-deploy/pull/509 will also make use of this.

*Description of changes:*

Previously, `IOptionSettingItemValidator` and `IRecipeValidator` were always initialized through parameterless constructors. The current set of validators are self contained (required, ranges, regexes) that did not need any dependencies.

However upcoming validators around the Docker file and execution directory require an instance of `IDirectoryManager` and `IFileManager`.

This reworks `ValidatorFactory` to be able to inject services into validators when initializing them. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
