### PR TITLE
chore: create an option setting dependency tree

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
+++ b/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
@@ -32,6 +32,11 @@ namespace AWS.Deploy.Common.Recipes
         OptionSettingItem GetOptionSetting(Recommendation recommendation, string? jsonPath);
 
         /// <summary>
+        /// This method retrieves the <see cref="OptionSettingItem"/> related to a specific <see cref="Recipe"/>.
+        /// </summary>
+        OptionSettingItem GetOptionSetting(RecipeDefinition recipe, string? jsonPath);
+
+        /// <summary>
         /// Retrieve the <see cref="OptionSettingItem"/> value for a specific <see cref="Recommendation"/>
         /// This method retrieves the value in a specified type.
         /// </summary>

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -58,6 +58,17 @@ namespace AWS.Deploy.Common.Recipes
         public string Id { get; set; }
 
         /// <summary>
+        /// The fully qualified id of the setting that includes the Id and all of the parent's Ids.
+        /// This helps easily reference the Option Setting without context of the parent setting.
+        /// </summary>
+        public string FullyQualifiedId { get; set; }
+
+        /// <summary>
+        /// The parent Option Setting Item that allows an option setting item to reference it's parent.
+        /// </summary>
+        public string? ParentId { get; set; }
+
+        /// <summary>
         /// The id of the parent option setting. This is used for tooling that wants to look up the existing resources for a setting based on the TypeHint but needs
         /// to know the parent AWS resource. For example if listing the available Beanstalk environments the listing should be for the environments of the Beanstalk application.
         /// </summary>
@@ -145,9 +156,15 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         public Dictionary<string, object> TypeHintData { get; set; } = new ();
 
-        public OptionSettingItem(string id, string name, string description)
+        /// <summary>
+        /// Indicates which option setting items need to be validated if a value update occurs.
+        /// </summary>
+        public List<string> Dependents { get; set; } = new List<string> ();
+
+        public OptionSettingItem(string id, string fullyQualifiedId, string name, string description)
         {
             Id = id;
+            FullyQualifiedId = fullyQualifiedId;
             Name = name;
             Description = description;
         }

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -140,6 +140,44 @@ namespace AWS.Deploy.Orchestration
         }
 
         /// <summary>
+        /// Interactively traverses given json path and returns target option setting.
+        /// Throws exception if there is no <see cref="OptionSettingItem" /> that matches <paramref name="jsonPath"/> />
+        /// In case an option setting of type <see cref="OptionSettingValueType.KeyValue"/> is encountered,
+        /// that <paramref name="jsonPath"/> can have the key value pair name as the leaf node with the option setting Id as the node before that.
+        /// </summary>
+        /// <param name="jsonPath">
+        /// Dot (.) separated key values string pointing to an option setting.
+        /// Read more <see href="https://tools.ietf.org/id/draft-goessner-dispatch-jsonpath-00.html"/>
+        /// </param>
+        /// <returns>Option setting at the json path. Throws <see cref="OptionSettingItemDoesNotExistException"/> if there doesn't exist an option setting.</returns>
+        public OptionSettingItem GetOptionSetting(RecipeDefinition recipe, string? jsonPath)
+        {
+            if (string.IsNullOrEmpty(jsonPath))
+                throw new OptionSettingItemDoesNotExistException(DeployToolErrorCode.OptionSettingItemDoesNotExistInRecipe, $"An option setting item with the specified fully qualified Id '{jsonPath}' cannot be found in the" +
+                    $" '{recipe.Name}' recipe.");
+
+            var ids = jsonPath.Split('.');
+            OptionSettingItem? optionSetting = null;
+
+            for (int i = 0; i < ids.Length; i++)
+            {
+                var optionSettings = optionSetting?.ChildOptionSettings ?? recipe.OptionSettings;
+                optionSetting = optionSettings.FirstOrDefault(os => os.Id.Equals(ids[i]));
+                if (optionSetting == null)
+                {
+                    throw new OptionSettingItemDoesNotExistException(DeployToolErrorCode.OptionSettingItemDoesNotExistInRecipe, $"An option setting item with the specified fully qualified Id '{jsonPath}' cannot be found in the" +
+                    $" '{recipe.Name}' recipe.");
+                }
+                if (optionSetting.Type.Equals(OptionSettingValueType.KeyValue))
+                {
+                    return optionSetting;
+                }
+            }
+
+            return optionSetting!;
+        }
+
+        /// <summary>
         /// Retrieves the value of the Option Setting Item in a given recommendation.
         /// </summary>
         public T GetOptionSettingValue<T>(Recommendation recommendation, OptionSettingItem optionSetting)

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -448,6 +448,7 @@
             "properties": {
                 "Id": {
                     "type": "string",
+                    "pattern": "^[a-zA-Z0-9_-]+$",
                     "title": "Unique ID for the setting",
                     "description": "The unqiue id for the setting. This value should never been change once the recipe is released because it will be stored in user config files.",
                     "minLength": 1

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestDirectoryManager.cs
@@ -12,6 +12,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
     public class TestDirectoryManager : IDirectoryManager
     {
         public readonly HashSet<string> CreatedDirectories = new();
+        public readonly Dictionary<string, HashSet<string>> AddedFiles = new();
 
         public DirectoryInfo CreateDirectory(string path)
         {
@@ -45,7 +46,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
             CreatedDirectories.ToArray();
 
         public string[] GetFiles(string path, string searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
-            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+            AddedFiles.ContainsKey(path) ? AddedFiles[path].ToArray() : new string[0];
 
         public bool IsEmpty(string path) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/AppRunnerOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/AppRunnerOptionSettingItemValidationTests.cs
@@ -40,7 +40,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("-abc123def45", false)] // does not start with a letter or a number
         public async Task AppRunnerServiceNameValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             // 4 to 40 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^([A-Za-z0-9][A-Za-z0-9_-]{3,39})$"));
             await Validate(optionSettingItem, value, isValid);
@@ -55,7 +55,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:iam::123456789012:role", false)] // missing resorce path
         public async Task RoleArnValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):iam::[0-9]{12}:(role|role/service-role)/[\\w+=,.@\\-/]{1,1000}"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -69,7 +69,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab", false)] // invalid key-id structure
         public async Task KmsKeyArnValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:aws(-[\\w]+)*:kms:[a-z\\-]+-[0-9]{1}:[0-9]{12}:key/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
             await Validate(optionSettingItem, value, isValid);
         }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -48,7 +48,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:ecs:us-east-1:012345678910:fluster/test", false)] //fluster instead of cluster
         public async Task ClusterArnValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:ecs:[^:]*:[0-9]{12}:cluster/.+"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -61,7 +61,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("123*&$abc", false)] //invalid characters
         public async Task NewClusterNameValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             //up to 255 letters(uppercase and lowercase), numbers, underscores, and hyphens are allowed.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^([A-Za-z0-9-]{1,255})$"));
             await Validate(optionSettingItem, value, isValid);
