### PR TITLE
fix: subnets and security groups are displayed without selected vpc id in app runner

### DIFF
--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -68,16 +68,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.ServerMode.Clien
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerServiceExample", "testapps\WorkerServiceExample\WorkerServiceExample.csproj", "{7C330493-9BF7-4DB6-815B-807C08500AC6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiNET6", "testapps\WebApiNET6\WebApiNET6.csproj", "{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiNET6", "testapps\WebApiNET6\WebApiNET6.csproj", "{B2EA65BD-9FFE-4452-B2DC-574EB1A9FAF1}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{3f7a5ca6-7178-4dbf-8dad-6a63684c7a8e}*SharedItemsImports = 5
-		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{5f8ec972-781d-4a82-a73f-36a97281b0d5}*SharedItemsImports = 5
-		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{8a351cc0-70c0-4412-b45e-358606251512}*SharedItemsImports = 5
-		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{f2266c44-c8c5-45ad-aa9b-44f8825bdf63}*SharedItemsImports = 13
-		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{fae4d4c5-9107-4622-a050-e30cc70be754}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -213,5 +206,13 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{3aac19a6-02e8-45d0-bdd0-cad0fbe15f64}*SharedItemsImports = 5
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{3f7a5ca6-7178-4dbf-8dad-6a63684c7a8e}*SharedItemsImports = 5
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{5f8ec972-781d-4a82-a73f-36a97281b0d5}*SharedItemsImports = 5
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{8a351cc0-70c0-4412-b45e-358606251512}*SharedItemsImports = 5
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{f2266c44-c8c5-45ad-aa9b-44f8825bdf63}*SharedItemsImports = 13
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{fae4d4c5-9107-4622-a050-e30cc70be754}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerBuildArgsCommand.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: async buildArgs => await ValidateBuildArgs(buildArgs, recommendation))
+                    validators: async buildArgs => await ValidateBuildArgs(buildArgs, recommendation, optionSetting))
                 .ToString()
                 .Replace("\"", "\"\"");
 
@@ -39,23 +39,9 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             return Task.FromResult<object>(settingValue);
         }
 
-        /// <summary>
-        /// This method will be invoked to set the Docker build arguments in the deployment bundle
-        /// when it is specified as part of the user provided configuration file.
-        /// </summary>
-        /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
-        /// <param name="dockerBuildArgs">Arguments to be passed when performing a Docker build</param>
-        public async Task OverrideValue(Recommendation recommendation, string dockerBuildArgs)
+        private async Task<string> ValidateBuildArgs(string buildArgs, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
-            var resultString = await ValidateBuildArgs(dockerBuildArgs, recommendation);
-            if (!string.IsNullOrEmpty(resultString))
-                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerBuildArgs, resultString);
-            recommendation.DeploymentBundle.DockerBuildArgs = dockerBuildArgs;
-        }
-
-        private async Task<string> ValidateBuildArgs(string buildArgs, Recommendation recommendation)
-        {
-            var validationResult = await new DockerBuildArgsValidator().Validate(buildArgs, recommendation);
+            var validationResult = await new DockerBuildArgsValidator().Validate(buildArgs, recommendation, optionSettingItem);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerExecutionDirectoryCommand.cs
@@ -35,24 +35,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: async executionDirectory => await ValidateExecutionDirectory(executionDirectory, recommendation));
+                    validators: async executionDirectory => await ValidateExecutionDirectory(executionDirectory, recommendation, optionSetting));
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = settingValue;
             return Task.FromResult<object>(settingValue);
-        }
-
-        /// <summary>
-        /// This method will be invoked to set the Docker execution directory in the deployment bundle
-        /// when it is specified as part of the user provided configuration file.
-        /// </summary>
-        /// <param name="recommendation">The selected recommendation used for deployment <see cref="Recommendation"/></param>
-        /// <param name="executionDirectory">The directory specified for Docker execution.</param>
-        public async Task OverrideValue(Recommendation recommendation, string executionDirectory)
-        {
-            var resultString = await ValidateExecutionDirectory(executionDirectory, recommendation);
-            if (!string.IsNullOrEmpty(resultString))
-                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDockerExecutionDirectory, resultString);
-            recommendation.DeploymentBundle.DockerExecutionDirectory = executionDirectory;
         }
 
         /// <summary>
