### PR TITLE
fix: Validate and respect deployment bundle settings for the Docker or dotnet builds during server mode

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -460,9 +460,7 @@ namespace AWS.Deploy.CLI.Commands
                         throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, $"Invalid value {optionSettingValue} for option setting item {optionSettingJsonPath}");
                     }
 
-                    _optionSettingHandler.SetOptionSettingValue(optionSetting, settingValue);
-
-                    SetDeploymentBundleOptionSetting(recommendation, optionSetting.Id, settingValue);
+                    _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, settingValue);
                 }
             }
 
@@ -485,30 +483,6 @@ namespace AWS.Deploy.CLI.Commands
                 errorMessage += result.ValidationFailedMessage + Environment.NewLine;
             }
             throw new InvalidUserDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNeedsAdjusting, errorMessage.Trim());
-        }
-
-        private void SetDeploymentBundleOptionSetting(Recommendation recommendation, string optionSettingId, object settingValue)
-        {
-            switch (optionSettingId)
-            {
-                case "DockerExecutionDirectory":
-                    ActivatorUtilities.CreateInstance<DockerExecutionDirectoryCommand>(_serviceProvider).OverrideValue(recommendation, settingValue.ToString() ?? "");
-                    break;
-                case "DockerBuildArgs":
-                    ActivatorUtilities.CreateInstance<DockerBuildArgsCommand>(_serviceProvider).OverrideValue(recommendation, settingValue.ToString() ?? "");
-                    break;
-                case "DotnetBuildConfiguration":
-                    ActivatorUtilities.CreateInstance<DotnetPublishBuildConfigurationCommand>(_serviceProvider).Overridevalue(recommendation, settingValue.ToString() ?? "");
-                    break;
-                case "DotnetPublishArgs":
-                    ActivatorUtilities.CreateInstance<DotnetPublishArgsCommand>(_serviceProvider).OverrideValue(recommendation, settingValue.ToString() ?? "");
-                    break;
-                case "SelfContainedBuild":
-                    ActivatorUtilities.CreateInstance<DotnetPublishSelfContainedBuildCommand>(_serviceProvider).OverrideValue(recommendation, (bool)settingValue);
-                    break;
-                default:
-                    return;
-            }
         }
 
         // This method prompts the user to select a CloudApplication name for existing deployments or create a new one.