@@ -75,7 +75,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("123*&$_abc_", false)] //invalid characters
         public async Task ECSServiceNameValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             // Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^([A-Za-z0-9_-]{1,255})$"));
             await Validate(optionSettingItem, value, isValid);
@@ -89,7 +89,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData(1000, true)]
         public async Task DesiredCountValidationTests(int value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRangeValidatorConfig(1, 5000));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -103,7 +103,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:iam::1234567890124354:role/S3Access", false)] //invalid account ID
         public async Task RoleArnValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:.+:iam::[0-9]{12}:.+"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -118,7 +118,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("vpc-ffffffffaaaabbbb12", false)] //suffix length greater than 17
         public async Task VpcIdValidationTests(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             //must start with the \"vpc-\" prefix,
             //followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^vpc-([0-9a-f]{8}|[0-9a-f]{17})$"));
@@ -133,7 +133,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:elasticloadbalancing:01234567891:elasticloadbalancing:loadbalancer", false)] //11 digit account ID
         public async Task LoadBalancerArnValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:elasticloadbalancing:[^:]*:[0-9]{12}:loadbalancer/.+"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -146,7 +146,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("/Api/Path/<dsd<>", false)] // contains invalid character '<' and '>'
         public async Task ListenerConditionPathPatternValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^/[a-zA-Z0-9*?&_\\-.$/~\"'@:+]{0,127}$"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -159,7 +159,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("myrepo123.a//b", false)] // cannot contain consecutive slashes.
         public async Task ECRRepositoryNameValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -168,7 +168,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public async Task ECSClusterNameValidationTest_Valid()
         {
             _awsResourceQueryer.Setup(x => x.GetCloudControlApiResource(It.IsAny<string>(), It.IsAny<string>())).Throws(new ResourceQueryException(DeployToolErrorCode.ResourceQuery, "", new ResourceNotFoundException("")));
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ECS::Cluster"));
             await Validate(optionSettingItem, "WebApp1", true);
         }
@@ -178,7 +178,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         {
             var resource = new ResourceDescription { Identifier = "WebApp1" };
             _awsResourceQueryer.Setup(x => x.GetCloudControlApiResource(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(resource);
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ECS::Cluster"));
             await Validate(optionSettingItem, "WebApp1", false);
         }
@@ -192,7 +192,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("--file file", false)]
         public async Task DockerBuildArgsValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
             {
                 ValidatorType = OptionSettingItemValidatorList.DockerBuildArgs
@@ -204,7 +204,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [Fact]
         public async Task DockerExecutionDirectory_AbsoluteExists()
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
             {
                 ValidatorType = OptionSettingItemValidatorList.DirectoryExists,
@@ -218,7 +218,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [Fact]
         public async Task DockerExecutionDirectory_AbsoluteDoesNotExist()
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
             {
                 ValidatorType = OptionSettingItemValidatorList.DirectoryExists,

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
@@ -38,7 +38,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("abc/123/#", false)] // invalid character forward slash(/)
         public async Task ApplicationNameValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             //can contain up to 100 Unicode characters, not including forward slash (/).
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^[^/]{1,100}$"));
             await Validate(optionSettingItem, value, isValid);
@@ -51,7 +51,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("-12-abc", false)] // invalid character leading hyphen (-)
         public async Task EnvironmentNameValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             // Must be from 4 to 40 characters in length. The name can contain only letters, numbers, and hyphens.
             // It can't start or end with a hyphen.
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^[a-zA-Z0-9][a-zA-Z0-9-]{2,38}[a-zA-Z0-9]$"));
@@ -67,7 +67,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:iam::1234567890124354:role/S3Access", false)] //invalid account ID
         public async Task IAMRoleArnValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:.+:iam::[0-9]{12}:.+"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -79,7 +79,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData(" 123 abc-456 ", false)] //leading and trailing space
         public async Task EC2KeyPairValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             // It allows all ASCII characters but without leading and trailing spaces
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^(?! ).+(?<! )$"));
             await Validate(optionSettingItem, value, isValid);
@@ -94,7 +94,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("arn:aws:elasticbeanstack:eu-west-1:123456789012:platform/MyPlatform", false)] //Typo elasticbeanstack instead of elasticbeanstalk
         public async Task ElasticBeanstalkPlatformArnValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("arn:[^:]+:elasticbeanstalk:[^:]+:[^:]*:platform/.+"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -108,7 +108,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("PTB1H20M30S", false)]
         public async Task ElasticBeanstalkRollingUpdatesPauseTime(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^P([0-9]+(?:[,\\.][0-9]+)?Y)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?D)?(?:T([0-9]+(?:[,\\.][0-9]+)?H)?([0-9]+(?:[,\\.][0-9]+)?M)?([0-9]+(?:[,\\.][0-9]+)?S)?)?$"));
             await Validate(optionSettingItem, value, isValid);
         }
@@ -117,7 +117,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public async Task ExistingApplicationNameValidationTest_Valid()
         {
             _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkApplications(It.IsAny<string>())).ReturnsAsync(new List<ApplicationDescription> { });
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ElasticBeanstalk::Application"));
             await Validate(optionSettingItem, "WebApp1", true);
         }