@@ -61,10 +47,11 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         /// </summary>
         /// <param name="executionDirectory">Proposed Docker execution directory</param>
         /// <param name="recommendation">The selected recommendation settings used for deployment</param>
+        /// <param name="optionSettingItem">The selected option setting item</param>
         /// <returns>Empty string if the directory is valid, an error message if not</returns>
-        private async Task<string> ValidateExecutionDirectory(string executionDirectory, Recommendation recommendation)
+        private async Task<string> ValidateExecutionDirectory(string executionDirectory, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
-            var validationResult = await new DirectoryExistsValidator(_directoryManager).Validate(executionDirectory, recommendation);
+            var validationResult = await new DirectoryExistsValidator(_directoryManager).Validate(executionDirectory, recommendation, optionSettingItem);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishArgsCommand.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                     _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting),
                     allowEmpty: true,
                     resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? "",
-                    validators: async publishArgs => await ValidateDotnetPublishArgs(publishArgs, recommendation))
+                    validators: async publishArgs => await ValidateDotnetPublishArgs(publishArgs, recommendation, optionSetting))
                 .ToString()
                 .Replace("\"", "\"\"");
 
@@ -40,23 +40,9 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             return Task.FromResult<object>(settingValue);
         }
 
-        /// <summary>
-        /// This method will be invoked to set any additional Dotnet build arguments in the deployment bundle
-        /// when it is specified as part of the user provided configuration file.
-        /// </summary>
-        /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
-        /// <param name="publishArgs">The user specified Dotnet build arguments.</param>
-        public async Task OverrideValue(Recommendation recommendation, string publishArgs)
+        private async Task<string> ValidateDotnetPublishArgs(string publishArgs, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
-            var resultString = await ValidateDotnetPublishArgs(publishArgs, recommendation);
-            if (!string.IsNullOrEmpty(resultString))
-                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidDotnetPublishArgs, resultString);
-            recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments = publishArgs.Replace("\"", "\"\"");
-        }
-
-        private async Task<string> ValidateDotnetPublishArgs(string publishArgs, Recommendation recommendation)
-        {
-            var validationResult = await new DotnetPublishArgsValidator().Validate(publishArgs, recommendation);
+            var validationResult = await new DotnetPublishArgsValidator().Validate(publishArgs, recommendation, optionSettingItem);
 
             if (validationResult.IsValid)
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishBuildConfigurationCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishBuildConfigurationCommand.cs
@@ -33,16 +33,5 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = settingValue;
             return Task.FromResult<object>(settingValue);
         }
-
-        /// <summary>
-        /// This method will be invoked to set the Dotnet build configuration in the deployment bundle
-        /// when it is specified as part of the user provided configuration file.
-        /// </summary>
-        /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
-        /// <param name="configuration">The user specified Dotnet build configuration.</param>
-        public void Overridevalue(Recommendation recommendation, string configuration)
-        {
-            recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = configuration;
-        }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishSelfContainedBuildCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetPublishSelfContainedBuildCommand.cs
@@ -29,16 +29,5 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var result = answer == YesNo.Yes ? "true" : "false";
             return Task.FromResult<object>(result);
         }
-
-        /// <summary>
-        /// This method will be invoked to indiciate if this is a self-contained build in the deployment bundle
-        /// when it is specified as part of the user provided configuration file.
-        /// </summary>
-        /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
-        /// <param name="publishSelfContainedBuild">The user specified value to indicate if this is a self-contained build.</param>
-        public void OverrideValue(Recommendation recommendation, bool publishSelfContainedBuild)
-        {
-            recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = publishSelfContainedBuild;
-        }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/FilePathCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/FilePathCommand.cs
@@ -50,20 +50,5 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
             return Task.FromResult<object>(userFilePath);
         }