@@ -855,7 +829,7 @@ namespace AWS.Deploy.CLI.Commands
             {
                 try
                 {
-                    _optionSettingHandler.SetOptionSettingValue(setting, settingValue);
+                    _optionSettingHandler.SetOptionSettingValue(recommendation, setting, settingValue);
                 }
                 catch (ValidationFailedException ex)
                 {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Common.TypeHintData;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -55,20 +55,16 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         private string ValidateBuildArgs(string buildArgs)
         {
-            var argsList = buildArgs.Split(",");
-            if (argsList.Length == 0)
-                return "";
+            var validationResult = new DockerBuildArgsValidator().Validate(buildArgs);
 
-            foreach (var arg in argsList)
+            if (validationResult.IsValid)
             {
-                var keyValue = arg.Split("=");
-                if (keyValue.Length == 2)
-                    return "";
-                else
-                    return "The Docker Build Args must have the following pattern 'arg1=val1,arg2=val2'.";
+                return string.Empty;
             }
-
-            return "";
+            else
+            {
+                return validationResult.ValidationFailedMessage ?? "Invalid value for additional Docker build options.";
+            }
         }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Common.TypeHintData;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -56,10 +57,16 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         private string ValidateExecutionDirectory(string executionDirectory)
         {
-            if (!string.IsNullOrEmpty(executionDirectory) && !_directoryManager.Exists(executionDirectory))
-                return "The directory specified for Docker execution does not exist.";
+            var validationResult = new DirectoryExistsValidator(_directoryManager).Validate(executionDirectory);
+
+            if (validationResult.IsValid)
+            {
+                return string.Empty;
+            }
             else
-                return "";
+            {   // Override the generic ValidationResultMessage with one about the the Docker execution directory
+                return "The directory specified for Docker execution does not exist.";
+            }
         }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Common.TypeHintData;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
@@ -56,18 +56,16 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
         private string ValidateDotnetPublishArgs(string publishArgs)
         {
-            var resultString = string.Empty;
+            var validationResult = new DotnetPublishArgsValidator().Validate(publishArgs);
 
-            if (publishArgs.Contains("-o ") || publishArgs.Contains("--output "))
-                resultString += "You must not include -o/--output as an additional argument as it is used internally." + Environment.NewLine;
-            if (publishArgs.Contains("-c ") || publishArgs.Contains("--configuration "))
-                resultString += "You must not include -c/--configuration as an additional argument. You can set the build configuration in the advanced settings." + Environment.NewLine;
-            if (publishArgs.Contains("--self-contained") || publishArgs.Contains("--no-self-contained"))
-                resultString += "You must not include --self-contained/--no-self-contained as an additional argument. You can set the self-contained property in the advanced settings." + Environment.NewLine;
-
-            if (!string.IsNullOrEmpty(resultString))
-                return "Invalid valid value for Dotnet Publish Arguments." + Environment.NewLine + resultString.Trim();
-            return "";
+            if (validationResult.IsValid)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return validationResult.ValidationFailedMessage ?? "Invalid value for Dotnet Publish Arguments.";
+            }
         }
     }
 }

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -251,7 +251,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 try
                 {
                     var setting = optionSettingHandler.GetOptionSetting(state.SelectedRecommendation, updatedSetting.Key);
-                    optionSettingHandler.SetOptionSettingValue(setting, updatedSetting.Value);
+                    optionSettingHandler.SetOptionSettingValue(state.SelectedRecommendation, setting, updatedSetting.Value);
                 }
                 catch (Exception ex)
                 {

--- a/src/AWS.Deploy.Common/IO/DirectoryManager.cs
+++ b/src/AWS.Deploy.Common/IO/DirectoryManager.cs
@@ -13,7 +13,30 @@ namespace AWS.Deploy.Common.IO
     {
         DirectoryInfo CreateDirectory(string path);
         DirectoryInfo GetDirectoryInfo(string path);
+
+        /// <summary>
+        /// Determines whether the given path refers to an existing directory on disk.
+        /// This can either be an absolute path or relative to the current working directory.
+        /// </summary>
+        /// <param name="path">The path to test</param>
+        /// <returns>
+        /// true if path refers to an existing directory;
+        /// false if the directory does not exist or an error occurs when trying to determine if the specified directory exists
+        /// </returns>
         bool Exists(string path);
+
+        /// <summary>
+        /// Determines whether the given path refers to an existing directory on disk.
+        /// This can either be an absolute path or relative to the given directory.
+        /// </summary>
+        /// <param name="path">The path to test</param>
+        /// <param name="relativeTo">Directory to consider the path as relative to</param>
+        /// <returns>
+        /// true if path refers to an existing directory;
+        /// false if the directory does not exist or an error occurs when trying to determine if the specified directory exists
+        /// </returns>
+        bool Exists(string path, string relativeTo);
+
         string[] GetFiles(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly);
         string[] GetDirectories(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly);
         bool IsEmpty(string path);
@@ -37,6 +60,18 @@ namespace AWS.Deploy.Common.IO
         public DirectoryInfo GetDirectoryInfo(string path) => new DirectoryInfo(path);
 
         public bool Exists(string path) => IsDirectoryValid(path);
+
+        public bool Exists(string path, string relativeTo)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return Exists(path);
+            }
+            else
+            {
+                return Exists(Path.Combine(relativeTo, path));
+            }
+        }
 
         public string[] GetFiles(string path, string? searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly)
             => Directory.GetFiles(path, searchPattern ?? "*", searchOption);

--- a/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
+++ b/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
@@ -13,7 +13,7 @@ namespace AWS.Deploy.Common.Recipes
         /// Due to different validations that could be put in place, access to other services may be needed.
         /// This method is meant to control access to those services and determine the value to be set.
         /// </summary>
-        void SetOptionSettingValue(OptionSettingItem optionSettingItem, object value);
+        void SetOptionSettingValue(Recommendation recommendation, OptionSettingItem optionSettingItem, object value);
 
         /// <summary>
         /// This method retrieves the <see cref="OptionSettingItem"/> related to a specific <see cref="Recommendation"/>.

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -92,7 +92,7 @@ namespace AWS.Deploy.Common.Recipes
         /// Thrown if one or more <see cref="Validators"/> determine
         /// <paramref name="valueOverride"/> is not valid.
         /// </exception>