@@ -126,7 +126,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public async Task ExistingApplicationNameValidationTest_Invalid()
         {
             _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkApplications(It.IsAny<string>())).ReturnsAsync(new List<ApplicationDescription> { new ApplicationDescription { ApplicationName = "WebApp1" } });
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ElasticBeanstalk::Application"));
             await Validate(optionSettingItem, "WebApp1", false);
         }
@@ -135,7 +135,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public async Task ExistingEnvironmentNameValidationTest_Valid()
         {
             _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new List<EnvironmentDescription> { });
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ElasticBeanstalk::Environment"));
             await Validate(optionSettingItem, "WebApp1", true);
         }
@@ -144,7 +144,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public async Task ExistingEnvironmentNameValidationTest_Invalid()
         {
             _awsResourceQueryer.Setup(x => x.ListOfElasticBeanstalkEnvironments(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new List<EnvironmentDescription> { new EnvironmentDescription { EnvironmentName = "WebApp1" } });
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetExistingResourceValidatorConfig("AWS::ElasticBeanstalk::Environment"));
             await Validate(optionSettingItem, "WebApp1", false);
         }
@@ -173,7 +173,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("--no-self-contained", false)]
         public async Task DotnetPublishArgsValidationTest(string value, bool isValid)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description");
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(new OptionSettingItemValidatorConfig
             {
                 ValidatorType = OptionSettingItemValidatorList.DotnetPublishArgs

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/OptionSettingsItemValidationTests.cs
@@ -46,7 +46,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("100")]
         public async Task InvalidInputInMultipleValidatorsThrowsException(string invalidValue)
         {
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Validators = new()
                 {
@@ -87,7 +87,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public async Task InvalidInputInSingleValidatorThrowsException()
         {
             var invalidValue = "lowercase_only";
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Validators = new()
                 {
@@ -124,7 +124,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         {
             var validValue = 8;
 
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Validators = new()
                 {
@@ -171,7 +171,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             var customValidationMessage = "Custom Validation Message: Testing!";
             var invalidValue = 100;
 
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Validators = new()
                 {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ValidatorFactoryTests.cs
@@ -54,7 +54,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             // ARRANGE
             var allValidators = Enum.GetValues(typeof(OptionSettingItemValidatorList));
 
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Validators =
                     allValidators
@@ -115,7 +115,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 ValidationFailedMessage = "Custom Test Message"
             };
 
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Name = "Test Item",
                 Validators = new List<OptionSettingItemValidatorConfig>
@@ -155,7 +155,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         public void WhenValidatorTypeAndConfigurationHaveAMismatchThenValidatorTypeWins()
         {
             // ARRANGE
-            var optionSettingItem = new OptionSettingItem("id", "name", "description")
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description")
             {
                 Name = "Test Item",
                 Validators = new List<OptionSettingItemValidatorConfig>

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/CustomRecipeLocatorTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/CustomRecipeLocatorTests.cs
@@ -13,6 +13,8 @@ using Should;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.IntegrationTests.Services;
 using AWS.Deploy.Common.Recipes;
+using Moq;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
 {
@@ -81,7 +83,10 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var directoryManager = new DirectoryManager();
             var fileManager = new FileManager();
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
-            return new RecipeHandler(deploymentManifestEngine, _inMemoryInteractiveService, directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            return new RecipeHandler(deploymentManifestEngine, _inMemoryInteractiveService, directoryManager, fileManager, optionSettingHandler);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -234,10 +234,12 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var fileManager = new FileManager();
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var localUserSettingsEngine = new LocalUserSettingsEngine(fileManager, directoryManager);
-            var recipeHandler = new RecipeHandler(deploymentManifestEngine, _inMemoryInteractiveService, directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            var recipeHandler = new RecipeHandler(deploymentManifestEngine, _inMemoryInteractiveService, directoryManager, fileManager, optionSettingHandler);
             var projectDefinition = await new ProjectDefinitionParser(fileManager, directoryManager).Parse(targetApplicationProjectPath);
             var session = new OrchestratorSession(projectDefinition);
-            var serviceProvider = new Mock<IServiceProvider>();
 
             return new Orchestrator(session,
                 _inMemoryInteractiveService,

--- a/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
@@ -50,7 +50,10 @@ namespace AWS.Deploy.CLI.UnitTests
             _fileManager = new FileManager();
             _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
             _orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
-            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager, _fileManager, optionSettingHandler);
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
             _orchestrator = new Orchestrator(null, null, null, null, null, null, null, null, null, null, null, null, null, _optionSettingHandler);
         }

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
@@ -44,7 +44,10 @@ namespace AWS.Deploy.CLI.UnitTests
             _fileManager = new FileManager();
             _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
             _orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
-            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager, _fileManager, optionSettingHandler);
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 

--- a/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
@@ -22,6 +22,8 @@ using System.Collections.Generic;
 using System.IO;
 using AWS.Deploy.Common.Recipes;
 using DeploymentTypes = AWS.Deploy.CLI.ServerMode.Models.DeploymentTypes;
+using System;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -59,7 +61,10 @@ namespace AWS.Deploy.CLI.UnitTests
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var consoleInteractiveServiceImpl = new ConsoleInteractiveServiceImpl();
             var consoleOrchestratorLogger = new ConsoleOrchestratorLogger(consoleInteractiveServiceImpl);
-            var recipeHandler = new RecipeHandler(deploymentManifestEngine, consoleOrchestratorLogger, directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            var recipeHandler = new RecipeHandler(deploymentManifestEngine, consoleOrchestratorLogger, directoryManager, fileManager, optionSettingHandler);
             var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager);
 
             var recipeController = new RecipeController(recipeHandler, projectDefinitionParser);
@@ -76,8 +81,11 @@ namespace AWS.Deploy.CLI.UnitTests
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var consoleInteractiveServiceImpl = new ConsoleInteractiveServiceImpl();
             var consoleOrchestratorLogger = new ConsoleOrchestratorLogger(consoleInteractiveServiceImpl);
-            var recipeHandler = new RecipeHandler(deploymentManifestEngine, consoleOrchestratorLogger, directoryManager);
             var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            var recipeHandler = new RecipeHandler(deploymentManifestEngine, consoleOrchestratorLogger, directoryManager, fileManager, optionSettingHandler);
 
             var recipeController = new RecipeController(recipeHandler, projectDefinitionParser);
             var recipeDefinitions = await recipeHandler.GetRecipeDefinitions(null);
@@ -98,6 +106,10 @@ namespace AWS.Deploy.CLI.UnitTests
             var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager);
 
             var deploymentManifestEngine = new Mock<IDeploymentManifestEngine>();
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+
             var customLocatorCalls = 0;
             var sourceProjectDirectory = SystemIOUtilities.ResolvePath("WebAppWithDockerFile");
             deploymentManifestEngine
@@ -109,7 +121,7 @@ namespace AWS.Deploy.CLI.UnitTests
                 })
                 .ReturnsAsync(new List<string>());
             var orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
-            var recipeHandler = new RecipeHandler(deploymentManifestEngine.Object, orchestratorInteractiveService, directoryManager);
+            var recipeHandler = new RecipeHandler(deploymentManifestEngine.Object, orchestratorInteractiveService, directoryManager, fileManager, optionSettingHandler);
 
 
             var projectDefinition = await projectDefinitionParser.Parse(sourceProjectDirectory);

--- a/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
@@ -41,7 +41,10 @@ namespace AWS.Deploy.CLI.UnitTests
             _fileManager = new FileManager();
             _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
             _orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
-            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager, _fileManager, optionSettingHandler);
 
             var parser = new ProjectDefinitionParser(new FileManager(), _directoryManager);
             var awsCredentials = new Mock<AWSCredentials>();

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -27,7 +29,10 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
 
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
-            var recipeHandler = new RecipeHandler(deploymentManifestEngine, orchestratorInteractiveService, directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            var recipeHandler = new RecipeHandler(deploymentManifestEngine, orchestratorInteractiveService, directoryManager, fileManager, optionSettingHandler);
 
             var parser = new ProjectDefinitionParser(fileManager, directoryManager);
             var awsCredentials = new Mock<AWSCredentials>();

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
@@ -26,6 +26,16 @@
       </None>
     </ItemGroup>
 
-    <Import Project="..\..\src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems" Label="Shared" />
+    <ItemGroup>
+      <None Remove="Recipes\**" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="Recipes\**">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
+  <Import Project="..\..\src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems" Label="Shared" />
 
 </Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Orchestration.UnitTests.Utilities;
@@ -44,7 +46,10 @@ namespace AWS.Deploy.Orchestration.UnitTests
             _fileManager = new FileManager();
             _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
             _orchestratorInteractiveService = new Mock<IOrchestratorInteractiveService>();
-            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService.Object, _directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService.Object, _directoryManager, _fileManager, optionSettingHandler);
             _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
             _cloudApplication = new CloudApplication("StackName", "UniqueId", CloudApplicationResourceType.CloudFormationStack, "RecipeId");
             _displayedResourcesFactory = new DisplayedResourceCommandFactory(_mockAWSResourceQueryer.Object);

--- a/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
@@ -45,7 +45,10 @@ namespace AWS.Deploy.Orchestration.UnitTests
             _fileManager = new FileManager();
             _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
             _orchestratorInteractiveService = new Mock<IOrchestratorInteractiveService>();
-            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService.Object, _directoryManager);
+            var serviceProvider = new Mock<IServiceProvider>();
+            var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+            var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+            _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService.Object, _directoryManager, _fileManager, optionSettingHandler);
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
         }
 

--- a/test/AWS.Deploy.Orchestration.UnitTests/RecipeHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/RecipeHandlerTests.cs
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.DeploymentManifest;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration.UnitTests.Utilities;
+using AWS.Deploy.Recipes;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.Orchestration.UnitTests
+{
+    public class RecipeHandlerTests
+    {
+        private readonly Mock<IDeploymentManifestEngine> _deploymentManifestEngine;
+        private readonly IOrchestratorInteractiveService _orchestratorInteractiveService;
+        private readonly TestDirectoryManager _directoryManager;
+        private readonly TestFileManager _fileManager;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+        private readonly IValidatorFactory _validatorFactory;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IRecipeHandler _recipeHandler;
+
+        public RecipeHandlerTests()
+        {
+            _deploymentManifestEngine = new Mock<IDeploymentManifestEngine>();
+            _orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
+            _directoryManager = new TestDirectoryManager();
+            _fileManager = new TestFileManager();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _validatorFactory = new ValidatorFactory(_serviceProvider.Object);
+            _optionSettingHandler = new OptionSettingHandler(_validatorFactory);
+            _recipeHandler = new RecipeHandler(_deploymentManifestEngine.Object, _orchestratorInteractiveService, _directoryManager, _fileManager, _optionSettingHandler);
+        }
+
+        [Fact]
+        public async Task DependencyTree_HappyPath()
+        {
+            _directoryManager.AddedFiles.Add(RecipeLocator.FindRecipeDefinitionsPath(), new HashSet<string> { "path1" });
+            _fileManager.InMemoryStore.Add("path1", File.ReadAllText("./Recipes/OptionSettingCyclicDependency.recipe"));
+            var recipeDefinitions = await _recipeHandler.GetRecipeDefinitions(null);
+
+            var recipe = Assert.Single(recipeDefinitions);
+            Assert.Equal("AspNetAppEcsFargate", recipe.Id);
+            var ecsCluster = recipe.OptionSettings.First(x => x.Id.Equals("ECSCluster"));
+            Assert.NotNull(ecsCluster);
+            Assert.Empty(ecsCluster.Dependents);
+            var ecsClusterCreateNew = ecsCluster.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+            Assert.NotNull(ecsClusterCreateNew);
+            Assert.Equal(2, ecsClusterCreateNew.Dependents.Count);
+            Assert.NotNull(ecsClusterCreateNew.Dependents.First(x => x.Equals("ECSCluster.ClusterArn")));
+            Assert.NotNull(ecsClusterCreateNew.Dependents.First(x => x.Equals("ECSCluster.NewClusterName")));
+        }
+
+        [Fact]
+        public async Task DependencyTree_CyclicDependency()
+        {
+            _directoryManager.AddedFiles.Add(RecipeLocator.FindRecipeDefinitionsPath(), new HashSet<string> { "path1" });
+            _fileManager.InMemoryStore.Add("path1", File.ReadAllText("./Recipes/OptionSettingCyclicDependency.recipe"));
+            var recipeDefinitions = await _recipeHandler.GetRecipeDefinitions(null);
+
+            var recipe = Assert.Single(recipeDefinitions);
+            Assert.Equal("AspNetAppEcsFargate", recipe.Id);
+            var iamRole = recipe.OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+            Assert.NotNull(iamRole);
+            Assert.Empty(iamRole.Dependents);
+            var iamRoleCreateNew = iamRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+            Assert.NotNull(iamRoleCreateNew);
+            Assert.Single(iamRoleCreateNew.Dependents);
+            Assert.NotNull(iamRoleCreateNew.Dependents.First(x => x.Equals("ApplicationIAMRole.RoleArn")));
+            var iamRoleRoleArn = iamRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+            Assert.NotNull(iamRoleRoleArn);
+            Assert.Single(iamRoleRoleArn.Dependents);
+            Assert.NotNull(iamRoleRoleArn.Dependents.First(x => x.Equals("ApplicationIAMRole.CreateNew")));
+        }
+    }
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/Recipes/OptionSettingCyclicDependency.recipe
+++ b/test/AWS.Deploy.Orchestration.UnitTests/Recipes/OptionSettingCyclicDependency.recipe
@@ -1,0 +1,791 @@
+{
+    "$schema": "./aws-deploy-recipe-schema.json",
+    "Id": "AspNetAppEcsFargate",
+    "Version": "0.1.0",
+    "Name": "ASP.NET Core App to Amazon ECS using Fargate",
+    "OptionSettings": [
+        {
+            "Id": "ECSCluster",
+            "Name": "ECS Cluster",
+            "Category": "General",
+            "Description": "The ECS cluster used for the deployment.",
+            "Type": "Object",
+            "TypeHint": "ECSCluster",
+            "AdvancedSetting": false,
+            "Updatable": false,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New ECS Cluster",
+                    "Description": "Do you want to create a new ECS cluster?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
+                },
+                {
+                    "Id": "ClusterArn",
+                    "Name": "Existing Cluster ARN",
+                    "Description": "The ARN of the existing cluster to use.",
+                    "Type": "String",
+                    "TypeHint": "ExistingECSCluster",
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "arn:[^:]+:ecs:[^:]*:[0-9]{12}:cluster/.+",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid cluster Arn. The ARN should contain the arn:[PARTITION]:ecs namespace, followed by the Region of the cluster, the AWS account ID of the cluster owner, the cluster namespace, and then the cluster name. For example, arn:aws:ecs:region:012345678910:cluster/test. For more information visit https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Cluster.html"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "ECSCluster.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                },
+                {
+                    "Id": "NewClusterName",
+                    "Name": "New Cluster Name",
+                    "Description": "The name of the new cluster to create.",
+                    "Type": "String",
+                    "DefaultValue": "{StackName}",
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^([A-Za-z0-9_-]{1,255})$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid cluster name. The cluster name can only contain letters (case-sensitive), numbers, hyphens, underscores and can't be longer than 255 character in length."
+                            }
+                        },
+                        {
+                            "ValidatorType": "ExistingResource",
+                            "Configuration": {
+                                "ResourceType": "AWS::ECS::Cluster"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "ECSCluster.CreateNew",
+                            "Value": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Id": "ECSServiceName",
+            "ParentSettingId": "ClusterName",
+            "Name": "ECS Service Name",
+            "Category": "General",
+            "Description": "The name of the ECS service running in the cluster.",
+            "Type": "String",
+            "TypeHint": "ECSService",
+            "DefaultValue": "{StackName}-service",
+            "AdvancedSetting": false,
+            "Updatable": false,
+            "Validators": [
+                {
+                    "ValidatorType": "Regex",
+                    "Configuration": {
+                        "Regex": "^([A-Za-z0-9_-]{1,255})$",
+                        "ValidationFailedMessage": "Invalid service name. The service name can only contain letters (case-sensitive), numbers, hyphens, underscores and can't be longer than 255 character in length."
+                    }
+                }
+            ]
+        },
+        {
+            "Id": "DesiredCount",
+            "Name": "Desired Task Count",
+            "Category": "Compute",
+            "Description": "The desired number of ECS tasks to run for the service.",
+            "Type": "Int",
+            "DefaultValue": 3,
+            "AdvancedSetting": false,
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "Range",
+                    "Configuration": {
+                        "Min": 1,
+                        "Max": 5000
+                    }
+                }
+            ]
+        },
+        {
+            "Id": "ApplicationIAMRole",
+            "Name": "Application IAM Role",
+            "Category": "Permissions",
+            "Description": "The Identity and Access Management (IAM) role that provides AWS credentials to the application to access AWS services.",
+            "Type": "Object",
+            "TypeHint": "IAMRole",
+            "TypeHintData": {
+                "ServicePrincipal": "ecs-tasks.amazonaws.com"
+            },
+            "AdvancedSetting": false,
+            "Updatable": true,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New Role",
+                    "Description": "Do you want to create a new role?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "ApplicationIAMRole.RoleArn",
+                            "Value": false
+                        }
+                    ]
+                },
+                {
+                    "Id": "RoleArn",
+                    "Name": "Existing Role ARN",
+                    "Description": "The ARN of the existing role to use.",
+                    "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "ecs-tasks.amazonaws.com"
+                    },
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "arn:.+:iam::[0-9]{12}:.+",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid IAM Role ARN. The ARN should contain the arn:[PARTITION]:iam namespace, followed by the account ID, and then the resource path. For example - arn:aws:iam::123456789012:role/S3Access is a valid IAM Role ARN. For more information visit https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "ApplicationIAMRole.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Id": "Vpc",
+            "Name": "Virtual Private Cloud (VPC)",
+            "Category": "VPC",
+            "Description": "A VPC enables you to launch the application into a virtual network that you've defined.",
+            "Type": "Object",
+            "TypeHint": "Vpc",
+            "AdvancedSetting": false,
+            "Updatable": false,
+            "ChildOptionSettings": [
+                {
+                    "Id": "IsDefault",
+                    "Name": "Use default VPC",
+                    "Description": "Do you want to use the default VPC for the deployment?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
+                },
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New VPC",
+                    "Description": "Do you want to create a new VPC?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "Vpc.IsDefault",
+                            "Value": false
+                        }
+                    ]
+                },
+                {
+                    "Id": "VpcId",
+                    "Name": "Existing VPC ID",
+                    "Description": "The ID of the existing VPC to use.",
+                    "Type": "String",
+                    "TypeHint": "ExistingVpc",
+                    "DefaultValue": null,
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "Vpc.IsDefault",
+                            "Value": false
+                        },
+                        {
+                            "Id": "Vpc.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Id": "LoadBalancer",
+            "Name": "Elastic Load Balancer",
+            "Category": "LoadBalancer",
+            "Description": "Load Balancer the ECS Service will register tasks to.",
+            "Type": "Object",
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New Load Balancer",
+                    "Description": "Do you want to create a new Load Balancer?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
+                },
+                {
+                    "Id": "ExistingLoadBalancerArn",
+                    "Name": "Existing Load Balancer ARN",
+                    "Description": "The ARN of an existing load balancer to use.",
+                    "Type": "String",
+                    "TypeHint": "ExistingApplicationLoadBalancer",
+                    "DefaultValue": null,
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "arn:[^:]+:elasticloadbalancing:[^:]*:[0-9]{12}:loadbalancer/.+",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid load balancer ARN. The ARN should contain the arn:[PARTITION]:elasticloadbalancing namespace, followed by the Region of the load balancer, the AWS account ID of the load balancer owner, the loadbalancer namespace, and then the load balancer name. For example, arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "LoadBalancer.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                },
+                {
+                    "Id": "DeregistrationDelayInSeconds",
+                    "Name": "Deregistration delay (seconds)",
+                    "Description": "The amount of time to allow requests to finish before deregistering ECS tasks.",
+                    "Type": "Int",
+                    "DefaultValue": 60,
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "HealthCheckPath",
+                    "Name": "Health Check Path",
+                    "Description": "The ping path destination where Elastic Load Balancing sends health check requests.",
+                    "Type": "String",
+                    "DefaultValue": "/",
+                    "AdvancedSetting": true,
+                    "Updatable": true
+                },
+                {
+                    "Id": "HealthCheckInternval",
+                    "Name": "Health Check Interval",
+                    "Description": "The approximate interval, in seconds, between health checks of an individual instance.",
+                    "Type": "Int",
+                    "DefaultValue": 30,
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 5,
+                                "Max": 300
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "HealthyThresholdCount",
+                    "Name": "Healthy Threshold Count",
+                    "Description": "The number of consecutive health check successes required before considering an unhealthy target healthy.",
+                    "Type": "Int",
+                    "DefaultValue": 5,
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 2,
+                                "Max": 10
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "UnhealthyThresholdCount",
+                    "Name": "Unhealthy Threshold Count",
+                    "Description": "The number of consecutive health check successes required before considering an unhealthy target unhealthy.",
+                    "Type": "Int",
+                    "DefaultValue": 2,
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 2,
+                                "Max": 10
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Id": "ListenerConditionType",
+                    "Name": "Type of Listener Condition",
+                    "Description": "The type of listener rule to create to direct traffic to ECS service.",
+                    "Type": "String",
+                    "DefaultValue": "None",
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "AllowedValues": [
+                        "None",
+                        "Path"
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "LoadBalancer.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                },
+                {
+                    "Id": "ListenerConditionPathPattern",
+                    "Name": "Listener Condition Path Pattern",
+                    "Description": "The resource path pattern to use for the listener rule. (i.e. \"/api/*\") ",
+                    "Type": "String",
+                    "DefaultValue": null,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^/[a-zA-Z0-9*?&_\\-.$/~\"'@:+]{0,127}$",
+                                "AllowEmptyString": true,
+                                "ValidationFailedMessage": "Invalid listener condition path. The path is case-sensitive and can be up to 128. It starts with '/' and consists of alpha-numeric characters, wildcards (* and ?), & (using &amp;), and the following special characters: '_-.$/~\"'@:+'"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "LoadBalancer.CreateNew",
+                            "Value": false
+                        },
+                        {
+                            "Id": "LoadBalancer.ListenerConditionType",
+                            "Value": "Path"
+                        }
+                    ]
+                },
+                {
+                    "Id": "ListenerConditionPriority",
+                    "Name": "Listener Condition Priority",
+                    "Description": "Priority of the condition rule. The value must be unique for the Load Balancer listener.",
+                    "Type": "Int",
+                    "DefaultValue": 100,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1,
+                                "Max": 50000
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "LoadBalancer.CreateNew",
+                            "Value": false
+                        },
+                        {
+                            "Id": "LoadBalancer.ListenerConditionType",
+                            "Value": "Path"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Id": "AutoScaling",
+            "Name": "AutoScaling",
+            "Category": "AutoScaling",
+            "Description": "The AutoScaling configuration for the ECS service.",
+            "Type": "Object",
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "ChildOptionSettings": [
+                {
+                    "Id": "Enabled",
+                    "Name": "Enable",
+                    "Description": "Do you want to enable AutoScaling?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": false,
+                    "Updatable": true
+                },
+                {
+                    "Id": "MinCapacity",
+                    "Name": "Minimum Capacity",
+                    "Description": "The minimum number of ECS tasks handling the demand for the ECS service.",
+                    "Type": "Int",
+                    "DefaultValue": 3,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1,
+                                "Max": 5000
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
+                    "Id": "MaxCapacity",
+                    "Name": "Maximum Capacity",
+                    "Description": "The maximum number of ECS tasks handling the demand for the ECS service.",
+                    "Type": "Int",
+                    "DefaultValue": 6,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1,
+                                "Max": 5000
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
+                    "Id": "ScalingType",
+                    "Name": "AutoScaling Metric",
+                    "Description": "The metric to monitor for scaling changes.",
+                    "Type": "String",
+                    "DefaultValue": "Cpu",
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "AllowedValues": [
+                        "Cpu",
+                        "Memory",
+                        "Request"
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
+                    "Id": "CpuTypeTargetUtilizationPercent",
+                    "Name": "CPU Target Utilization",
+                    "Description": "The target cpu utilization percentage that triggers a scaling change.",
+                    "Type": "Double",
+                    "DefaultValue": 70,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1,
+                                "Max": 100
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Cpu"
+                        }
+                    ]
+                },
+                {
+                    "Id": "CpuTypeScaleInCooldownSeconds",
+                    "Name": "Scale in cooldown (seconds)",
+                    "Description": "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start.",
+                    "Type": "Int",
+                    "DefaultValue": 300,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Cpu"
+                        }
+                    ]
+                },
+                {
+                    "Id": "CpuTypeScaleOutCooldownSeconds",
+                    "Name": "Scale out cooldown (seconds)",
+                    "Description": "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start.",
+                    "Type": "Int",
+                    "DefaultValue": 300,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Cpu"
+                        }
+                    ]
+                },
+                {
+                    "Id": "MemoryTypeTargetUtilizationPercent",
+                    "Name": "Memory Target Utilization",
+                    "Description": "The target memory utilization percentage that triggers a scaling change.",
+                    "Type": "Double",
+                    "DefaultValue": 70,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1,
+                                "Max": 100
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Memory"
+                        }
+                    ]
+                },
+                {
+                    "Id": "MemoryTypeScaleInCooldownSeconds",
+                    "Name": "Scale in cooldown (seconds)",
+                    "Description": "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start.",
+                    "Type": "Int",
+                    "DefaultValue": 300,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Memory"
+                        }
+                    ]
+                },
+                {
+                    "Id": "MemoryTypeScaleOutCooldownSeconds",
+                    "Name": "Scale out cooldown (seconds)",
+                    "Description": "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start.",
+                    "Type": "Int",
+                    "DefaultValue": 300,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Memory"
+                        }
+                    ]
+                },
+                {
+                    "Id": "RequestTypeRequestsPerTarget",
+                    "Name": "Request per task",
+                    "Description": "The number of request per ECS task that triggers a scaling change.",
+                    "Type": "Int",
+                    "DefaultValue": 1000,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 1
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Request"
+                        }
+                    ]
+                },
+                {
+                    "Id": "RequestTypeScaleInCooldownSeconds",
+                    "Name": "Scale in cooldown (seconds)",
+                    "Description": "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start.",
+                    "Type": "Int",
+                    "DefaultValue": 300,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Request"
+                        }
+                    ]
+                },
+                {
+                    "Id": "RequestTypeScaleOutCooldownSeconds",
+                    "Name": "Scale out cooldown (seconds)",
+                    "Description": "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start.",
+                    "Type": "Int",
+                    "DefaultValue": 300,
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Range",
+                            "Configuration": {
+                                "Min": 0,
+                                "Max": 3600
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "AutoScaling.Enabled",
+                            "Value": true
+                        },
+                        {
+                            "Id": "AutoScaling.ScalingType",
+                            "Value": "Request"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestDirectoryManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestDirectoryManager.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using AWS.Deploy.Common.IO;
+using System.Linq;
 
 namespace AWS.Deploy.Orchestration.UnitTests
 {
     public class TestDirectoryManager : IDirectoryManager
     {
         public readonly HashSet<string> CreatedDirectories = new();
+        public readonly Dictionary<string, HashSet<string>> AddedFiles = new();
 
         public DirectoryInfo CreateDirectory(string path)
         {
@@ -45,7 +47,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
 
         public string[] GetFiles(string path, string searchPattern = null, SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
-            throw new NotImplementedException("If your test needs this method, you'll need to implement this.");
+            AddedFiles.ContainsKey(path) ? AddedFiles[path].ToArray() : new string[0];
 
         public bool IsEmpty(string path) =>
             throw new NotImplementedException("If your test needs this method, you'll need to implement this.");

--- a/test/AWS.Deploy.Orchestration.UnitTests/Utilities/TestToolOrchestratorInteractiveService.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/Utilities/TestToolOrchestratorInteractiveService.cs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Deploy.Orchestration.UnitTests.Utilities
+{
+    public class TestToolOrchestratorInteractiveService : IOrchestratorInteractiveService
+    {
+        public IList<string> SectionStartMessages { get; } = new List<string>();
+        public IList<string> DebugMessages { get; } = new List<string>();
+        public IList<string> OutputMessages { get; } = new List<string>();
+        public IList<string> ErrorMessages { get; } = new List<string>();
+
+        public void LogSectionStart(string message, string description) => SectionStartMessages.Add(message);
+        public void LogDebugMessage(string message) => DebugMessages.Add(message);
+        public void LogErrorMessage(string message) => ErrorMessages.Add(message);
+        public void LogInfoMessage(string message) => OutputMessages.Add(message);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5920

*Description of changes:*
* Build an option setting dependency tree that allows us to easily determine which option settings need to be validated when a value update happens.
* Added Leaf ID and Parent fields to option settings to allow easy navigation of option settings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