-
-        /// <summary>
-        /// This method will be invoked to set a file path setting in the deployment bundle
-        /// when it is specified as part of the user provided configuration file.
-        /// </summary>
-        /// <param name="recommendation">The selected recommendation settings used for deployment <see cref="Recommendation"/></param>
-        /// <param name="filePath">File path entered by the user</param>
-        public async Task OverrideValue(Recommendation recommendation, string filePath)
-        {
-            var validator = new FileExistsValidator(_fileManager);
-            var validationResult = await (validator as IOptionSettingItemValidator).Validate(filePath, recommendation);
-
-            if (!validationResult.IsValid)
-                throw new InvalidOverrideValueException(DeployToolErrorCode.InvalidFilePath, validationResult.ValidationFailedMessage ?? validator.ValidationFailedMessage);
-        }
     }
 }

--- a/src/AWS.Deploy.CLI/ConsoleUtilities.cs
+++ b/src/AWS.Deploy.CLI/ConsoleUtilities.cs
@@ -99,7 +99,12 @@ namespace AWS.Deploy.CLI
                 }
                 else if (selectedOperation.Equals(NOOP))
                 {
-                    break;
+                    if (userInputConfiguration.CanBeEmpty || currentOptionSettingValue.Any())
+                        break;
+                    else
+                    {
+                        _interactiveService.WriteErrorLine("The list cannot be empty. You must specify at least 1 value.");
+                    }
                 }
             }
 

