### PR TITLE
feat: persist invalid value in validation object of option setting item

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -102,18 +102,26 @@ namespace AWS.Deploy.Common.Recipes
                     var result = await validator.Validate(valueOverride);
                     if (!result.IsValid)
                     {
-                        throw new ValidationFailedException(DeployToolErrorCode.OptionSettingItemValueValidationFailed,
-                            result.ValidationFailedMessage?.Trim() ?? $"The value '{valueOverride}' is invalid for option setting '{Name}'.");
+                        Validation.ValidationStatus = ValidationStatus.Invalid;
+                        Validation.ValidationMessage = result.ValidationFailedMessage?.Trim() ?? $"The value '{valueOverride}' is invalid for option setting '{Name}'.";
+                        Validation.InvalidValue = valueOverride;
+                        throw new ValidationFailedException(DeployToolErrorCode.OptionSettingItemValueValidationFailed, Validation.ValidationMessage);
                     }
                 }
-                
-                Validation.ValidationStatus = ValidationStatus.Valid;
-                Validation.ValidationMessage = string.Empty;
             }
 
             if (AllowedValues != null && AllowedValues.Count > 0 && valueOverride != null &&
                 !AllowedValues.Contains(valueOverride.ToString() ?? ""))
-                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, $"Invalid value for option setting item '{Name}'");
+            {
+                Validation.ValidationStatus = ValidationStatus.Invalid;
+                Validation.ValidationMessage = $"Invalid value for option setting item '{Name}'";
+                Validation.InvalidValue = valueOverride;
+                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidValueForOptionSettingItem, Validation.ValidationMessage);
+            }
+
+            Validation.ValidationStatus = ValidationStatus.Valid;
+            Validation.ValidationMessage = string.Empty;
+            Validation.InvalidValue = null;
 
             if (valueOverride is bool || valueOverride is int || valueOverride is long || valueOverride is double || valueOverride is Dictionary<string, string> || valueOverride is SortedSet<string>)
             {

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingValidation.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingValidation.cs
@@ -11,8 +11,21 @@ namespace AWS.Deploy.Common.Recipes
 
     public class OptionSettingValidation
     {
+        /// <summary>
+        /// Determines whether the current value as set by the user is in a valid or invalid state.
+        /// </summary>
         public ValidationStatus ValidationStatus { get; set; } = ValidationStatus.Valid;
 
+        /// <summary>
+        /// The validation message in the case where the value set by the user is an invalid one.
+        /// This is empty in the case where the value set by the user is a valid one.
+        /// </summary>
         public string ValidationMessage { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The value last attempted to be set by the user in the case where that value is invalid.
+        /// This is null in the case where the value is valid.
+        /// </summary>
+        public object? InvalidValue { get; set; }
     }
 }

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -38,6 +38,7 @@ namespace AWS.Deploy.Orchestration
                 {
                     optionSetting.Validation.ValidationStatus = ValidationStatus.Valid;
                     optionSetting.Validation.ValidationMessage = string.Empty;
+                    optionSetting.Validation.InvalidValue = null;
                     continue;
                 }
 
@@ -48,15 +49,23 @@ namespace AWS.Deploy.Orchestration
                     .Where(x => !x.IsValid)
                     .ToList());
 
-                if (settingValidatorFailedResults.Any())
+                // Only update the validation object if there is no InvalidValue set.
+                // In the case where a user tries to set an Invalid Value, this is the value that will be on the UI.
+                // We don't want to update that value in the background if it is triggered by a dependent setting validation
+                // since it won't be reflected on the UI.
+                if (optionSetting.Validation.InvalidValue == null)
                 {
-                    optionSetting.Validation.ValidationStatus = ValidationStatus.Invalid;
-                    optionSetting.Validation.ValidationMessage = string.Join(Environment.NewLine, settingValidatorFailedResults.Select(x => x.ValidationFailedMessage)).Trim();
-                }
-                else
-                {
-                    optionSetting.Validation.ValidationStatus = ValidationStatus.Valid;
-                    optionSetting.Validation.ValidationMessage = string.Empty;
+                    if (settingValidatorFailedResults.Any())
+                    {
+                        optionSetting.Validation.ValidationStatus = ValidationStatus.Invalid;
+                        optionSetting.Validation.ValidationMessage = string.Join(Environment.NewLine, settingValidatorFailedResults.Select(x => x.ValidationFailedMessage)).Trim();
+                        optionSetting.Validation.InvalidValue = optionSettingValue;
+                    }
+                    else
+                    {
+                        optionSetting.Validation.ValidationStatus = ValidationStatus.Valid;
+                        optionSetting.Validation.ValidationMessage = string.Empty;
+                    }
                 }
 
                 settingValidatorFailedResults.AddRange(RunOptionSettingValidators(recommendation, optionSetting.ChildOptionSettings));