-        public void SetValue(IOptionSettingHandler optionSettingHandler, object valueOverride, IOptionSettingItemValidator[] validators)
+        public void SetValue(IOptionSettingHandler optionSettingHandler, object valueOverride, IOptionSettingItemValidator[] validators, Recommendation recommendation)
         {
             var isValid = true;
             var validationFailedMessage = string.Empty;
@@ -148,7 +148,7 @@ namespace AWS.Deploy.Common.Recipes
                 {
                     if (deserialized.TryGetValue(childOptionSetting.Id, out var childValueOverride))
                     {
-                        optionSettingHandler.SetOptionSettingValue(childOptionSetting, childValueOverride);
+                        optionSettingHandler.SetOptionSettingValue(recommendation, childOptionSetting, childValueOverride);
                     }
                 }
             }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -40,8 +40,9 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         /// <param name="optionSettingHandler">Handler use to set any child option settings</param>
         /// <param name="value">Value to set</param>
-        /// /// <param name="validators">Validators for this item</param>
-        void SetValue(IOptionSettingHandler optionSettingHandler, object value, IOptionSettingItemValidator[] validators);
+        /// <param name="validators">Validators for this item</param>
+        /// <param name="recommendation">Selected recommendation</param>
+        void SetValue(IOptionSettingHandler optionSettingHandler, object value, IOptionSettingItemValidator[] validators, Recommendation recommendation);
     }
 
     /// <summary>

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -16,6 +16,18 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="RequiredValidator"/>
         /// </summary>
