### PR TITLE
fix: Add validation for EC2 instance types for Elastic Beanstalk recipes

### DIFF
--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -21,11 +21,31 @@ using Amazon.CloudControlApi.Model;
 
 namespace AWS.Deploy.Common.Data
 {
+    /// <summary>
+    /// Retrieves AWS resources
+    /// </summary>
+    /// <remarks>
+    /// This is meant to be a lightweight wrapper around the SDK,
+    /// business logic should generally be implemented in the caller.
+    /// </remarks>
     public interface IAWSResourceQueryer
     {
         Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier);
         Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName);
+
+        /// <summary>
+        /// Lists all of the EC2 instance types available in the deployment region without any filtering
+        /// </summary>
+        /// <returns>List of <see cref="InstanceTypeInfo"/></returns>
         Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes();
+
+        /// <summary>
+        /// Describes a single EC2 instance type
+        /// </summary>
+        /// <param name="instanceType">Instance type (for example, "t2.micro")</param>
+        /// <returns>The first <see cref="InstanceTypeInfo"/> if the specified type exists</returns>
+        Task<InstanceTypeInfo?> DescribeInstanceType(string instanceType);
+
         Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
         Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
         Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentName);

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -40,6 +40,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="StringLengthValidator"/>
         /// </summary>
-        StringLength
+        StringLength,
+        /// <summary>
+        /// Must be paired with <see cref="InstanceTypeValidator"/>
+        /// </summary>
+        InstanceType
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/InstanceTypeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/InstanceTypeValidator.cs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using Amazon.EC2;
+using Amazon.EC2.Model;
+using AWS.Deploy.Common.Data;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that a given EC2 instance is valid for the deployment region
+    /// </summary>
+    public class InstanceTypeValidator : IOptionSettingItemValidator
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public InstanceTypeValidator(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        {
+            var rawInstanceType = Convert.ToString(input);
+            InstanceTypeInfo? instanceTypeInfo;
+
+            if (string.IsNullOrEmpty(rawInstanceType))
+            {
+                return ValidationResult.Valid();
+            }
+
+            try
+            {
+                instanceTypeInfo = await _awsResourceQueryer.DescribeInstanceType(rawInstanceType);
+            }
+            catch (ResourceQueryException ex)
+            {
+                // Check for the expected exception if the provided instance type is invalid
+                if (ex.InnerException is AmazonEC2Exception ec2Exception &&
+                    string.Equals(ec2Exception.ErrorCode, "InvalidInstanceType", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    instanceTypeInfo = null;
+                }
+                else // Anything else is unexpected, so proceed with usual exception handling
+                {
+                   throw ex;
+                }
+            }
+            if (instanceTypeInfo != null)
+            {
+                return ValidationResult.Valid();
+            }
+            else
+            {
+                return ValidationResult.Failed($"The specified instance type {rawInstanceType} does not exist in the deployment region.");
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -54,7 +54,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.DotnetPublishArgs, typeof(DotnetPublishArgsValidator) },
             { OptionSettingItemValidatorList.ExistingResource, typeof(ExistingResourceValidator) },
             { OptionSettingItemValidatorList.FileExists, typeof(FileExistsValidator) },
-            { OptionSettingItemValidatorList.StringLength, typeof(StringLengthValidator) }
+            { OptionSettingItemValidatorList.StringLength, typeof(StringLengthValidator) },
+            { OptionSettingItemValidatorList.InstanceType, typeof(InstanceTypeValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -167,6 +167,22 @@ namespace AWS.Deploy.Orchestration.Data
             });
         }
 
+        public async Task<InstanceTypeInfo?> DescribeInstanceType(string instanceType)
+        {
+            var ec2Client = _awsClientFactory.GetAWSClient<IAmazonEC2>();
+
+            var request = new DescribeInstanceTypesRequest
+            {
+                InstanceTypes = new List<string> { instanceType }
+            };
+
+            return await HandleException(async () =>
+            {
+                var response = await ec2Client.DescribeInstanceTypesAsync(request);
+                return response.InstanceTypes.FirstOrDefault();
+            });
+        }
+
         public async Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors()
         {
             var appRunnerClient = _awsClientFactory.GetAWSClient<Amazon.AppRunner.IAmazonAppRunner>();

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -250,7 +250,12 @@
             "Type": "String",
             "TypeHint": "InstanceType",
             "AdvancedSetting": true,
-            "Updatable": true
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "InstanceType"
+                }
+            ]
         },
         {
             "Id": "EnvironmentType",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -610,7 +610,8 @@
                                     "DotnetPublishArgs",
                                     "ExistingResource",
                                     "FileExists",
-                                    "StringLength"
+                                    "StringLength",
+                                    "InstanceType"
                                 ]
                             }
                         },

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -58,6 +58,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
+        public Task<InstanceTypeInfo> DescribeInstanceType(string instanceType) => throw new NotImplementedException();
         public Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
         public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -83,6 +83,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<string>> ListOfSNSTopicArns() => throw new NotImplementedException();
         public Task<List<Amazon.S3.Model.S3Bucket>> ListOfS3Buckets() => throw new NotImplementedException();
         public Task<List<InstanceTypeInfo>> ListOfAvailableInstanceTypes() => throw new NotImplementedException();
+        public Task<InstanceTypeInfo> DescribeInstanceType(string instanceType) => throw new NotImplementedException();
         public Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticBeanstalk.Model.Tag>> ListElasticBeanstalkResourceTags(string resourceArn) => throw new NotImplementedException();
         public Task<List<ConfigurationOptionSetting>> GetBeanstalkEnvironmentConfigurationSettings(string environmentId) => throw new NotImplementedException();


### PR DESCRIPTION
*Issue #, if available:* DOTNET-5894

*Description of changes:* This adds an OptionSettingItemValidator for the EC2 Instance Type on the Elastic Beanstalk recipe.

### Before
A user in the VS Toolkit could skip the modal dialog to select from the full list, they are able to enter freetext which may be invalid. This would attempt to deploy and then fail.
![image](https://user-images.githubusercontent.com/1170880/171448936-77f56175-4d63-4a0d-9639-2a0492df01ee.png)

### After

![image](https://user-images.githubusercontent.com/1170880/171448337-4f24455a-df12-49df-9dbe-d76a99b8e460.png)


This also validates that a seemingly well-formed instance type that is not available in the deployment region (here ap-northeast-3):
![image](https://user-images.githubusercontent.com/1170880/171448017-51c75ff9-b80d-4ddb-b209-885b193a131a.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