--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -2006,54 +2006,77 @@ namespace AWS.Deploy.ServerMode.Client
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.1.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class OptionSettingItemSummary 
     {
+        /// <summary>The unique id of setting. This value will be persisted in other config files so its value should never change once a recipe is released.</summary>
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
     
+        /// <summary>The fully qualified id of the setting that includes the Id and all of the parent's Ids.
+        /// This helps easily reference the Option Setting without context of the parent setting.</summary>
         [Newtonsoft.Json.JsonProperty("fullyQualifiedId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string FullyQualifiedId { get; set; }
     
+        /// <summary>The display friendly name of the setting.</summary>
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; }
     
+        /// <summary>The category for the setting. This value must match an id field in the list of categories.</summary>
         [Newtonsoft.Json.JsonProperty("category", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Category { get; set; }
     
+        /// <summary>The description of what the setting is used for.</summary>
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Description { get; set; }
     
+        /// <summary>The value used for the recipe if it is set by the user.</summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Value { get; set; }
     
+        /// <summary>The type of primitive value expected for this setting.
+        /// For example String, Int</summary>
         [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Type { get; set; }
     
+        /// <summary>Hint the the UI what type of setting this is optionally add additional UI features to select a value.
+        /// For example a value of BeanstalkApplication tells the UI it can display the list of available Beanstalk applications for the user to pick from.</summary>
         [Newtonsoft.Json.JsonProperty("typeHint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string TypeHint { get; set; }
     
+        /// <summary>Type hint additional data required to facilitate handling of the option setting.</summary>
         [Newtonsoft.Json.JsonProperty("typeHintData", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, object> TypeHintData { get; set; }
     
+        /// <summary>UI can use this to reduce the amount of settings to show to the user when confirming the recommendation. This can make it so the user sees only the most important settings
+        /// they need to know about before deploying.</summary>
         [Newtonsoft.Json.JsonProperty("advanced", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool Advanced { get; set; }
     
+        /// <summary>Indicates whether the setting can be edited</summary>
         [Newtonsoft.Json.JsonProperty("readOnly", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool ReadOnly { get; set; }
     
+        /// <summary>Indicates whether the setting is visible/displayed on the UI</summary>
         [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool Visible { get; set; }
     
+        /// <summary>Indicates whether the setting can be displayed as part of the settings summary of the previous deployment.</summary>
         [Newtonsoft.Json.JsonProperty("summaryDisplayable", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool SummaryDisplayable { get; set; }
     
+        /// <summary>The allowed values for the setting.</summary>
         [Newtonsoft.Json.JsonProperty("allowedValues", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<string> AllowedValues { get; set; }
     
+        /// <summary>The value mapping for allowed values. The key of the dictionary is what is sent to services
+        /// and the value is the display value shown to users.</summary>
         [Newtonsoft.Json.JsonProperty("valueMapping", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> ValueMapping { get; set; }
     
+        /// <summary>Child option settings for AWS.Deploy.Common.Recipes.OptionSettingValueType.Object value types
+        /// AWS.Deploy.CLI.ServerMode.Models.OptionSettingItemSummary.ChildOptionSettings value depends on the values of AWS.Deploy.CLI.ServerMode.Models.OptionSettingItemSummary.ChildOptionSettings</summary>
         [Newtonsoft.Json.JsonProperty("childOptionSettings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<OptionSettingItemSummary> ChildOptionSettings { get; set; }
     
+        /// <summary>The validation state of the setting that contains the validation status and message.</summary>
         [Newtonsoft.Json.JsonProperty("validation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public OptionSettingValidation Validation { get; set; }
     
@@ -2069,6 +2092,9 @@ namespace AWS.Deploy.ServerMode.Client
     
         [Newtonsoft.Json.JsonProperty("validationMessage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ValidationMessage { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("invalidValue", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object InvalidValue { get; set; }
     
     
     }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
@@ -79,12 +79,15 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 var applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
                 Assert.Equal(ValidationStatus.Valid, applicationIAMRole.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(applicationIAMRole.Validation.ValidationMessage));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
                 var validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
                 Assert.Equal(ValidationStatus.Valid, validCreateNew.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(validCreateNew.Validation.ValidationMessage));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
                 var validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
                 Assert.Equal(ValidationStatus.Valid, validRoleArn.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(validRoleArn.Validation.ValidationMessage));
+                Assert.Null(validRoleArn.Validation.InvalidValue);
 
                 var applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
                 {
@@ -97,13 +100,17 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
                 Assert.Equal(ValidationStatus.Valid, applicationIAMRole.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(applicationIAMRole.Validation.ValidationMessage));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
                 validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
                 Assert.Equal(ValidationStatus.Valid, validCreateNew.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(validCreateNew.Validation.ValidationMessage));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
                 validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
                 Assert.Equal(ValidationStatus.Invalid, validRoleArn.Validation.ValidationStatus);
                 Assert.Equal("Invalid IAM Role ARN. The ARN should contain the arn:[PARTITION]:iam namespace, followed by the account ID, and then the resource path. For example - arn:aws:iam::123456789012:role/S3Access is a valid IAM Role ARN. For more information visit https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns",
                     validRoleArn.Validation.ValidationMessage);
+                Assert.NotNull(validRoleArn.Validation.InvalidValue);
+                Assert.True(string.IsNullOrEmpty(validRoleArn.Validation.InvalidValue.ToString()));
 
                 applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
                 {
@@ -116,12 +123,103 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
                 Assert.Equal(ValidationStatus.Valid, applicationIAMRole.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(applicationIAMRole.Validation.ValidationMessage));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
                 validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
                 Assert.Equal(ValidationStatus.Valid, validCreateNew.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(validCreateNew.Validation.ValidationMessage));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
                 validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
                 Assert.Equal(ValidationStatus.Valid, validRoleArn.Validation.ValidationStatus);
                 Assert.True(string.IsNullOrEmpty(validRoleArn.Validation.ValidationMessage));
+                Assert.Null(validRoleArn.Validation.InvalidValue);
+            }
+            finally
+            {
+                cancelSource.Cancel();
+                _stackName = null;
+            }
+        }
+
+        [Fact]
+        public async Task SettingInvalidValue()
+        {
+            _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
+            var portNumber = 4022;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await restClient.WaitTillServerModeReady();
+
+                var sessionId = await restClient.StartDeploymentSession(projectPath, _awsRegion);
+
+                var logOutput = new StringBuilder();
+                await ServerModeExtensions.SetupSignalRConnection(baseUrl, sessionId, logOutput);
+
+                var beanstalkRecommendation = await restClient.GetRecommendationsAndSetDeploymentTarget(sessionId, "AspNetAppElasticBeanstalkLinux", _stackName);
+
+                var applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
+                var validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
+                var validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.Null(validRoleArn.Validation.InvalidValue);
+
+                var applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"ApplicationIAMRole.CreateNew", "false"},
+                        {"ApplicationIAMRole.RoleArn", "fakeArn"}
+                    }
+                });
+
+                applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
+                validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
+                validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.NotNull(validRoleArn.Validation.InvalidValue);
+                Assert.Equal("fakeArn", validRoleArn.Validation.InvalidValue);
+
+                applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"ApplicationIAMRole.CreateNew", "true"}
+                    }
+                });
+
+                applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
+                validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
+                validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.Null(validRoleArn.Validation.InvalidValue);
+
+                applyConfigResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"ApplicationIAMRole.RoleArn", "fakeArn"}
+                    }
+                });
+
+                applicationIAMRole = (await restClient.GetConfigSettingsAsync(sessionId)).OptionSettings.First(x => x.Id.Equals("ApplicationIAMRole"));
+                Assert.Null(applicationIAMRole.Validation.InvalidValue);
+                validCreateNew = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("CreateNew"));
+                Assert.Null(validCreateNew.Validation.InvalidValue);
+                validRoleArn = applicationIAMRole.ChildOptionSettings.First(x => x.Id.Equals("RoleArn"));
+                Assert.Null(validRoleArn.Validation.InvalidValue);
             }
             finally
             {


### PR DESCRIPTION
*Description of changes:*
Persist invalid value set by the user in the validation object of the option setting item. This is used mainly in the toolkit from server mode where invalid values can remain on the UI until users replace them with valid settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
