### PR TITLE
fix: Check for duplicate cloud application names

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -146,14 +146,12 @@ namespace AWS.Deploy.CLI.Commands
         /// If a new Cloudformation stack name is selected, then a fresh deployment is initiated with the user-selected deployment recipe.
         /// If an existing deployment target is selected, then a re-deployment is initiated with the same deployment recipe.
         /// </summary>
-        /// <param name="applicationName">The cloud application name provided via the --application-name CLI argument</param>
+        /// <param name="cloudApplicationName">The cloud application name provided via the --application-name CLI argument</param>
         /// <param name="userDeploymentSettings">The deserialized object from the user provided config file.<see cref="UserDeploymentSettings"/></param>
         /// <param name="deploymentProjectPath">The absolute or relative path of the CDK project that will be used for deployment</param>
         /// <returns>A tuple consisting of the Orchestrator object, Selected Recommendation, Cloud Application metadata.</returns>
-        public async Task<(Orchestrator, Recommendation, CloudApplication)> InitializeDeployment(string applicationName, UserDeploymentSettings? userDeploymentSettings, string deploymentProjectPath)
+        public async Task<(Orchestrator, Recommendation, CloudApplication)> InitializeDeployment(string cloudApplicationName, UserDeploymentSettings? userDeploymentSettings, string deploymentProjectPath)
         {
-            string cloudApplicationName;
-
             var orchestrator = new Orchestrator(
                     _session,
                     _orchestratorInteractiveService,
@@ -180,8 +178,9 @@ namespace AWS.Deploy.CLI.Commands
             // Filter compatible applications that can be re-deployed  using the current set of recommendations.
             var compatibleApplications = await _deployedApplicationQueryer.GetCompatibleApplications(recommendations, allDeployedApplications, _session);
 
-            // Try finding the CloudApplication name via the --application-name CLI argument or user provided config settings.
-            cloudApplicationName = GetCloudApplicationNameFromDeploymentSettings(applicationName, userDeploymentSettings);
+            if (string.IsNullOrEmpty(cloudApplicationName))
+                // Try finding the CloudApplication name via the user provided config settings.
+                cloudApplicationName = userDeploymentSettings?.ApplicationName ?? string.Empty;
 
             // Prompt the user with a choice to re-deploy to existing targets or deploy to a new cloud application.
             if (string.IsNullOrEmpty(cloudApplicationName))
@@ -222,12 +221,19 @@ namespace AWS.Deploy.CLI.Commands
                     // The ECR repository name is already configurable as part of the recipe option settings.
                     if (selectedRecommendation.Recipe.DeploymentType == DeploymentTypes.ElasticContainerRegistryImage)
                     {
-                        cloudApplicationName = _cloudApplicationNameGenerator.GenerateValidName(_session.ProjectDefinition, compatibleApplications);
+                        cloudApplicationName = _cloudApplicationNameGenerator.GenerateValidName(_session.ProjectDefinition, compatibleApplications, selectedRecommendation.Recipe.DeploymentType);
                     }
                     else
                     {
                         cloudApplicationName = AskForNewCloudApplicationName(selectedRecommendation.Recipe.DeploymentType, compatibleApplications);
                     }
+                }
+                // cloudApplication name was already provided via CLI args or the deployment config file
+                else
+                {
+                    var validationResult = _cloudApplicationNameGenerator.IsValidName(cloudApplicationName, allDeployedApplications, selectedRecommendation.Recipe.DeploymentType);
+                    if (!validationResult.IsValid)
+                        throw new InvalidCloudApplicationNameException(DeployToolErrorCode.InvalidCloudApplicationName, validationResult.ErrorMessage);
                 }
             }
 
@@ -503,33 +509,6 @@ namespace AWS.Deploy.CLI.Commands
             }
         }
 
