### PR TITLE
chore: Alter option setting names in Elastic Beanstalk recipe

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -128,9 +128,9 @@
     "OptionSettings": [
         {
             "Id": "BeanstalkApplication",
-            "Name": "Application Name",
+            "Name": "Elastic Beanstalk Application",
             "Category": "General",
-            "Description": "The Elastic Beanstalk application name.",
+            "Description": "The Elastic Beanstalk application.",
             "Type": "Object",
             "TypeHint": "BeanstalkApplication",
             "AdvancedSetting": false,


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5882

*Description of changes:*
This PR changes the top-level `BeanstalkApplication` option setting name to `Elastic Beanstalk Application`. This is done because the original option setting name (`Application Name`) was also being used to set the name of the CloudFormation stack. Using the same name to represent the different constructs can be confusing to users.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
