### PR TITLE
feat: run dependent settings validators when an option setting value is set

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -198,7 +198,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             foreach (var setting in configurableOptionSettings)
             {
-                var settingSummary = new OptionSettingItemSummary(setting.Id, setting.Name, setting.Description, setting.Type.ToString())
+                var settingSummary = new OptionSettingItemSummary(setting.Id, setting.FullyQualifiedId, setting.Name, setting.Description, setting.Type.ToString())
                 {
                     Category = setting.Category,
                     TypeHint = setting.TypeHint?.ToString(),
@@ -210,6 +210,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                     SummaryDisplayable = optionSettingHandler.IsSummaryDisplayable(recommendation, setting),
                     AllowedValues = setting.AllowedValues,
                     ValueMapping = setting.ValueMapping,
+                    Validation = setting.Validation,
                     ChildOptionSettings = ListOptionSettingSummary(optionSettingHandler, recommendation, setting.ChildOptionSettings)
                 };
 

--- a/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Models/OptionSettingItemSummary.cs
@@ -3,47 +3,111 @@
 
 using System;
 using System.Collections.Generic;
+using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.CLI.ServerMode.Models
 {
     public class OptionSettingItemSummary
     {
+        /// <summary>
+        /// The unique id of setting. This value will be persisted in other config files so its value should never change once a recipe is released.
+        /// </summary>
         public string Id { get; set; }
 
+        /// <summary>
+        /// The fully qualified id of the setting that includes the Id and all of the parent's Ids.
+        /// This helps easily reference the Option Setting without context of the parent setting.
+        /// </summary>
+        public string FullyQualifiedId { get; set; }
+
+        /// <summary>
+        /// The display friendly name of the setting.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// The category for the setting. This value must match an id field in the list of categories.
+        /// </summary>
         public string? Category { get; set; }
 
+        /// <summary>
+        /// The description of what the setting is used for.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// The value used for the recipe if it is set by the user.
+        /// </summary>
         public object? Value { get; set; }
 
+        /// <summary>
+        /// The type of primitive value expected for this setting.
+        /// For example String, Int
+        /// </summary>
         public string Type { get; set; }
 
+        /// <summary>
+        /// Hint the the UI what type of setting this is optionally add additional UI features to select a value.
+        /// For example a value of BeanstalkApplication tells the UI it can display the list of available Beanstalk applications for the user to pick from.
+        /// </summary>
         public string? TypeHint { get; set; }
 
+        /// <summary>
+        /// Type hint additional data required to facilitate handling of the option setting.
+        /// </summary>
         public Dictionary<string, object> TypeHintData { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// UI can use this to reduce the amount of settings to show to the user when confirming the recommendation. This can make it so the user sees only the most important settings
+        /// they need to know about before deploying.
+        /// </summary>
         public bool Advanced { get; set; }
 
+        /// <summary>
+        /// Indicates whether the setting can be edited
+        /// </summary>
         public bool ReadOnly { get; set; }
 
+        /// <summary>
+        /// Indicates whether the setting is visible/displayed on the UI
+        /// </summary>
         public bool Visible { get; set; }
 
+        /// <summary>
+        /// Indicates whether the setting can be displayed as part of the settings summary of the previous deployment.
+        /// </summary>
         public bool SummaryDisplayable { get; set; }
 
+        /// <summary>
+        /// The allowed values for the setting.
+        /// </summary>
         public IList<string> AllowedValues { get; set; } = new List<string>();
 
+        /// <summary>
+        /// The value mapping for allowed values. The key of the dictionary is what is sent to services
+        /// and the value is the display value shown to users.
+        /// </summary>
         public IDictionary<string, string> ValueMapping { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Child option settings for <see cref="OptionSettingValueType.Object"/> value types
+        /// <see cref="ChildOptionSettings"/> value depends on the values of <see cref="ChildOptionSettings"/>
+        /// </summary>
         public List<OptionSettingItemSummary> ChildOptionSettings { get; set; } = new();
 
-        public OptionSettingItemSummary(string id, string name, string description, string type)
+        /// <summary>
+        /// The validation state of the setting that contains the validation status and message.
+        /// </summary>
+        public OptionSettingValidation Validation { get; set; }
+
+        public OptionSettingItemSummary(string id, string fullyQualifiedId, string name, string description, string type)
         {
             Id = id;
+            FullyQualifiedId = fullyQualifiedId;
             Name = name;
             Description = description;
             Type = type;
+            Validation = new OptionSettingValidation();
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -109,7 +109,14 @@ namespace AWS.Deploy.Common.Recipes
                     }
                 }
                 if (!isValid)
+                {
                     throw new ValidationFailedException(DeployToolErrorCode.OptionSettingItemValueValidationFailed, validationFailedMessage.Trim());
+                }
+                else
+                {
+                    Validation.ValidationStatus = ValidationStatus.Valid;
+                    Validation.ValidationMessage = string.Empty;
+                }
             }
 
             if (AllowedValues != null && AllowedValues.Count > 0 && valueOverride != null &&

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -161,12 +161,18 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         public List<string> Dependents { get; set; } = new List<string> ();
 
+        /// <summary>
+        /// The validation state of the setting that contains the validation status and message.
+        /// </summary>
+        public OptionSettingValidation Validation { get; set; }
+
         public OptionSettingItem(string id, string fullyQualifiedId, string name, string description)
         {
             Id = id;
             FullyQualifiedId = fullyQualifiedId;
             Name = name;
             Description = description;
+            Validation = new OptionSettingValidation();
         }
 
         /// <summary>

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingValidation.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingValidation.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes
+{
+    public enum ValidationStatus
+    {
+        Valid,
+        Invalid
+    }
+
+    public class OptionSettingValidation
+    {
+        public ValidationStatus ValidationStatus { get; set; } = ValidationStatus.Valid;
+
+        public string ValidationMessage { get; set; } = string.Empty;
+    }
+}

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -340,7 +340,6 @@
                             "ValidatorType": "Regex",
                             "Configuration": {
                                 "Regex": "arn:.+:iam::[0-9]{12}:.+",
-                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid IAM Role ARN. The ARN should contain the arn:[PARTITION]:iam namespace, followed by the account ID, and then the resource path. For example - arn:aws:iam::123456789012:role/S3Access is a valid IAM Role ARN. For more information visit https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns"
                             }
                         }

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -2009,6 +2009,9 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("fullyQualifiedId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string FullyQualifiedId { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; }
     
@@ -2050,6 +2053,22 @@ namespace AWS.Deploy.ServerMode.Client
     
         [Newtonsoft.Json.JsonProperty("childOptionSettings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<OptionSettingItemSummary> ChildOptionSettings { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("validation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public OptionSettingValidation Validation { get; set; }
+    
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class OptionSettingValidation 
+    {
+        [Newtonsoft.Json.JsonProperty("validationStatus", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public ValidationStatus ValidationStatus { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("validationMessage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ValidationMessage { get; set; }
     
     
     }
@@ -2222,6 +2241,17 @@ namespace AWS.Deploy.ServerMode.Client
         [Newtonsoft.Json.JsonProperty("displayName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string DisplayName { get; set; }
     
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v13.0.0.0)")]
+    public enum ValidationStatus
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"Valid")]
+        Valid = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"Invalid")]
+        Invalid = 1,
     
     }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using AWS.Deploy.CLI.Commands;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Utilities;
+using AWS.Deploy.ServerMode.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
+{
+    public class DependencyValidationOptionSettings : IDisposable
+    {
+        private bool _isDisposed;
+        private string _stackName;
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly string _awsRegion;
+        private readonly TestAppManager _testAppManager;
+
+        public DependencyValidationOptionSettings()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddCustomServices();
+            serviceCollection.AddTestServices();
+
+            _serviceProvider = serviceCollection.BuildServiceProvider();
+
+            _awsRegion = "us-west-2";
+
+            _testAppManager = new TestAppManager();
+        }
+
+        public Task<AWSCredentials> ResolveCredentials()
+        {
+            var testCredentials = FallbackCredentialsFactory.GetCredentials();
+            return Task.FromResult<AWSCredentials>(testCredentials);
+        }
+
+        [Fact]
+        public async Task DependentOptionSettingsGetInvalidated()
+        {
+            _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
+            var portNumber = 4022;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await restClient.WaitTillServerModeReady();
+
+                var sessionId = await restClient.StartDeploymentSession(projectPath, _awsRegion);
+
+                var logOutput = new StringBuilder();
+                await ServerModeExtensions.SetupSignalRConnection(baseUrl, sessionId, logOutput);
+
+                var beanstalkRecommendation = await restClient.GetRecommendationsAndSetDeploymentTarget(sessionId, "AspNetAppElasticBeanstalkLinux", _stackName);
+
+                var applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Equal(ValidationStatus.Valid, applicationIAMRole.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(applicationIAMRole.Validation.ValidationMessage));
+                var validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Equal(ValidationStatus.Valid, validCreateNew.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(validCreateNew.Validation.ValidationMessage));
+                var validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.Equal(ValidationStatus.Valid, validRoleArn.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(validRoleArn.Validation.ValidationMessage));
+
+                var applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"ApplicationIAMRole.CreateNew", "false"}
+                    }
+                });
+
+                applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Equal(ValidationStatus.Valid, applicationIAMRole.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(applicationIAMRole.Validation.ValidationMessage));
+                validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Equal(ValidationStatus.Valid, validCreateNew.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(validCreateNew.Validation.ValidationMessage));
+                validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.Equal(ValidationStatus.Invalid, validRoleArn.Validation.ValidationStatus);
+                Assert.Equal("Invalid IAM Role ARN. The ARN should contain the arn:[PARTITION]:iam namespace, followed by the account ID, and then the resource path. For example - arn:aws:iam::123456789012:role/S3Access is a valid IAM Role ARN. For more information visit https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns",
+                    validRoleArn.Validation.ValidationMessage);
+
+                applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"ApplicationIAMRole.CreateNew", "true"}
+                    }
+                });
+
+                applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Equal(ValidationStatus.Valid, applicationIAMRole.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(applicationIAMRole.Validation.ValidationMessage));
+                validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Equal(ValidationStatus.Valid, validCreateNew.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(validCreateNew.Validation.ValidationMessage));
+                validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.Equal(ValidationStatus.Valid, validRoleArn.Validation.ValidationStatus);
+                Assert.True(string.IsNullOrEmpty(validRoleArn.Validation.ValidationMessage));
+            }
+            finally
+            {
+                cancelSource.Cancel();
+                _stackName = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            _isDisposed = true;
+        }
+
+        ~DependencyValidationOptionSettings()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -9,22 +9,19 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
-using Amazon.CloudFormation.Model;
-using Amazon.Runtime;
 using AWS.Deploy.CLI.Commands;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.CLI.Extensions;
 using AWS.Deploy.CLI.IntegrationTests.Extensions;