-        // This method tries to find the cloud application name via the user provided CLI arguments or deployment config file.
-        // If a name is not present at either of the places then return string.empty
-        private string GetCloudApplicationNameFromDeploymentSettings(string? applicationName, UserDeploymentSettings? userDeploymentSettings)
-        {
-            // validate and return the applicationName provided by the --application-name cli argument if present.
-            if (!string.IsNullOrEmpty(applicationName))
-            {
-                if (_cloudApplicationNameGenerator.IsValidName(applicationName))
-                    return applicationName;
-
-                PrintInvalidApplicationNameMessage(applicationName);
-                throw new InvalidCliArgumentException(DeployToolErrorCode.InvalidCliArguments, "Found invalid CLI arguments");
-            }
-
-            // validate and return the applicationName from the deployment settings if present.
-            if (!string.IsNullOrEmpty(userDeploymentSettings?.ApplicationName))
-            {
-                if (_cloudApplicationNameGenerator.IsValidName(userDeploymentSettings.ApplicationName))
-                    return userDeploymentSettings.ApplicationName;
-
-                PrintInvalidApplicationNameMessage(userDeploymentSettings.ApplicationName);
-                throw new InvalidUserDeploymentSettingsException(DeployToolErrorCode.UserDeploymentInvalidStackName, "Please provide a valid cloud application name and try again.");
-            }
-
-            return string.Empty;
-        }
-
         // This method prompts the user to select a CloudApplication name for existing deployments or create a new one.
         // If a user chooses to create a new CloudApplication, then this method returns string.Empty
         private string AskForCloudApplicationNameFromDeployedApplications(List<CloudApplication> deployedApplications)
@@ -573,14 +552,14 @@ namespace AWS.Deploy.CLI.Commands
 
             try
             {
-                defaultName = _cloudApplicationNameGenerator.GenerateValidName(_session.ProjectDefinition, deployedApplications);
+                defaultName = _cloudApplicationNameGenerator.GenerateValidName(_session.ProjectDefinition, deployedApplications, deploymentType);
             }
             catch (Exception exception)
             {
                 _toolInteractiveService.WriteDebugLine(exception.PrettyPrint());
             }
 
-            var cloudApplicationName = "";
+            var cloudApplicationName = string.Empty;
 
             while (true)
             {
@@ -610,12 +589,14 @@ namespace AWS.Deploy.CLI.Commands
                         allowEmpty: false,
                         defaultAskValuePrompt: inputPrompt);
 
-                if (string.IsNullOrEmpty(cloudApplicationName) || !_cloudApplicationNameGenerator.IsValidName(cloudApplicationName))
-                    PrintInvalidApplicationNameMessage(cloudApplicationName);
-                else if (deployedApplications.Any(x => x.Name.Equals(cloudApplicationName)))
-                    PrintApplicationNameAlreadyExistsMessage();
-                else
+                var validationResult = _cloudApplicationNameGenerator.IsValidName(cloudApplicationName, deployedApplications, deploymentType);
+                if (validationResult.IsValid)
+                {
                     return cloudApplicationName;
+                }
+
+                _toolInteractiveService.WriteLine();
+                _toolInteractiveService.WriteErrorLine(validationResult.ErrorMessage);
             }
         }
 
@@ -651,20 +632,6 @@ namespace AWS.Deploy.CLI.Commands
             _toolInteractiveService.WriteLine();
             _toolInteractiveService.WriteLine($"Configuring Recommendation with: '{selectedRecommendation.Name}'.");
             return selectedRecommendation;
-        }
-
-        private void PrintInvalidApplicationNameMessage(string name)
-        {
-            _toolInteractiveService.WriteLine();
-            _toolInteractiveService.WriteErrorLine(_cloudApplicationNameGenerator.InvalidNameMessage(name));
-        }
-
-        private void PrintApplicationNameAlreadyExistsMessage()
-        {
-            _toolInteractiveService.WriteLine();
-            _toolInteractiveService.WriteErrorLine(
-                "Invalid application name. There already exists a CloudFormation stack with the name you provided. " +
-                "Please choose another application name.");
         }
 
         private bool ConfirmDeployment(Recommendation recommendation)