-        Required
+        Required,
+        /// <summary>
+        /// Must be paired with <see cref="DirectoryExistsValidator"/>
+        /// </summary>
+        DirectoryExists,
+        /// <summary>
+        /// Must be paired with <see cref="DockerBuildArgsValidator"/>
+        /// </summary>
+        DockerBuildArgs,
+        /// <summary>
+        /// Must be paried with <see cref="DotnetPublishArgsValidator"/>
+        /// </summary>
+        DotnetPublishArgs
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validator that validates if a given directory exists
+    /// </summary>
+    public class DirectoryExistsValidator : IOptionSettingItemValidator
+    {
+        private readonly IDirectoryManager _directoryManager;
+
+        public DirectoryExistsValidator(IDirectoryManager directoryManager)
+        {
+            _directoryManager = directoryManager;
+        }
+
+        /// <summary>
+        /// Validates that the given directory exists.
+        /// This can be either an absolute path, or a path relative to the project directory.
+        /// </summary>
+        /// <param name="input">Path to validate</param>
+        /// <returns>Valid if the directory exists, invalid otherwise</returns>
+        public ValidationResult Validate(object input)
+        {
+            var executionDirectory = (string)input;
+
+            if (!string.IsNullOrEmpty(executionDirectory) && !_directoryManager.Exists(executionDirectory))
+                return ValidationResult.Failed("The specified directory does not exist.");
+            else
+                return ValidationResult.Valid();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validator for Docker build-time variables, passed via --build-arg
+    /// </summary>
+    public class DockerBuildArgsValidator : IOptionSettingItemValidator
+    {
+        /// <summary>
+        /// Validates that additional Docker build options don't collide
+        /// with those set by the deploy tool
+        /// </summary>
+        /// <param name="input">Proposed Docker build args</param>
+        /// <returns>Valid if the options do not contain those set by the deploy tool, invalid otherwise</returns>
+        public ValidationResult Validate(object input)
+        {
+            var buildArgs = Convert.ToString(input);
+            var errorMessage = string.Empty;
+
+            if (string.IsNullOrEmpty(buildArgs))
+            {
+                return ValidationResult.Valid();
+            }
+
+            if (buildArgs.Contains("-t ") || buildArgs.Contains("--tag "))
+                errorMessage += "You must not include -t/--tag as an additional argument as it is used internally. " +
+                    "You may set the Image Tag property in the advanced settings for some recipes." + Environment.NewLine;
+
+            if (buildArgs.Contains("-f ") || buildArgs.Contains("--file "))
+                errorMessage += "You must not include -f/--file as an additional argument as it is used internally." + Environment.NewLine;
+
+            if (!string.IsNullOrEmpty(errorMessage))
+                return ValidationResult.Failed("Invalid value for additional Docker build options." + Environment.NewLine + errorMessage.Trim());
+
+            return ValidationResult.Valid();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validator for additional arguments to 'dotnet publish'
+    /// </summary>
+    public class DotnetPublishArgsValidator : IOptionSettingItemValidator
+    {
+        /// <summary>
+        /// Validates that additional 'dotnet publish' arguments do not collide with those used by the deploy tool
+        /// </summary>
+        /// <param name="input">Additional publish arguments</param>
+        /// <returns>Valid if the arguments don't interfere with the deploy tool, invalid otherwise</returns>
+        public ValidationResult Validate(object input)
+        {
+            var publishArgs = Convert.ToString(input);
+            var errorMessage = string.Empty;
+
+            if (string.IsNullOrEmpty(publishArgs))
+            {
+                return ValidationResult.Valid();
+            }
+
+            if (publishArgs.Contains("-o ") || publishArgs.Contains("--output "))
+                errorMessage += "You must not include -o/--output as an additional argument as it is used internally." + Environment.NewLine;
+
+            if (publishArgs.Contains("-c ") || publishArgs.Contains("--configuration "))
+                errorMessage += "You must not include -c/--configuration as an additional argument. You can set the build configuration in the advanced settings." + Environment.NewLine;
+
+            if (publishArgs.Contains("--self-contained") || publishArgs.Contains("--no-self-contained"))
+                errorMessage += "You must not include --self-contained/--no-self-contained as an additional argument. You can set the self-contained property in the advanced settings." + Environment.NewLine;
+
+            if (!string.IsNullOrEmpty(errorMessage))
+                return ValidationResult.Failed("Invalid value for Dotnet Publish Arguments." + Environment.NewLine + errorMessage.Trim());
+
+            return ValidationResult.Valid();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -47,7 +47,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         {
             { OptionSettingItemValidatorList.Range, typeof(RangeValidator) },
             { OptionSettingItemValidatorList.Regex, typeof(RegexValidator) },
-            { OptionSettingItemValidatorList.Required, typeof(RequiredValidator) }
+            { OptionSettingItemValidatorList.Required, typeof(RequiredValidator) },
+            { OptionSettingItemValidatorList.DirectoryExists, typeof(DirectoryExistsValidator) },
+            { OptionSettingItemValidatorList.DockerBuildArgs, typeof(DockerBuildArgsValidator) },
+            { OptionSettingItemValidatorList.DotnetPublishArgs, typeof(DotnetPublishArgsValidator) },
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -178,21 +178,16 @@ namespace AWS.Deploy.Orchestration
 
         private string GetDockerBuildArgs(Recommendation recommendation)
         {
-            var buildArgs = string.Empty;
-            var argsDictionary = recommendation.DeploymentBundle.DockerBuildArgs
-                .Split(',')
-                .Where(x => x.Contains("="))
-                .ToDictionary(
-                    k => k.Split('=')[0],
-                    v => v.Split('=')[1]
-                );
+            var buildArgs = recommendation.DeploymentBundle.DockerBuildArgs;
 
-            foreach (var arg in argsDictionary.Keys)
-            {
-                buildArgs += $" --build-arg {arg}={argsDictionary[arg]}";
-            }
+            if (string.IsNullOrEmpty(buildArgs))
+                return buildArgs;
 
-            return buildArgs;
+            // Ensure it starts with a space so it doesn't collide with the previous option
+            if (!char.IsWhiteSpace(buildArgs[0]))
+                return $" {buildArgs}";
+            else
+                return buildArgs;
         }
 
         private async Task InitiateDockerLogin()

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AWS.Deploy.Common;
@@ -26,9 +27,47 @@ namespace AWS.Deploy.Orchestration
         /// Thrown if one or more <see cref="Validators"/> determine
         /// <paramref name="value"/> is not valid.
         /// </exception>
-        public void SetOptionSettingValue(OptionSettingItem optionSettingItem, object value)
+        public void SetOptionSettingValue(Recommendation recommendation, OptionSettingItem optionSettingItem, object value)
         {
-            optionSettingItem.SetValue(this, value, _validatorFactory.BuildValidators(optionSettingItem));
+            optionSettingItem.SetValue(this, value, _validatorFactory.BuildValidators(optionSettingItem), recommendation);
+
+            // If the optionSettingItem came from the selected recommendation's deployment bundle,
+            // set the corresponding property on recommendation.DeploymentBundle
+            SetDeploymentBundleProperty(recommendation, optionSettingItem, value);
+        }
+
+        /// <summary>
+        /// Sets the corresponding value in <see cref="DeploymentBundle"/> when the
+        /// corresponding <see cref="OptionSettingItem"> was just set
+        /// </summary>
+        /// <param name="recommendation">Selected recommendation</param>
+        /// <param name="optionSettingItem">Option setting that was just set</param>
+        /// <param name="value">Value that was just set, assumed to be valid</param>
+        private void SetDeploymentBundleProperty(Recommendation recommendation, OptionSettingItem optionSettingItem, object value)
+        {
+            switch (optionSettingItem.Id)
+            {
+                case "DockerExecutionDirectory":
+                    recommendation.DeploymentBundle.DockerExecutionDirectory = value.ToString() ?? string.Empty;
+                    break;
+                case "DockerBuildArgs":
+                    recommendation.DeploymentBundle.DockerBuildArgs = value.ToString() ?? string.Empty;
+                    break;
+                case "ECRRepositoryName":
+                    recommendation.DeploymentBundle.ECRRepositoryName = value.ToString() ?? string.Empty;
+                    break;
+                case "DotnetBuildConfiguration":
+                    recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = value.ToString() ?? string.Empty;
+                    break;
+                case "DotnetPublishArgs":
+                    recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments = value.ToString() ?? string.Empty;
+                    break;
+                case "SelfContainedBuild":
+                    recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = Convert.ToBoolean(value);
+                    break;
+                default:
+                    return;
+            }
         }
 
         /// <summary>

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -157,7 +157,7 @@ namespace AWS.Deploy.Orchestration
             {
                 if (previousSettings.TryGetValue(optionSetting.Id, out var value))
                 {
-                    _optionSettingHandler.SetOptionSettingValue(optionSetting, value);
+                    _optionSettingHandler.SetOptionSettingValue(recommendationCopy, optionSetting, value);
                 }
             }
 
@@ -255,6 +255,8 @@ namespace AWS.Deploy.Orchestration
 
             _dockerEngine.DetermineDockerExecutionDirectory(recommendation);
 
+            // Read this from the OptionSetting instead of recommendation.DeploymentBundle.
+            // When its value comes from a replacement token, it wouldn't have been set back to the DeploymentBundle 
             var respositoryName = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, "ECRRepositoryName"));
 
             string imageTag;

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -9,7 +9,12 @@
             "TypeHint": "DockerBuildArgs",
             "DefaultValue": "",
             "AdvancedSetting": true,
-            "Updatable": true
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "DockerBuildArgs"
+                }
+            ]
         },
         {
             "Id": "DockerExecutionDirectory",
@@ -19,7 +24,12 @@
             "TypeHint": "DockerExecutionDirectory",
             "DefaultValue": "",
             "AdvancedSetting": true,
-            "Updatable": true
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "DirectoryExists"
+                }
+            ]
         },
         {
             "Id": "ECRRepositoryName",

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -4,7 +4,7 @@
         {
             "Id": "DockerBuildArgs",
             "Name": "Docker Build Args",
-            "Description": "The list of additional docker build args.",
+            "Description": "The list of additional options to append to the `docker build` command.",
             "Type": "String",
             "TypeHint": "DockerBuildArgs",
             "DefaultValue": "",

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/DotnetPublishZipFile.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/DotnetPublishZipFile.deploymentbundle
@@ -19,7 +19,12 @@
             "TypeHint": "DotnetPublishAdditionalBuildArguments",
             "DefaultValue": "",
             "AdvancedSetting": true,
-            "Updatable": true
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "DotnetPublishArgs"
+                }
+            ]
         },
         {
             "Id": "SelfContainedBuild",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -602,7 +602,10 @@
                                 "enum": [
                                     "Range",
                                     "Regex",
-                                    "Required"
+                                    "Required",
+                                    "DirectoryExists",
+                                    "DockerBuildArgs",
+                                    "DotnetPublishArgs"
                                 ]
                             }
                         },

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
@@ -37,6 +37,9 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
             return CreatedDirectories.Contains(path);
         }
 