--- a/src/AWS.Deploy.CLI/TypeHintResponses/VPCConnectorTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/VPCConnectorTypeHintResponse.cs
@@ -13,6 +13,7 @@ namespace AWS.Deploy.CLI.TypeHintResponses
     public class VPCConnectorTypeHintResponse : IDisplayable
     {
         public string? VpcConnectorId { get; set; }
+        public bool UseVPCConnector { get; set; }
         public bool CreateNew { get; set; }
         public string? VpcId { get; set; }
         public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -30,6 +30,7 @@ namespace AWS.Deploy.Common.Data
     /// </remarks>
     public interface IAWSResourceQueryer
     {
+        Task<Vpc> GetDefaultVpc();
         Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier);
         Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName);
 

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -101,7 +101,7 @@ namespace AWS.Deploy.Common.Recipes
             {
                 foreach (var validator in validators)
                 {
-                    var result = await validator.Validate(valueOverride, recommendation);
+                    var result = await validator.Validate(valueOverride, recommendation, this);
                     if (!result.IsValid)
                     {
                         Validation.ValidationStatus = ValidationStatus.Invalid;

--- a/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/IOptionSettingItemValidator.cs
@@ -17,7 +17,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         /// <param name="input">Raw input for an option</param>
         /// <param name="recommendation">Selected recommendation, which may be used if the validator needs to consider properties other than itself</param>
+        /// <param name="optionSettingItem">Selected option setting item, which may be used if the validator needs to consider properties other than itself</param>
         /// <returns>Whether or not the input is valid</returns>
-        Task<ValidationResult> Validate(object input, Recommendation recommendation);
+        Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DirectoryExistsValidator.cs
@@ -23,8 +23,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// This can be either an absolute path, or a path relative to the project directory.
         /// </summary>
         /// <param name="input">Path to validate</param>
+        /// <param name="recommendation">Selected recommendation, which may be used if the validator needs to consider properties other than itself</param>
+        /// <param name="optionSettingItem">Selected option setting item, which may be used if the validator needs to consider properties other than itself</param>
         /// <returns>Valid if the directory exists, invalid otherwise</returns>
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var executionDirectory = (string)input;
 

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DockerBuildArgsValidator.cs
@@ -16,8 +16,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// with those set by the deploy tool
         /// </summary>
         /// <param name="input">Proposed Docker build args</param>
+        /// <param name="recommendation">Selected recommendation, which may be used if the validator needs to consider properties other than itself</param>
+        /// <param name="optionSettingItem">Selected option setting item, which may be used if the validator needs to consider properties other than itself</param>
         /// <returns>Valid if the options do not contain those set by the deploy tool, invalid otherwise</returns>
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var buildArgs = Convert.ToString(input);
             var errorMessage = string.Empty;

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/DotnetPublishArgsValidator.cs
@@ -15,8 +15,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// Validates that additional 'dotnet publish' arguments do not collide with those used by the deploy tool
         /// </summary>
         /// <param name="input">Additional publish arguments</param>
+        /// <param name="recommendation">Selected recommendation, which may be used if the validator needs to consider properties other than itself</param>
+        /// <param name="optionSettingItem">Selected option setting item, which may be used if the validator needs to consider properties other than itself</param>
         /// <returns>Valid if the arguments don't interfere with the deploy tool, invalid otherwise</returns>
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var publishArgs = Convert.ToString(input);
             var errorMessage = string.Empty;

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
             _awsResourceQueryer = awsResourceQueryer;
         }
 
-        public async Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             if (string.IsNullOrEmpty(ResourceType))
                 throw new MissingValidatorConfigurationException(DeployToolErrorCode.MissingValidatorConfiguration, $"The validator of type '{typeof(ExistingResourceValidator)}' is missing the configuration property '{nameof(ResourceType)}'.");

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/FileExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/FileExistsValidator.cs
@@ -26,7 +26,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// </summary>
         public bool AllowEmptyString { get; set; } = true;
 
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var inputFilePath = input?.ToString() ?? string.Empty;
 

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/InstanceTypeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/InstanceTypeValidator.cs
@@ -21,7 +21,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
             _awsResourceQueryer = awsResourceQueryer;
         }
 
-        public async Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var rawInstanceType = Convert.ToString(input);
             InstanceTypeInfo? instanceTypeInfo;

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RangeValidator.cs
@@ -24,7 +24,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
         public bool AllowEmptyString { get; set; }
 
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             if (AllowEmptyString && string.IsNullOrEmpty(input?.ToString()))
                 return ValidationResult.ValidAsync();

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RegexValidator.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
         public bool AllowEmptyString { get; set; }
 
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var regex = new Regex(Regex);
 

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/StringLengthValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/StringLengthValidator.cs
@@ -17,7 +17,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public int MaxLength { get; set; } = 1000;
         public string ValidationFailedMessage { get; set; } = "Invalid value. Number of characters must be between {{min}} and {{max}}";
 
-        public Task<ValidationResult> Validate(object input, Recommendation recommendation)
+        public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var inputString = input?.ToString() ?? string.Empty;
             var stringLength = inputString.Length;

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -15,6 +15,7 @@ namespace AWS.Deploy.Constants
         public const string REPLACE_TOKEN_ECR_REPOSITORY_NAME = "{DefaultECRRepositoryName}";
         public const string REPLACE_TOKEN_ECR_IMAGE_TAG = "{DefaultECRImageTag}";
         public const string REPLACE_TOKEN_DOCKERFILE_PATH = "{DockerfilePath}";
+        public const string REPLACE_TOKEN_DEFAULT_VPC_ID = "{DefaultVpcId}";
 
         /// <summary>
         /// Id for the 'dotnet publish --configuration' recipe option

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -472,6 +472,24 @@ namespace AWS.Deploy.Orchestration.Data
                 .ToListAsync());
         }
 
+        public async Task<Vpc> GetDefaultVpc()
+        {
+            var vpcClient = _awsClientFactory.GetAWSClient<IAmazonEC2>();
+
+            return await HandleException(async () => await vpcClient.Paginators
+                .DescribeVpcs(
+                    new DescribeVpcsRequest
+                    {
+                        Filters = new List<Filter> {
+                            new Filter {
+                                Name = "is-default",
+                                Values = new List<string> { "true" }
+                            }
+                        }
+                    })
+                .Vpcs.FirstAsync());
+        }
+
         public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns()
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -193,6 +193,14 @@ namespace AWS.Deploy.Orchestration
                     recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DOCKERFILE_PATH, defaultDockerfilePath);
                 }
             }
