### PR TITLE
feat: Update supported target frameworks for recipes

### DIFF
--- a/src/AWS.Deploy.DockerEngine/Properties/DockerFileConfig.json
+++ b/src/AWS.Deploy.DockerEngine/Properties/DockerFileConfig.json
@@ -3,6 +3,11 @@
         "SdkType": "Microsoft.NET.Sdk.Web",
         "ImageMapping": [
             {
+                "TargetFramework": "net7.0",
+                "BaseImage": "mcr.microsoft.com/dotnet/aspnet:7.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:7.0"
+            },
+            {
                 "TargetFramework": "net6.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/aspnet:6.0",
                 "BuildImage": "mcr.microsoft.com/dotnet/sdk:6.0"
@@ -16,27 +21,17 @@
                 "TargetFramework": "netcoreapp3.1",
                 "BaseImage": "mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim",
                 "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:3.1-buster"
-            },
-            {
-                "TargetFramework": "netcoreapp3.0",
-                "BaseImage": "mcr.microsoft.com/dotnet/core/aspnet:3.0-buster-slim",
-                "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:3.0-buster"
-            },
-            {
-                "TargetFramework": "netcoreapp2.2",
-                "BaseImage": "mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim",
-                "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:2.2-stretch"
-            },
-            {
-                "TargetFramework": "netcoreapp2.1",
-                "BaseImage": "mcr.microsoft.com/dotnet/core/aspnet:2.1-stretch-slim",
-                "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:2.1-stretch"
             }
         ]
     },
     {
         "SdkType": "Microsoft.NET.Sdk",
         "ImageMapping": [
+            {
+                "TargetFramework": "net7.0",
+                "BaseImage": "mcr.microsoft.com/dotnet/runtime:7.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:7.0"
+            },
             {
                 "TargetFramework": "net6.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/runtime:6.0",
@@ -51,21 +46,6 @@
                 "TargetFramework": "netcoreapp3.1",
                 "BaseImage": "mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim",
                 "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:3.1-buster"
-            },
-            {
-                "TargetFramework": "netcoreapp3.0",
-                "BaseImage": "mcr.microsoft.com/dotnet/core/runtime:3.0-buster-slim",
-                "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:3.0-buster"
-            },
-            {
-                "TargetFramework": "netcoreapp2.2",
-                "BaseImage": "mcr.microsoft.com/dotnet/core/runtime:2.2-stretch-slim",
-                "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:2.2-stretch"
-            },
-            {
-                "TargetFramework": "netcoreapp2.1",
-                "BaseImage": "mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim",
-                "BuildImage": "mcr.microsoft.com/dotnet/core/sdk:2.1-stretch"
             }
         ]
     }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -32,7 +32,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -40,7 +40,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -32,7 +32,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -24,7 +24,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -40,7 +40,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 },
                 {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -35,7 +35,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ],

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -28,6 +28,7 @@ namespace AWS.Deploy.CLI.UnitTests
         [InlineData("WebAppDifferentTargetFramework", "")]
         [InlineData("ConsoleSdkType", "")]
         [InlineData("WorkerServiceExample", "")]
+        [InlineData("WebAppNet7", "")]
         public async Task DockerGenerate(string topLevelFolder, string projectName)
         {
             var projectPath = ResolvePath(Path.Combine(topLevelFolder, projectName));

--- a/testapps/docker/WebAppDifferentTargetFramework/WebAppDifferentTargetFramework.csproj
+++ b/testapps/docker/WebAppDifferentTargetFramework/WebAppDifferentTargetFramework.csproj
@@ -1,16 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>bf478cab-4535-46b3-a828-d2f495205f19</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
 
 </Project>

--- a/testapps/docker/WebAppNet7/Program.cs
+++ b/testapps/docker/WebAppNet7/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Test .NET 7");
+app.Run();

--- a/testapps/docker/WebAppNet7/WebAppNet7.csproj
+++ b/testapps/docker/WebAppNet7/WebAppNet7.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/testapps/docker/WebAppNet7/appsettings.Development.json
+++ b/testapps/docker/WebAppNet7/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/testapps/docker/WebAppNet7/appsettings.json
+++ b/testapps/docker/WebAppNet7/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/testapps/docker/WorkerServiceExample/Dockerfile
+++ b/testapps/docker/WorkerServiceExample/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["WorkerServiceExample.csproj", ""]
+RUN dotnet restore "WorkerServiceExample.csproj"
+COPY . .
+WORKDIR "/src/"
+RUN dotnet build "WorkerServiceExample.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN apt-get update -yq \
+    && apt-get install curl gnupg -yq \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash \
+    && apt-get install nodejs -yq
+RUN dotnet publish "WorkerServiceExample.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WorkerServiceExample.dll"]


### PR DESCRIPTION
*Description of changes:*
For all container based recipes add .NET 7 to the list of supported target frameworks and include the .NET 7 base images to the framework to image mapping.

Also removed .NET Core 2.1 from the list since the version is well out of support and no reason to GA with that support in the tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
