### PR TITLE
ci: add integration test PR check codebuild project concurrency limit

### DIFF
--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -87,6 +87,7 @@ Resources:
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
+      ConcurrentBuildLimit: 1
       Name: !Sub ${CodeBuildProjectName}
       ServiceRole: !GetAtt CodeBuildProjectRole.Arn
       Environment:


### PR DESCRIPTION
*Description of changes:*
PR checks are failing because of CF throttling since we are running multiple checks at once. This change will add a concurrency limit of 1 for the codebuild project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