+        public bool Exists(string path, string relativeTo) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
         public string[] GetDirectories(string path, string searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/AppRunnerOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/AppRunnerOptionSettingItemValidationTests.cs
@@ -71,7 +71,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             ValidationFailedException exception = null;
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(optionSettingItem, value);
+                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, value);
             }
             catch (ValidationFailedException e)
             {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
@@ -104,6 +104,26 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             Validate(optionSettingItem, value, isValid);
         }
 
+        [Theory]
+        [InlineData("", true)]
+        [InlineData("--no-restore --nologo --framework net5.0", true)]
+        [InlineData("-o dir", false)]                   // -o or --output is reserved by the deploy tool
+        [InlineData("--output dir", false)]
+        [InlineData("-c Release", false)]               // -c or --configuration is controlled by DotnetPublishBuildConfiguration instead
+        [InlineData("--configuration Release", false)]
+        [InlineData("--self-contained true", false)]    // --self-contained is controlled by SelfContainedBuild instead
+        [InlineData("--no-self-contained", false)]
+        public void DotnetPublishArgsValidationTest(string value, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
+            {
+                ValidatorType = OptionSettingItemValidatorList.DotnetPublishArgs
+            });
+
+            Validate(optionSettingItem, value, isValid);
+        }
+
         private OptionSettingItemValidatorConfig GetRegexValidatorConfig(string regex)
         {
             var regexValidatorConfig = new OptionSettingItemValidatorConfig
@@ -137,7 +157,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
 
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(optionSettingItem, value);
+                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, value);
             }
             catch (ValidationFailedException e)
             {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
@@ -64,7 +64,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             // ACT
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(optionSettingItem, invalidValue);
+                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, invalidValue);
             }
             catch (ValidationFailedException e)
             {
@@ -100,7 +100,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             // ACT
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(optionSettingItem, invalidValue);
+                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, invalidValue);
             }
             catch (ValidationFailedException e)
             {
@@ -142,7 +142,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             // ACT
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(optionSettingItem, validValue);
+                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, validValue);
             }
             catch (ValidationFailedException e)
             {
@@ -186,7 +186,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             // ACT
             try
             {
-                _optionSettingHandler.SetOptionSettingValue(optionSettingItem, invalidValue);
+                _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, invalidValue);
             }
             catch (ValidationFailedException e)
             {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
@@ -34,6 +34,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
 
             var mockServiceProvider = new Mock<IServiceProvider>();
             mockServiceProvider.Setup(x => x.GetService(typeof(IOptionSettingHandler))).Returns(_optionSettingHandler);
+            mockServiceProvider.Setup(x => x.GetService(typeof(IDirectoryManager))).Returns(new TestDirectoryManager());
             _serviceProvider = mockServiceProvider.Object;
             _validatorFactory = new ValidatorFactory(_serviceProvider);
         }

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
@@ -89,7 +89,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
             var managedActionsEnabled = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, $"{optionSetting}.{childSetting}");
