### PR TITLE
 feat: Add URI validator and set default value for resource path pattern in the Blazor recipe

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -831,7 +831,7 @@ namespace AWS.Deploy.CLI.Commands
                 }
             }
 
-            if (!Equals(settingValue, currentValue) && settingValue != null)
+            if (settingValue != null)
             {
                 try
                 {

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -52,6 +52,9 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="SecurityGroupsInVpcValidator"/>
         /// </summary>
-        SecurityGroupsInVpc
+        SecurityGroupsInVpc,
+        /// Must be paired with <see cref="UriValidator"/>
+        /// </summary>
+        Uri
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/UriValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/UriValidator.cs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Checks if a URI is structurally valid
+    /// </summary>
+    public class UriValidator : IOptionSettingItemValidator
+    {
+        public string ValidationFailedMessage { get; set; } = "{{URI}} is not a valid URI.";
+
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var uri = input?.ToString() ?? string.Empty;
+
+            /// It is possible that a URI specific option setting item is optional and can be null or empty.
+            /// To enforce the presence of a non-null or non-empty value, you must combine this validator with a <see cref="RequiredValidator"/>
+            if (string.IsNullOrEmpty(uri))
+            {
+                return ValidationResult.ValidAsync();
+            }
+
+            var message = ValidationFailedMessage.Replace("{{URI}}", uri);
+            try
+            {
+                var uriResult = new Uri(uri);
+                if (!Uri.IsWellFormedUriString(uri, UriKind.Absolute))
+                    return ValidationResult.FailedAsync(message);
+            }
+            catch (UriFormatException)
+            {
+                return ValidationResult.FailedAsync(message);
+            }
+
+            return ValidationResult.ValidAsync();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -57,7 +57,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.StringLength, typeof(StringLengthValidator) },
             { OptionSettingItemValidatorList.InstanceType, typeof(InstanceTypeValidator) },
             { OptionSettingItemValidatorList.SubnetsInVpc, typeof(SubnetsInVpcValidator) },
-            { OptionSettingItemValidatorList.SecurityGroupsInVpc, typeof(SecurityGroupsInVpcValidator) }
+            { OptionSettingItemValidatorList.SecurityGroupsInVpc, typeof(SecurityGroupsInVpcValidator) },
+            { OptionSettingItemValidatorList.Uri, typeof(UriValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
@@ -174,6 +174,14 @@
                             "Id": "BackendApi.Enable",
                             "Value": true
                         }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Uri"
+                        },
+                        {
+                            "ValidatorType": "Required"
+                        }
                     ]
                 },
                 {
@@ -181,13 +189,22 @@
                     "Name": "Resource Path Pattern",
                     "Description": "The resource path pattern to determine which request go to backend rest api. (i.e. \"/api/*\") ",
                     "Type": "String",
-                    "DefaultValue": "",
+                    "DefaultValue": "/api/*",
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "DependsOn": [
                         {
                             "Id": "BackendApi.Enable",
                             "Value": true
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^/\\S+$",
+                                "ValidationFailedMessage": "Invalid resource path pattern. The resource path must start with a forward slash (/) followed by one or more unicode characters"
+                            }
                         }
                     ]
                 }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -613,7 +613,8 @@
                                     "StringLength",
                                     "InstanceType",
                                     "SubnetsInVpc",
-                                    "SecurityGroupsInVpc"
+                                    "SecurityGroupsInVpc",
+                                    "Uri"
                                 ]
                             }
                         },
@@ -695,6 +696,22 @@
                                                 "MaxLength": {
                                                     "type": "integer"
                                                 },
