### PR TITLE
feat: Add string length validator to ECR repository name

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -36,6 +36,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="FileExistsValidator"/>
         /// </summary>
-        FileExists
+        FileExists,
+        /// <summary>
+        /// Must be paired with <see cref="StringLengthValidator"/>
+        /// </summary>
+        StringLength
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/StringLengthValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/StringLengthValidator.cs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that an OptionSettingItem of type string satisifes the required length constraints
+    /// </summary>
+    public class StringLengthValidator : IOptionSettingItemValidator
+    {
+        public int MinLength { get; set; } = 0;
+        public int MaxLength { get; set; } = 1000;
+        public string ValidationFailedMessage { get; set; } = "Invalid value. Number of characters must be between {{min}} and {{max}}";
+
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        {
+            var inputString = input?.ToString() ?? string.Empty;
+            var stringLength = inputString.Length;
+
+            if (stringLength < MinLength || stringLength > MaxLength)
+            {
+                var message = ValidationFailedMessage
+                                    .Replace("{{min}}", MinLength.ToString())
+                                    .Replace("{{max}}", MaxLength.ToString());
+                
+                return ValidationResult.FailedAsync(message);
+            }
+
+            return ValidationResult.ValidAsync();
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -53,7 +53,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.DockerBuildArgs, typeof(DockerBuildArgsValidator) },
             { OptionSettingItemValidatorList.DotnetPublishArgs, typeof(DotnetPublishArgsValidator) },
             { OptionSettingItemValidatorList.ExistingResource, typeof(ExistingResourceValidator) },
-            { OptionSettingItemValidatorList.FileExists, typeof(FileExistsValidator) }
+            { OptionSettingItemValidatorList.FileExists, typeof(FileExistsValidator) },
+            { OptionSettingItemValidatorList.StringLength, typeof(StringLengthValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -63,9 +63,16 @@
             "Validators": [
                 {
                     "ValidatorType": "Regex",
-                    "Configuration" : {
+                    "Configuration": {
                         "Regex": "^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$",
                         "ValidationFailedMessage": "Invalid ECR repository Name. The ECR repository name can only contain lowercase letters, numbers, hyphens(-), dots(.), underscores(_) and forward slashes (/). For more information visit https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html#cfn-ecr-repository-repositoryname"
+                    }
+                },
+                {
+                    "ValidatorType": "StringLength",
+                    "Configuration": {
+                        "MinLength": 2,
+                        "MaxLength": 256
                     }
                 }
             ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -609,7 +609,8 @@
                                     "DockerBuildArgs",
                                     "DotnetPublishArgs",
                                     "ExistingResource",
-                                    "FileExists"
+                                    "FileExists",
+                                    "StringLength"
                                 ]
                             }
                         },
@@ -669,6 +670,28 @@
                                     "properties": {
                                         "Configuration": {
                                             "properties": {
+                                                "ValidationFailedMessage": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": { "ValidatorType": { "const": "StringLength" } }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "Configuration": {
+                                            "properties": {
+                                                "MinLength": {
+                                                    "type": "integer"
+                                                },
+                                                "MaxLength": {
+                                                    "type": "integer"
+                                                },
                                                 "ValidationFailedMessage": {
                                                     "type": "string"
                                                 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -157,10 +157,15 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         [InlineData("MyRepo", false)] // cannot contain uppercase letters
         [InlineData("myrepo123@", false)] // cannot contain @
         [InlineData("myrepo123.a//b", false)] // cannot contain consecutive slashes.
+        [InlineData("aa", true)]
+        [InlineData("a", false)] //length cannot be less than 2
+        [InlineData("", false)] // length cannot be less than 2
+        [InlineData("reporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporeporepo", false)] // cannot be greater than 256 characters
         public async Task ECRRepositoryNameValidationTest(string value, bool isValid)
         {
             var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
             optionSettingItem.Validators.Add(GetRegexValidatorConfig("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$"));
+            optionSettingItem.Validators.Add(GetStringLengthValidatorConfig(2, 256));
             await Validate(optionSettingItem, value, isValid);
         }
 
@@ -265,6 +270,20 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 }
             };
             return rangeValidatorConfig;
+        }
+
+        private OptionSettingItemValidatorConfig GetStringLengthValidatorConfig(int minLength, int maxLength)
+        {
+            var stringLengthValidatorConfig = new OptionSettingItemValidatorConfig
+            {
+                ValidatorType = OptionSettingItemValidatorList.StringLength,
+                Configuration = new StringLengthValidator
+                {
+                    MinLength = minLength,
+                    MaxLength = maxLength
+                }
+            };
+            return stringLengthValidatorConfig;
         }
 
         private async Task Validate<T>(OptionSettingItem optionSettingItem, T value, bool isValid)


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5919

*Description of changes:*
This PR adds a new validator type `StringLengthValidator` and imposes it on ECR repository names.

![image](https://user-images.githubusercontent.com/36622308/171736762-88502537-36fd-4b6f-b1b0-8ac92ef43d07.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