+            if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID))
+            {
+                if (_awsResourceQueryer == null)
+                    throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
+
+                var defaultVPC = await _awsResourceQueryer.GetDefaultVpc();
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID, defaultVPC.VpcId);
+            }
         }
 
         public async Task DeployRecommendation(CloudApplication cloudApplication, Recommendation recommendation)

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
@@ -14,6 +14,11 @@ namespace AspNetAppAppRunner.Configurations
     public partial class VPCConnectorConfiguration
     {
         /// <summary>
+        /// If set, the deployment will use a VPC Connector to connect to the AppRunner service.
+        /// </summary>
+        public bool UseVPCConnector { get; set; }
+
+        /// <summary>
         /// If set, creates a new VPC Connector to connect to the AppRunner service.
         /// </summary>
         public bool CreateNew { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Recipe.cs
@@ -149,7 +149,7 @@ namespace AspNetAppAppRunner
                 }
             };
 
-            if ((settings.VPCConnector.CreateNew && VPCConnector != null) || !string.IsNullOrEmpty(settings.VPCConnector.VpcConnectorId))
+            if (settings.VPCConnector.UseVPCConnector)
             {
                 appRunnerServiceProp.NetworkConfiguration = new CfnService.NetworkConfigurationProperty
                 {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -413,13 +413,28 @@
             "Updatable": true,
             "ChildOptionSettings": [
                 {
+                    "Id": "UseVPCConnector",
+                    "Name": "Use VPC Connector",
+                    "Description": "Do you want to use a VPC Connector to connect to a VPC?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": false,
+                    "Updatable": true
+                },
+                {
                     "Id": "CreateNew",
                     "Name": "Create New VPC Connector",
                     "Description": "Do you want to create a new VPC Connector?",
                     "Type": "Bool",
                     "DefaultValue": false,
                     "AdvancedSetting": false,
-                    "Updatable": true
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "VPCConnector.UseVPCConnector",
+                            "Value": true
+                        }
+                    ]
                 },
                 {
                     "Id": "VpcConnectorId",
@@ -430,7 +445,23 @@
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Required"
+                        },
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):apprunner:\\w+(?:-\\w+)+:[0-9]{12}:vpcconnector/[\\w+=,.@\\-/]{1,1000}",
+                                "ValidationFailedMessage": "Invalid VPC Connector ARN. The ARN should contain the arn:[PARTITION]:apprunner namespace, followed by the AWS region and account ID, and then the resource path. For example - arn:aws:apprunner:us-west-2:123456789012:vpcconnector/RecipeVPCConnector is a valid VPC Connector ARN."
+                            }
+                        }
+                    ],
                     "DependsOn": [
+                        {
+                            "Id": "VPCConnector.UseVPCConnector",
+                            "Value": true
+                        },
                         {
                             "Id": "VPCConnector.CreateNew",
                             "Value": false
@@ -443,7 +474,7 @@
                     "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
                     "Type": "String",
                     "TypeHint": "ExistingVpc",
-                    "DefaultValue": null,
+                    "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": true,
                     "Validators": [
@@ -451,12 +482,15 @@
                             "ValidatorType": "Regex",
                             "Configuration": {
                                 "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
-                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
                             }
                         }
                     ],
                     "DependsOn": [
+                        {
+                            "Id": "VPCConnector.UseVPCConnector",
+                            "Value": true
+                        },
                         {
                             "Id": "VPCConnector.CreateNew",
                             "Value": true
@@ -474,18 +508,28 @@
                     "Updatable": true,
                     "Validators": [
                         {
+                            "ValidatorType": "Required"
+                        },
+                        {
                             "ValidatorType": "Regex",
                             "Configuration": {
                                 "Regex": "^subnet-([0-9a-f]{8}|[0-9a-f]{17})$",
-                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid Subnet ID. The Subnet ID must start with the \"subnet-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example subnet-abc88de9 is a valid Subnet ID."
                             }
                         }
                     ],
                     "DependsOn": [
                         {
+                            "Id": "VPCConnector.UseVPCConnector",
+                            "Value": true
+                        },
+                        {
                             "Id": "VPCConnector.CreateNew",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPCConnector.VpcId",
+                            "Operation": "NotEmpty"
                         }
                     ]
                 },
@@ -500,18 +544,28 @@
                     "Updatable": true,
                     "Validators": [
                         {
+                            "ValidatorType": "Required"
+                        },
+                        {
                             "ValidatorType": "Regex",
                             "Configuration": {
                                 "Regex": "^sg-([0-9a-f]{8}|[0-9a-f]{17})$",
-                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
                             }
                         }
                     ],
                     "DependsOn": [
                         {
+                            "Id": "VPCConnector.UseVPCConnector",
+                            "Value": true
+                        },
+                        {
                             "Id": "VPCConnector.CreateNew",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPCConnector.VpcId",
+                            "Operation": "NotEmpty"
                         }
                     ]
                 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -85,14 +85,15 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
                 var subnetsResourcesEmpty = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.Subnets");
                 var securityGroupsResourcesEmpty = await restClient.GetConfigSettingResourcesAsync(sessionId, "VPCConnector.SecurityGroups");
                 Assert.NotEmpty(vpcResources.Resources);
-                Assert.Empty(subnetsResourcesEmpty.Resources);
-                Assert.Empty(securityGroupsResourcesEmpty.Resources);
+                Assert.NotEmpty(subnetsResourcesEmpty.Resources);
+                Assert.NotEmpty(securityGroupsResourcesEmpty.Resources);
 
                 var vpcId = vpcResources.Resources.First().SystemName;
                 await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
                 {
                     UpdatedSettings = new Dictionary<string, string>()
                     {
+                        {"VPCConnector.UseVPCConnector", "true"},
                         {"VPCConnector.CreateNew", "true"},
                         {"VPCConnector.VpcId", vpcId}
                     }
@@ -120,6 +121,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
                 Assert.True(metadata.Settings.ContainsKey("VPCConnector"));
                 var vpcConnector = JsonConvert.DeserializeObject<VPCConnectorTypeHintResponse>(metadata.Settings["VPCConnector"].ToString());
+                Assert.True(vpcConnector.UseVPCConnector);
                 Assert.True(vpcConnector.CreateNew);
                 Assert.Equal(vpcId, vpcConnector.VpcId);
                 Assert.Contains<string>(subnet, vpcConnector.Subnets);

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -69,5 +69,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
         public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
         public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
+        public Task<Vpc> GetDefaultVpc() => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
@@ -127,13 +127,71 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
 
+            var useVpcConnector = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.UseVPCConnector");
             var createNew = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.CreateNew");
+            var vpcId = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.VpcId");
             var subnets = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.Subnets");
             var securityGroups = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, "VPCConnector.SecurityGroups");
 
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, useVpcConnector, true);
             await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, createNew, true);
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, vpcId, "vpc-1234abcd");
             await Assert.ThrowsAsync<ValidationFailedException>(async () => await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, subnets, new SortedSet<string>(){ "subnet1" }));
             await Assert.ThrowsAsync<ValidationFailedException>(async () => await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, securityGroups, new SortedSet<string>(){ "securityGroup1" }));