-            _optionSettingHandler.SetOptionSettingValue(managedActionsEnabled, childValue);
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, managedActionsEnabled, childValue);
 
             var elasticBeanstalkManagedPlatformUpdates = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, optionSetting);
             var elasticBeanstalkManagedPlatformUpdatesValue = _optionSettingHandler.GetOptionSettingValue<Dictionary<string, object>>(beanstalkRecommendation, elasticBeanstalkManagedPlatformUpdates);
@@ -109,8 +109,8 @@ namespace AWS.Deploy.CLI.UnitTests
             var subnets = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.Subnets");
             var securityGroups = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.SecurityGroups");
 
-            Assert.Throws<ValidationFailedException>(() => _optionSettingHandler.SetOptionSettingValue(subnets, new SortedSet<string>(){ "subnet1" }));
-            Assert.Throws<ValidationFailedException>(() => _optionSettingHandler.SetOptionSettingValue(securityGroups, new SortedSet<string>(){ "securityGroup1" }));
+            Assert.Throws<ValidationFailedException>(() => _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, subnets, new SortedSet<string>(){ "subnet1" }));
+            Assert.Throws<ValidationFailedException>(() => _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, securityGroups, new SortedSet<string>(){ "securityGroup1" }));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var subnets = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.Subnets");
             var emptySubnetsValue = _optionSettingHandler.GetOptionSettingValue(appRunnerRecommendation, subnets);
 