+                                                "ValidationFailedMessage": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": { "ValidatorType": { "const": "Uri" } }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "Configuration": {
+                                            "properties": {
                                                 "ValidationFailedMessage": {
                                                     "type": "string"
                                                 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/BlazorWasmOptionSettingItemValidationTest.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/BlazorWasmOptionSettingItemValidationTest.cs
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using Moq;
+using Should;
+using Xunit;
+
+namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
+{
+    public class BlazorWasmOptionSettingItemValidationTest
+    {
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IServiceProvider _serviceProvider;
+
+        public BlazorWasmOptionSettingItemValidationTest()
+        {
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            _serviceProvider = mockServiceProvider.Object;
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
+        }
+
+        [Theory]
+        [InlineData("https://www.abc.com/")]
+        [InlineData("http://www.abc.com/")]
+        [InlineData("http://abc.com")]
+        [InlineData("http://abc.com.xyz")]
+        [InlineData("http://abc.com/def")]
+        [InlineData("http://abc.com//def")]
+        [InlineData("http://api-uri")]
+        [InlineData("customScheme://www.abc.com")]
+        [InlineData("")] // Special case - It is possible that a URI specific option setting item is optional and can be null or empty.
+        public async Task BackendApiUriValidationTests_ValidUri(string uri)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
+            optionSettingItem.Validators.Add(GetUriValidatorConfig());
+            await Validate(optionSettingItem, uri, true);
+        }
+
+        [Theory]
+        [InlineData("//")]
+        [InlineData("/")]
+        [InlineData("abc.com")]
+        [InlineData("abc")]
+        [InlineData("http:www.abc.com")]
+        [InlineData("http:/www.abc.com")]
+        [InlineData("http//:www.abc.com")]
+        [InlineData("://www.abc.com")]
+        [InlineData("www.abc.com")]
+        public async Task BackendApiUriValidationTests_InvalidUri(string uri)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
+            optionSettingItem.Validators.Add(GetUriValidatorConfig());
+            await Validate(optionSettingItem, uri, false);
+        }
+
+        [Theory]
+        [InlineData("/*", true)]
+        [InlineData("/api/*", true)]
+        [InlineData("/api/myResource", true)]
+        [InlineData("/", false)]
+        [InlineData("", false)]
+        [InlineData("abc", false)]
+        public async Task BackendApiResourcePathValidationTests_InvalidUri(string resourcePath, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("^/\\S+$"));
+            await Validate(optionSettingItem, resourcePath, isValid);
+        }
+
+        private OptionSettingItemValidatorConfig GetUriValidatorConfig()
+        {
+            var rangeValidatorConfig = new OptionSettingItemValidatorConfig
+            {
+                ValidatorType = OptionSettingItemValidatorList.Uri,
+            };
+            return rangeValidatorConfig;
+        }
+
+        private OptionSettingItemValidatorConfig GetRegexValidatorConfig(string regex)
+        {
+            var regexValidatorConfig = new OptionSettingItemValidatorConfig
+            {
+                ValidatorType = OptionSettingItemValidatorList.Regex,
+                Configuration = new RegexValidator
+                {
+                    Regex = regex
+                }
+            };
+            return regexValidatorConfig;
+        }
+
+        private async Task Validate<T>(OptionSettingItem optionSettingItem, T value, bool isValid)
+        {
+            ValidationFailedException exception = null;
+            try
+            {
+                await _optionSettingHandler.SetOptionSettingValue(null, optionSettingItem, value);
+            }
+            catch (ValidationFailedException e)
+            {
+                exception = e;
+            }
+
+            if (isValid)
+                exception.ShouldBeNull();
+            else
+                exception.ShouldNotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
* DOTNET-5805
* DOTNET-5806

*Description of changes:*
* Add new `UriValidator` class
* Enforces the `UriValidator` and `RegexValidator` on `BackendApi.Uri`.
* Set default value for `BackendApi.ResourcePathPattern` and impose the `RegexValidator` on it.

![image](https://user-images.githubusercontent.com/36622308/171946306-09fd8c99-cc16-40e9-b13d-fefe0f11797b.png)
![image](https://user-images.githubusercontent.com/36622308/171946525-f69a3cec-c4a6-4d42-adfb-43e9ec3072cd.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