+        }
+
+        [Fact]
+        public async Task GetOptionSettingTests_VPCConnector_DisplayableItems()
+        {
+            var SETTING_ID_VPCCONNECTOR = "VPCConnector";
+            var SETTING_ID_USEVPCCONNECTOR = "UseVPCConnector";
+            var SETTING_ID_CREATENEW = "CreateNew";
+            var SETTING_ID_VPCCONNECTORID = "VpcConnectorId";
+            var SETTING_ID_VPCID = "VpcId";
+            var SETTING_ID_SUBNETS = "Subnets";
+            var SETTING_ID_SECURITYGROUPS = "SecurityGroups";
+
+            var engine = await BuildRecommendationEngine("WebAppWithDockerFile");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var appRunnerRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_APPRUNNER_ID);
+
+            var vpcConnector = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, SETTING_ID_VPCCONNECTOR);
+            var vpcConnectorChildren = vpcConnector.ChildOptionSettings.Where(x => _optionSettingHandler.IsOptionSettingDisplayable(appRunnerRecommendation, x)).ToList();
+            Assert.Single(vpcConnectorChildren);
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_USEVPCCONNECTOR)));
+
+            var useVpcConnector = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, $"{SETTING_ID_VPCCONNECTOR}.{SETTING_ID_USEVPCCONNECTOR}");
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, useVpcConnector, true);
+            vpcConnectorChildren = vpcConnector.ChildOptionSettings.Where(x => _optionSettingHandler.IsOptionSettingDisplayable(appRunnerRecommendation, x)).ToList();
+            Assert.Equal(3, vpcConnectorChildren.Count);
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_USEVPCCONNECTOR)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_CREATENEW)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_VPCCONNECTORID)));
+
+            var createNew = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, $"{SETTING_ID_VPCCONNECTOR}.{SETTING_ID_CREATENEW}");
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, createNew, true);
+            vpcConnectorChildren = vpcConnector.ChildOptionSettings.Where(x => _optionSettingHandler.IsOptionSettingDisplayable(appRunnerRecommendation, x)).ToList();
+            Assert.Equal(3, vpcConnectorChildren.Count);
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_USEVPCCONNECTOR)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_CREATENEW)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_VPCID)));
+
+            var vpcId = _optionSettingHandler.GetOptionSetting(appRunnerRecommendation, $"{SETTING_ID_VPCCONNECTOR}.{SETTING_ID_VPCID}");
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, vpcId, "vpc-abcd1234");
+            vpcConnectorChildren = vpcConnector.ChildOptionSettings.Where(x => _optionSettingHandler.IsOptionSettingDisplayable(appRunnerRecommendation, x)).ToList();
+            Assert.Equal(5, vpcConnectorChildren.Count);
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_USEVPCCONNECTOR)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_CREATENEW)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_VPCID)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_SUBNETS)));
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_SECURITYGROUPS)));
+
+            await _optionSettingHandler.SetOptionSettingValue(appRunnerRecommendation, useVpcConnector, false);
+            vpcConnectorChildren = vpcConnector.ChildOptionSettings.Where(x => _optionSettingHandler.IsOptionSettingDisplayable(appRunnerRecommendation, x)).ToList();
+            Assert.Single(vpcConnectorChildren);
+            Assert.NotNull(vpcConnectorChildren.First(x => x.Id.Equals(SETTING_ID_USEVPCCONNECTOR)));
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
@@ -102,6 +102,7 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
 
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
             {
+                "y",
                 "n",
                 "1"
             });
@@ -149,6 +150,7 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
             {
                 "y",
+                "y",
                 "1",
                 "1",
                 "1",
@@ -159,6 +161,16 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
             });
             var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
             var command = new VPCConnectorCommand(_mockAWSResourceQueryer.Object, consoleUtilities, _toolInteractiveService, _optionSettingHandler);
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.DescribeAppRunnerVpcConnectors())
+                .ReturnsAsync(new List<VpcConnector>()
+                {
+                    new VpcConnector()
+                    {
+                        VpcConnectorArn = "arn:aws:apprunner:us-west-2:123456789010:vpcconnector/fakeVpcConnector"
+                    }
+                });
 
             _mockAWSResourceQueryer
                 .Setup(x => x.GetListOfVpcs())

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -94,5 +94,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string vpcID = null) => throw new NotImplementedException();
         public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
         public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
+        public Task<Vpc> GetDefaultVpc() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5906

*Description of changes:*
* Updated App Runner recipe to add dependencies and validators for the VPC Connector setting so that Subnets and Security groups will no longer be displayed if a Vpc Id is not set.
* Remove orphaned function `OverrideValue` from type hints as it is not used
* Updated OptionSetting Validators to accept OptionSettingItem as a parameter
* Updated Required validator to display more information message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