-            _optionSettingHandler.SetOptionSettingValue(subnets, new SortedSet<string>(){ "subnet-1234abcd" });
+            _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, subnets, new SortedSet<string>(){ "subnet-1234abcd" });
             var subnetsValue = _optionSettingHandler.GetOptionSettingValue(appRunnerRecommendation, subnets);
 
             var emptySubnetsString = Assert.IsType<string>(emptySubnetsValue);

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -185,11 +185,11 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var originalDefaultValue = _optionSettingHandler.GetOptionSettingDefaultValue<int>(fargateRecommendation, desiredCountOptionSetting);
 
-            _optionSettingHandler.SetOptionSettingValue(desiredCountOptionSetting, 2);
+            _optionSettingHandler.SetOptionSettingValue(fargateRecommendation, desiredCountOptionSetting, 2);
 
             Assert.Equal(2, _optionSettingHandler.GetOptionSettingValue<int>(fargateRecommendation, desiredCountOptionSetting));
 
-            _optionSettingHandler.SetOptionSettingValue(desiredCountOptionSetting, consoleUtilities.AskUserForValue("Title", "2", true, originalDefaultValue.ToString()));
+            _optionSettingHandler.SetOptionSettingValue(fargateRecommendation, desiredCountOptionSetting, consoleUtilities.AskUserForValue("Title", "2", true, originalDefaultValue.ToString()));
 
             Assert.Equal(originalDefaultValue, _optionSettingHandler.GetOptionSettingValue<int>(fargateRecommendation, desiredCountOptionSetting));
         }
@@ -214,11 +214,11 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var originalDefaultValue = _optionSettingHandler.GetOptionSettingDefaultValue<string>(fargateRecommendation, ecsServiceNameOptionSetting);
 
-            _optionSettingHandler.SetOptionSettingValue(ecsServiceNameOptionSetting, "TestService");
+            _optionSettingHandler.SetOptionSettingValue(fargateRecommendation, ecsServiceNameOptionSetting, "TestService");
 
             Assert.Equal("TestService", _optionSettingHandler.GetOptionSettingValue<string>(fargateRecommendation, ecsServiceNameOptionSetting));
 
-            _optionSettingHandler.SetOptionSettingValue(ecsServiceNameOptionSetting, consoleUtilities.AskUserForValue("Title", "TestService", true, originalDefaultValue));
+            _optionSettingHandler.SetOptionSettingValue(fargateRecommendation, ecsServiceNameOptionSetting, consoleUtilities.AskUserForValue("Title", "TestService", true, originalDefaultValue));
 
             Assert.Equal(originalDefaultValue, _optionSettingHandler.GetOptionSettingValue<string>(fargateRecommendation, ecsServiceNameOptionSetting));
         }
@@ -262,7 +262,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
             var environmentTypeOptionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("EnvironmentType"));
 
-            _optionSettingHandler.SetOptionSettingValue(environmentTypeOptionSetting, "LoadBalanced");
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, environmentTypeOptionSetting, "LoadBalanced");
             Assert.Equal("LoadBalanced", _optionSettingHandler.GetOptionSettingValue(beanstalkRecommendation, environmentTypeOptionSetting));
         }
 
@@ -276,7 +276,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
             var applicationIAMRoleOptionSetting = beanstalkRecommendation.Recipe.OptionSettings.First(optionSetting => optionSetting.Id.Equals("ApplicationIAMRole"));
 
-            _optionSettingHandler.SetOptionSettingValue(applicationIAMRoleOptionSetting, new IAMRoleTypeHintResponse {CreateNew = false,
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, applicationIAMRoleOptionSetting, new IAMRoleTypeHintResponse {CreateNew = false,
                 RoleArn = "arn:aws:iam::123456789012:group/Developers" });
 
             var iamRoleTypeHintResponse = _optionSettingHandler.GetOptionSettingValue<IAMRoleTypeHintResponse>(beanstalkRecommendation, applicationIAMRoleOptionSetting);
@@ -391,7 +391,7 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, loadBalancerTypeOptionSetting));
 
             // Satisfy dependency
-            _optionSettingHandler.SetOptionSettingValue(environmentTypeOptionSetting, "LoadBalanced");
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, environmentTypeOptionSetting, "LoadBalanced");
             Assert.Equal("LoadBalanced", _optionSettingHandler.GetOptionSettingValue(beanstalkRecommendation, environmentTypeOptionSetting));
 
             // Verify