-using AWS.Deploy.CLI.IntegrationTests.Helpers;
 using AWS.Deploy.CLI.TypeHintResponses;
 using AWS.Deploy.Common;
-using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.ServerMode.Client;
 using AWS.Deploy.Common.TypeHintData;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
+using AWS.Deploy.CLI.IntegrationTests.Utilities;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 {
@@ -57,22 +54,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
             _testAppManager = new TestAppManager();
         }
 
-        public TemplateMetadataReader GetTemplateMetadataReader(string templateBody)
-        {
-            var templateMetadataReader = new TemplateMetadataReader(_mockAWSClientFactory.Object);
-            var cfResponse = new GetTemplateResponse();
-            cfResponse.TemplateBody = templateBody;
-            _mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonCloudFormation>(It.IsAny<string>())).Returns(_mockCFClient.Object);
-            _mockCFClient.Setup(x => x.GetTemplateAsync(It.IsAny<GetTemplateRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(cfResponse);
-            return templateMetadataReader;
-        }
-
-        public Task<AWSCredentials> ResolveCredentials()
-        {
-            var testCredentials = FallbackCredentialsFactory.GetCredentials();
-            return Task.FromResult<AWSCredentials>(testCredentials);
-        }
-
         [Fact]
         public async Task GetAndApplyAppRunnerSettings_VPCConnector()
         {
@@ -80,7 +61,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
             var portNumber = 4021;
-            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ServerModeExtensions.ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
             var cancelSource = new CancellationTokenSource();
@@ -91,14 +72,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 var baseUrl = $"http://localhost:{portNumber}/";
                 var restClient = new RestAPIClient(baseUrl, httpClient);
 
-                await WaitTillServerModeReady(restClient);
+                await restClient.WaitTillServerModeReady();
 
-                var sessionId = await StartDeploymentSession(restClient, projectPath);
+                var sessionId = await restClient.StartDeploymentSession(projectPath, _awsRegion);
 
                 var logOutput = new StringBuilder();
-                await SetupSignalRConnection(baseUrl, sessionId, logOutput);
+                await ServerModeExtensions.SetupSignalRConnection(baseUrl, sessionId, logOutput);
 
-                var appRunnerRecommendation = await GetRecommendationsAndSelectAppRunner(restClient, sessionId);
+                var appRunnerRecommendation = await restClient.GetRecommendationsAndSetDeploymentTarget(sessionId, "AspNetAppAppRunner", _stackName);
 
                 var vpcResources = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.VpcId");
                 var subnetsResourcesEmpty = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.Subnets");
@@ -135,7 +116,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
                 var generateCloudFormationTemplateResponse = await restClient.GenerateCloudFormationTemplateAsync(sessionId);
 
-                var metadata = await GetAppSettingsFromCFTemplate(generateCloudFormationTemplateResponse.CloudFormationTemplate, _stackName);
+                var metadata = await ServerModeExtensions.GetAppSettingsFromCFTemplate(_mockAWSClientFactory, _mockCFClient, generateCloudFormationTemplateResponse.CloudFormationTemplate, _stackName);
 
                 Assert.True(metadata.Settings.ContainsKey("VPCConnector"));
                 var vpcConnector = JsonConvert.DeserializeObject<VPCConnectorTypeHintResponse>(metadata.Settings["VPCConnector"].ToString());
@@ -158,7 +139,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
             var portNumber = 4002;
-            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ServerModeExtensions.ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
             var cancelSource = new CancellationTokenSource();
@@ -169,14 +150,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 var baseUrl = $"http://localhost:{portNumber}/";
                 var restClient = new RestAPIClient(baseUrl, httpClient);
 
-                await WaitTillServerModeReady(restClient);
+                await restClient.WaitTillServerModeReady();
 
-                var sessionId = await StartDeploymentSession(restClient, projectPath);
+                var sessionId = await restClient.StartDeploymentSession(projectPath, _awsRegion);
 
                 var logOutput = new StringBuilder();
-                await SetupSignalRConnection(baseUrl, sessionId, logOutput);
+                await ServerModeExtensions.SetupSignalRConnection(baseUrl, sessionId, logOutput);
 
-                await GetRecommendationsAndSelectAppRunner(restClient, sessionId);
+                await restClient.GetRecommendationsAndSetDeploymentTarget(sessionId, "AspNetAppAppRunner", _stackName);
 
                 var configSettings = restClient.GetConfigSettingsAsync(sessionId);
                 Assert.NotEmpty(configSettings.Result.OptionSettings);
@@ -189,68 +170,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 cancelSource.Cancel();
                 _stackName = null;
             }
-        }
-
-        private async Task WaitTillServerModeReady(RestAPIClient restApiClient)
-        {
-            await WaitUntilHelper.WaitUntil(async () =>
-            {
-                SystemStatus status = SystemStatus.Error;
-                try
-                {
-                    status = (await restApiClient.HealthAsync()).Status;
-                }
-                catch (Exception)
-                {
-                }
-
-                return status == SystemStatus.Ready;
-            }, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
-        }
-
-        private async Task<CloudApplicationMetadata> GetAppSettingsFromCFTemplate(string cloudFormationTemplate, string stackName)
-        {
-            var templateMetadataReader = GetTemplateMetadataReader(cloudFormationTemplate);
-            return await templateMetadataReader.LoadCloudApplicationMetadata(stackName);
-        }
-
-        private async Task<string> StartDeploymentSession(RestAPIClient restClient, string projectPath)
-        {
-            var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
-            {
-                AwsRegion = _awsRegion,
-                ProjectPath = projectPath
-            });
-
-            var sessionId = startSessionOutput.SessionId;
-            Assert.NotNull(sessionId);
-            return sessionId;
-        }
-
-        private static async Task SetupSignalRConnection(string baseUrl, string sessionId, StringBuilder logOutput)
-        {
-            var signalRClient = new DeploymentCommunicationClient(baseUrl);
-            await signalRClient.JoinSession(sessionId);
-
-            AWS.Deploy.CLI.IntegrationTests.ServerModeTests.RegisterSignalRMessageCallbacks(signalRClient, logOutput);
-        }
-
-        private async Task<RecommendationSummary> GetRecommendationsAndSelectAppRunner(RestAPIClient restClient, string sessionId)
-        {
-            var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
-            Assert.NotEmpty(getRecommendationOutput.Recommendations);
-
-            var appRunnerRecommendation =
-                getRecommendationOutput.Recommendations.FirstOrDefault(x => string.Equals(x.RecipeId, "AspNetAppAppRunner"));
-            Assert.NotNull(appRunnerRecommendation);
-
-            await restClient.SetDeploymentTargetAsync(sessionId,
-                new SetDeploymentTargetInput
-                {
-                    NewDeploymentName = _stackName,
-                    NewDeploymentRecipeId = appRunnerRecommendation.RecipeId
-                });
-            return appRunnerRecommendation;
         }
 
         public void Dispose()

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/ServerModeUtilities.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/ServerModeUtilities.cs
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Amazon.Runtime;
+using AWS.Deploy.Common;
+using AWS.Deploy.Orchestration.Utilities;
+using AWS.Deploy.ServerMode.Client;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Utilities
+{
+    public static class ServerModeExtensions
+    {
+        public static async Task WaitTillServerModeReady(this RestAPIClient restApiClient)
+        {
+            await WaitUntilHelper.WaitUntil(async () =>
+            {
+                SystemStatus status = SystemStatus.Error;
+                try
+                {
+                    status = (await restApiClient.HealthAsync()).Status;
+                }
+                catch (Exception)
+                {
+                }
+
+                return status == SystemStatus.Ready;
+            }, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
+        }
+
+        public static async Task<string> StartDeploymentSession(this RestAPIClient restClient, string projectPath, string awsRegion)
+        {
+            var startSessionOutput = await restClient.StartDeploymentSessionAsync(new StartDeploymentSessionInput
+            {
+                AwsRegion = awsRegion,
+                ProjectPath = projectPath
+            });
+
+            var sessionId = startSessionOutput.SessionId;
+            Assert.NotNull(sessionId);
+            return sessionId;
+        }
+
+        public static async Task SetupSignalRConnection(string baseUrl, string sessionId, StringBuilder logOutput)
+        {
+            var signalRClient = new DeploymentCommunicationClient(baseUrl);
+            await signalRClient.JoinSession(sessionId);
+
+            ServerModeTests.RegisterSignalRMessageCallbacks(signalRClient, logOutput);
+        }
+
+        public static async Task<RecommendationSummary> GetRecommendationsAndSetDeploymentTarget(this RestAPIClient restClient, string sessionId, string recipeId, string stackName)
+        {
+            var getRecommendationOutput = await restClient.GetRecommendationsAsync(sessionId);
+            Assert.NotEmpty(getRecommendationOutput.Recommendations);
+
+            var beanstalkRecommendation =
+                getRecommendationOutput.Recommendations.FirstOrDefault(x => string.Equals(x.RecipeId, recipeId));
+            Assert.NotNull(beanstalkRecommendation);
+
+            await restClient.SetDeploymentTargetAsync(sessionId,
+                new SetDeploymentTargetInput
+                {
+                    NewDeploymentName = stackName,
+                    NewDeploymentRecipeId = beanstalkRecommendation.RecipeId
+                });
+            return beanstalkRecommendation;
+        }
+
+        public static async Task<CloudApplicationMetadata> GetAppSettingsFromCFTemplate(Mock<IAWSClientFactory> mockAWSClientFactory, Mock<IAmazonCloudFormation> mockCFClient, string cloudFormationTemplate, string stackName)
+        {
+            var templateMetadataReader = GetTemplateMetadataReader(mockAWSClientFactory, mockCFClient, cloudFormationTemplate);
+            return await templateMetadataReader.LoadCloudApplicationMetadata(stackName);
+        }
+
+        public static TemplateMetadataReader GetTemplateMetadataReader(Mock<IAWSClientFactory> mockAWSClientFactory, Mock<IAmazonCloudFormation> mockCFClient, string templateBody)
+        {
+            var templateMetadataReader = new TemplateMetadataReader(mockAWSClientFactory.Object);
+            var cfResponse = new GetTemplateResponse();
+            cfResponse.TemplateBody = templateBody;
+            mockAWSClientFactory.Setup(x => x.GetAWSClient<IAmazonCloudFormation>(It.IsAny<string>())).Returns(mockCFClient.Object);
+            mockCFClient.Setup(x => x.GetTemplateAsync(It.IsAny<GetTemplateRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(cfResponse);
+            return templateMetadataReader;
+        }
+
+        public static Task<AWSCredentials> ResolveCredentials()
+        {
+            var testCredentials = FallbackCredentialsFactory.GetCredentials();
+            return Task.FromResult<AWSCredentials>(testCredentials);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5920

*Description of changes:*
* Added a validation status and validation message to option setting items
* The validators of dependent settings are now run when that setting is set
* Updated server mode to return the validation object


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
