### PR TITLE
ci: remove push from AWS CodeBuild CI workflow

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -2,7 +2,6 @@ name: AWS CodeBuild CI
 
 on:
   pull_request:
-  push:
     branches:
       - main
       - dev


### PR DESCRIPTION
*Description of changes:*
Having the AWS CodeBuild CI workflow triggered on push and pull_request causes 2 CodeBuild jobs to be run when a release PR is created. 1 of the 2 PR checks are destined to fail since the concurrency limit for that project is 1. This PR reverts the triggers to what they were like before the latest OIDC rework.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