@@ -414,11 +414,11 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(fargateRecommendation, vpcIdOptionSetting));
 
             // Satisfy dependencies
-            _optionSettingHandler.SetOptionSettingValue(isDefaultOptionSetting, false);
+            _optionSettingHandler.SetOptionSettingValue(fargateRecommendation, isDefaultOptionSetting, false);
             Assert.False(_optionSettingHandler.GetOptionSettingValue<bool>(fargateRecommendation, isDefaultOptionSetting));
 
             // Default value for Vpc.CreateNew already false, this is to show explicitly setting an override that satisfies Vpc Id option setting
-            _optionSettingHandler.SetOptionSettingValue(createNewOptionSetting, false);
+            _optionSettingHandler.SetOptionSettingValue(fargateRecommendation, createNewOptionSetting, false);
             Assert.False(_optionSettingHandler.GetOptionSettingValue<bool>(fargateRecommendation, createNewOptionSetting));
 
             // Verify
@@ -441,7 +441,7 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, subnetsSetting));
 
             // Satisfy dependencies
-            _optionSettingHandler.SetOptionSettingValue(vpcIdOptionSetting, "vpc-1234abcd");
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, vpcIdOptionSetting, "vpc-1234abcd");
             Assert.True(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, subnetsSetting));
         }
 
@@ -463,11 +463,11 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, securityGroupsSetting));
 
             // Satisfy 1 dependency
-            _optionSettingHandler.SetOptionSettingValue(vpcIdOptionSetting, "vpc-1234abcd");
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, vpcIdOptionSetting, "vpc-1234abcd");
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, securityGroupsSetting));
 
             // Satisfy 2 dependencies
-            _optionSettingHandler.SetOptionSettingValue(subnetsSetting, new SortedSet<string> { "subnet-1234abcd" });
+            _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, subnetsSetting, new SortedSet<string> { "subnet-1234abcd" });
             Assert.True(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, securityGroupsSetting));
         }
 

--- a/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
@@ -90,10 +90,10 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 new Mock<IFileManager>().Object,
                 _optionSettingHandler);
 
-            _optionSettingHandler.SetOptionSettingValue(_optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.EnhancedHealthReportingOptionId), "basic");
-            _optionSettingHandler.SetOptionSettingValue(_optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.HealthCheckURLOptionId), "/url");
-            _optionSettingHandler.SetOptionSettingValue(_optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.ProxyOptionId), "none");
-            _optionSettingHandler.SetOptionSettingValue(_optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.XRayTracingOptionId), "true");
+            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.EnhancedHealthReportingOptionId), "basic");
+            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.HealthCheckURLOptionId), "/url");
+            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.ProxyOptionId), "none");
+            _optionSettingHandler.SetOptionSettingValue(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.ElasticBeanstalk.XRayTracingOptionId), "true");
 
             // ACT
             var optionSettings = elasticBeanstalkHandler.GetEnvironmentConfigurationSettings(recommendation);

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestDirectoryManager.cs
@@ -38,6 +38,9 @@ namespace AWS.Deploy.Orchestration.UnitTests
             return CreatedDirectories.Contains(path);
         }
 
+        public bool Exists(string path, string relativeTo) =>
+            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+
         public string[] GetDirectories(string path, string searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-5922

*Description of changes:* 

**Problem**:
Option settings that are defined in the `.deploymentbundle` files (as opposed to the `.recipe` files) have been backed by `DeploymentBundle` class in addition to the `OptionSettingItem` collection.

The CLI mode writes directly to `DeploymentBundle` via the TypeHints, but server mode (and thus the Visual Studio Toolkit) was only setting the values in the `OptionSettingItem` objects.

The orchestrator was largely reading these options from `DeploymentBundle`, effectively ignoring them during server mode.

**Now**:
1. We "write-through" the `OptionSettingItem` to the `DeploymentBundle` for these options.
     * We were previously doing this during `ConfigureDeploymentFromConfigFile`, but now we do it for every `SetValue`
1. Moved validation for these settings to three new `IOptionSettingItemValidator` instances out of the TypeHint, since those don't run during server mode.
     * Validating `DockerExecutionDirectory` requires access to the recommendation object, so that we can validate a relative path from the project directory. This is extracting some in-progress work from https://github.com/aws/aws-dotnet-deploy/pull/509

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
