### PR TITLE
feat: only run validators if setting is displayable

### DIFF
--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -75,7 +75,7 @@ namespace AWS.Deploy.Orchestration
         public async Task SetOptionSettingValue(Recommendation recommendation, OptionSettingItem optionSettingItem, object value, bool skipValidation = false)
         {
             IOptionSettingItemValidator[] validators = new IOptionSettingItemValidator[0];
-            if (!skipValidation)
+            if (!skipValidation && IsOptionSettingDisplayable(recommendation, optionSettingItem))
                 validators = _validatorFactory.BuildValidators(optionSettingItem);
             
             await optionSettingItem.SetValue(this, value, validators, recommendation, skipValidation);

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
@@ -127,9 +127,11 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
 
+            var createNew = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.CreateNew");
             var subnets = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.Subnets");
             var securityGroups = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.SecurityGroups");
 
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, createNew, true);
             await Assert.ThrowsAsync<ValidationFailedException>(async () => await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, subnets, new SortedSet<string>(){ "subnet1" }));
             await Assert.ThrowsAsync<ValidationFailedException>(async () => await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, securityGroups, new SortedSet<string>(){ "securityGroup1" }));
         }


### PR DESCRIPTION
*Description of changes:*
When setting an option setting value, all validators are run for that setting and its children. This change changes this behavior to only run the validators for the displayable children as they are the only ones applicable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
