### PR TITLE
Temporarily disable GitHub action to inovke Codebuiild job

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Description of changes:*

Temporarily disables the GitHub PR Action that uses a Code Build job.  Code Build job is being upgraded and needs 
https://github.com/aws/aws-dotnet-deploy/pull/551/.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