--- a/src/AWS.Deploy.CLI/Exceptions.cs
+++ b/src/AWS.Deploy.CLI/Exceptions.cs
@@ -84,4 +84,12 @@ namespace AWS.Deploy.CLI
     {
         public FailedToGetCredentialsForProfile(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if cloud application name is invalid.
+    /// </summary>
+    public class InvalidCloudApplicationNameException : DeployToolException
+    {
+        public InvalidCloudApplicationNameException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -383,14 +383,13 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                     return NotFound($"Recommendation {input.NewDeploymentRecipeId} not found.");
                 }
 
+                // We only validate the name when the recipe deployment type is not ElasticContainerRegistryImage.
+                // This is because pushing images to ECR does not need a cloud application name.
                 if (state.SelectedRecommendation.Recipe.DeploymentType != Common.Recipes.DeploymentTypes.ElasticContainerRegistryImage)
                 {
-                    // We only validate the name when the recipe deployment type is not ElasticContainerRegistryImage.
-                    // This is because pushing images to ECR does not need a cloud application name.
-                    if (!cloudApplicationNameGenerator.IsValidName(newDeploymentName))
-                    {
-                        return ValidationProblem(cloudApplicationNameGenerator.InvalidNameMessage(newDeploymentName));
-                    }
+                    var validationResult = cloudApplicationNameGenerator.IsValidName(newDeploymentName, state.ExistingDeployments ?? new List<CloudApplication>(), state.SelectedRecommendation.Recipe.DeploymentType);
+                    if (!validationResult.IsValid)
+                        return ValidationProblem(validationResult.ErrorMessage);
                 }
 
                 state.ApplicationDetails.Name = newDeploymentName;

--- a/src/AWS.Deploy.Common/CloudApplication.cs
+++ b/src/AWS.Deploy.Common/CloudApplication.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.Common
 {
@@ -17,6 +18,14 @@ namespace AWS.Deploy.Common
                 { CloudApplicationResourceType.CloudFormationStack, "CloudFormation Stack" },
                 { CloudApplicationResourceType.BeanstalkEnvironment, "Elastic Beanstalk Environment" },
                 { CloudApplicationResourceType.ElasticContainerRegistryImage, "ECR Repository" }
+            };
+
+        private readonly Dictionary<CloudApplicationResourceType, DeploymentTypes> _deploymentTypeMapping =
+            new()
+            {
+                { CloudApplicationResourceType.CloudFormationStack, DeploymentTypes.CdkProject},
+                { CloudApplicationResourceType.BeanstalkEnvironment, DeploymentTypes.BeanstalkEnvironment },
+                { CloudApplicationResourceType.ElasticContainerRegistryImage, DeploymentTypes.ElasticContainerRegistryImage }
             };
 
         /// <summary>
@@ -38,8 +47,7 @@ namespace AWS.Deploy.Common
         public string RecipeId { get; set; }
 
         /// <summary>
-        /// indicates the type of the AWS resource which serves as the deployment target.
-        /// Current supported values are None, CloudFormationStack and BeanstalkEnvironment.
+        /// Indicates the type of the AWS resource which serves as the deployment target.
         /// </summary>
         public CloudApplicationResourceType ResourceType { get; set; }
 
@@ -62,6 +70,11 @@ namespace AWS.Deploy.Common
         /// Display the name of the Cloud Application
         /// </summary>
         public override string ToString() => Name;
+
+        /// <summary>
+        /// Gets the deployment type of the recommendation that was used to deploy the cloud application.
+        /// </summary>
+        public DeploymentTypes DeploymentType => _deploymentTypeMapping[ResourceType];
 
         public CloudApplication(string name, string uniqueIdentifier, CloudApplicationResourceType resourceType, string recipeId, DateTime? lastUpdatedTime = null)
         {

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -113,7 +113,8 @@ namespace AWS.Deploy.Common
         FailedToCreateCDKProject = 10009100,
         ResourceQuery = 10009200,
         FailedToRetrieveStackId = 10009300,
-        FailedToGetECRAuthorizationToken = 10009400
+        FailedToGetECRAuthorizationToken = 10009400,
+        InvalidCloudApplicationName = 10009500
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/CloudApplicationNameGenerator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.Orchestration.Utilities
 {
@@ -20,23 +21,38 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// <exception cref="ArgumentException">
         /// Thrown if can't generate a valid name from <paramref name="target"/>.
         /// </exception>
-        string GenerateValidName(ProjectDefinition target, List<CloudApplication> existingApplications);
+        string GenerateValidName(ProjectDefinition target, List<CloudApplication> existingApplications, DeploymentTypes? deploymentType = null);
 
         /// <summary>
-        /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
+        /// Validates the cloud application name
         /// </summary>
-        bool IsValidName(string name);
+        /// <param name="name">User provided cloud application name</param>
+        /// <param name="deploymentType">The deployment type of the selected recommendation</param>
+        /// <param name="existingApplications">List of existing deployed applications</param>
+        /// <returns><see cref="CloudApplicationNameValidationResult"/></returns>
+        CloudApplicationNameValidationResult IsValidName(string name, IList<CloudApplication> existingApplications, DeploymentTypes? deploymentType = null);
+    }
 
-        /// <summary>
-        /// The message that should be displayed when an invalid name is passed
-        /// </summary>
-        string InvalidNameMessage(string name);
+    /// <summary>
+    /// Stores the result from validating the cloud application name.
+    /// </summary>
+    public class CloudApplicationNameValidationResult
+    {
+        public readonly bool IsValid;
+        public readonly string ErrorMessage;
+
+        public CloudApplicationNameValidationResult(bool isValid, string errorMessage)
+        {
+            IsValid = isValid;
+            ErrorMessage = errorMessage;
+        }
     }
 
     public class CloudApplicationNameGenerator : ICloudApplicationNameGenerator
     {
         private readonly IFileManager _fileManager;
         private readonly IDirectoryManager _directoryManager;
+
         /// <summary>
         /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
         /// </summary>
@@ -48,7 +64,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             _directoryManager = directoryManager;
         }
 
-        public string GenerateValidName(ProjectDefinition target, List<CloudApplication> existingApplications)
+        public string GenerateValidName(ProjectDefinition target, List<CloudApplication> existingApplications, DeploymentTypes? deploymentType = null)
         {
             // generate recommendation
             var recommendedPrefix = "deployment";
@@ -86,7 +102,9 @@ namespace AWS.Deploy.Orchestration.Utilities
             var suffix = !string.IsNullOrEmpty(suffixString) ? int.Parse(suffixString): 0;
             while (suffix < int.MaxValue)
             {
-                if (existingApplications.All(x => x.Name != recommendation) && IsValidName(recommendation))
+                var validationResult = IsValidName(recommendation, existingApplications, deploymentType);
+
+                if (validationResult.IsValid)
                     return recommendation;
 
                 recommendation = $"{prefix}{++suffix}";
@@ -95,15 +113,52 @@ namespace AWS.Deploy.Orchestration.Utilities
             throw new ArgumentException("Failed to generate a valid and unique name.");
         }
 
-        /// <remarks>
-        /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
-        /// </remarks>>
-        public bool IsValidName(string name) => _validatorRegex.IsMatch(name);
 
-        public string InvalidNameMessage(string name)
+        public CloudApplicationNameValidationResult IsValidName(string name, IList<CloudApplication> existingApplications, DeploymentTypes? deploymentType = null)
         {
-            return $"Invalid cloud application name {name}. The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
-                "It must start with an alphabetic character and can't be longer than 128 characters";
+            var errorMessage = string.Empty;
+
+            if (!SatisfiesRegex(name))
+            {
+                errorMessage += $"The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
+                $"It must start with an alphabetic character and can't be longer than 128 characters.{Environment.NewLine}";
+            }
+            if (MatchesExistingDeployment(name, existingApplications, deploymentType))
+            {
+                errorMessage += "A cloud application already exists with this name.";
+            }
+
+            if (string.IsNullOrEmpty(errorMessage))
+                return new CloudApplicationNameValidationResult(true, string.Empty);
+
+            return new CloudApplicationNameValidationResult(false, $"Invalid cloud application name: {name}{Environment.NewLine}{errorMessage}");
+        }
+
+        /// <summary>
+        /// This method first filters the existing applications by the current deploymentType if the deploymentType is not null
+        /// It will then check if the current name matches the filtered list of existing applications
+        /// </summary>
+        /// <param name="name">User provided cloud application name</param>
+        /// <param name="deploymentType">The deployment type of the selected recommendation</param>
+        /// <param name="existingApplications">List of existing deployed applications</param>
+        /// <returns>true if found a match. false otherwise</returns>
+        private bool MatchesExistingDeployment(string name, IList<CloudApplication> existingApplications, DeploymentTypes? deploymentType = null)
+        {
+            if (!existingApplications.Any())
+                return false;
+
+            if (deploymentType != null)
+                existingApplications = existingApplications.Where(x => x.DeploymentType == deploymentType).ToList();
+
+            return existingApplications.Any(x => x.Name == name);
+        }
+
+        /// <summary>
+        /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
+        /// </summary>
+        private bool SatisfiesRegex(string name)
+        {
+            return _validatorRegex.IsMatch(name);
         }
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -158,49 +158,6 @@ namespace AWS.Deploy.CLI.IntegrationTests
         }
 
         [Fact]
-        public async Task SetInvalidCloudFormationStackName()
-        {
-            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
-            var portNumber = 4080;
-            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
-
-            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
-            var cancelSource = new CancellationTokenSource();
-
-            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
-            try
-            {
-                var restClient = new RestAPIClient($"http://localhost:{portNumber}/", httpClient);
-                await WaitTillServerModeReady(restClient);
-
-                var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
-                {
-                    AwsRegion = _awsRegion,
-                    ProjectPath = projectPath
-                });
-
-                var sessionId = startSessionOutput.SessionId;
-                Assert.NotNull(sessionId);
-
-                var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
-                Assert.NotEmpty(getRecommendationOutput.Recommendations);
-                var beanstalkRecommendation = getRecommendationOutput.Recommendations.FirstOrDefault();
-
-                var exception = await Assert.ThrowsAsync<ApiException<ProblemDetails>>(() => restClient.SetDeploymentTargetAsync(sessionId, new SetDeploymentTargetInput
-                {
-                    NewDeploymentRecipeId = beanstalkRecommendation.RecipeId,
-                    NewDeploymentName = "Hello$World"
-                }));
-
-                Assert.Contains("Invalid cloud application name Hello$World.", exception.Result.Detail);
-            }
-            finally
-            {
-                cancelSource.Cancel();
-            }
-        }
-
-        [Fact]
         public async Task WebFargateDeploymentNoConfigChanges()
         {
             _stackName = $"ServerModeWebFargate{Guid.NewGuid().ToString().Split('-').Last()}";
@@ -400,8 +357,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
                 Assert.Equal(400, exception.StatusCode);
 
-                var errorMessage = $"Invalid cloud application name {invalidStackName}. The application name can contain only alphanumeric characters (case-sensitive) and hyphens. " +
-                    "It must start with an alphabetic character and can't be longer than 128 characters";
+                var errorMessage = $"Invalid cloud application name: {invalidStackName}";
                 Assert.Contains(errorMessage, exception.Result.Detail);
             }
             finally


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5924

*Description of changes:*
https://github.com/aws/aws-dotnet-deploy/pull/505 prevented the user from providing an existing cloud application name, while performing a new deployment.

This PR extends this functionality to server mode and ensures that the cloud application name is only unique within the current deployment type.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
