### PR TITLE
feat: Add .NET 6 as a target framework for CLI to support M1 Macs

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <ToolCommandName>dotnet-aws</ToolCommandName>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
@@ -140,7 +140,12 @@ namespace AWS.Deploy.CLI.Commands
         /// <returns>The default save directory path.</returns>
         private string GenerateDefaultSaveDirectoryPath()
         {
-            var applicatonDirectoryFullPath = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath).Parent.FullName;
+            var targetApplicationDi = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath);
+            if(targetApplicationDi.Parent == null)
+            {
+                throw new FailedToGenerateAnyRecommendations(DeployToolErrorCode.InvalidFilePath, $"Failed to find parent directory for directory {_targetApplicationFullPath}.");
+            }
+            var applicatonDirectoryFullPath = targetApplicationDi.Parent.FullName;
             var saveCdkDirectoryFullPath = applicatonDirectoryFullPath + ".Deployment";
 
             var suffixNumber = 0;
@@ -173,9 +178,15 @@ namespace AWS.Deploy.CLI.Commands
         /// <returns>A tuple containing a boolean that indicates if the directory is valid and a corresponding string error message.</returns>
         private Tuple<bool, string> ValidateSaveCdkDirectory(string saveCdkDirectoryPath)
         {
+            var targetApplicationDi = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath);
+            if (targetApplicationDi.Parent == null)
+            {
+                throw new FailedToGenerateAnyRecommendations(DeployToolErrorCode.InvalidFilePath, $"Failed to find parent directory for directory {_targetApplicationFullPath}.");
+            }
+
             var errorMessage = string.Empty;
             var isValid = true;
-            var targetApplicationDirectoryFullPath = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath).Parent.FullName;
+            var targetApplicationDirectoryFullPath = targetApplicationDi.Parent.FullName;
            
             if (!_directoryManager.IsEmpty(saveCdkDirectoryPath))
             {
@@ -215,7 +226,13 @@ namespace AWS.Deploy.CLI.Commands
         /// <param name="projectDisplayName">The name of the deployment project that will be displayed in the list of available deployment options.</param>
         private async Task GenerateDeploymentRecipeSnapShot(Recommendation recommendation, string saveCdkDirectoryPath, string projectDisplayName)
         {
-            var targetApplicationDirectoryName = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath).Parent.Name;
+            var targetApplicationDi = _directoryManager.GetDirectoryInfo(_targetApplicationFullPath);
+            if (targetApplicationDi.Parent == null)
+            {
+                throw new FailedToGenerateAnyRecommendations(DeployToolErrorCode.InvalidFilePath, $"Failed to find parent directory for directory {_targetApplicationFullPath}.");
+            }
+
+            var targetApplicationDirectoryName = targetApplicationDi.Name;
             var recipeSnapshotFileName = _directoryManager.GetDirectoryInfo(saveCdkDirectoryPath).Name + ".recipe";
             var recipeSnapshotFilePath = Path.Combine(saveCdkDirectoryPath, recipeSnapshotFileName);
             var recipePath = recommendation.Recipe.RecipePath;

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SNSTopicArnsCommand.cs
@@ -40,7 +40,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentValueStr = currentValue.ToString() ?? string.Empty;
             var topicArns = await GetResources(recommendation, optionSetting);
 
-            var topicNames = topicArns.Select(queue => queue.DisplayName).ToList();
+            var topicNames = topicArns?.Select(topic => topic.DisplayName).ToList() ?? new List<string>();
             var currentName = string.Empty;
             if (currentValue.ToString()?.LastIndexOf(':') != -1)
             {
@@ -54,7 +54,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 title: "Select a SNS topic:",
                 defaultValue: currentName);
 
-            var selectedTopicArn = topicArns.FirstOrDefault(x => string.Equals(x.DisplayName, userResponse, StringComparison.OrdinalIgnoreCase));
+            var selectedTopicArn = topicArns?.FirstOrDefault(x => string.Equals(x.DisplayName, userResponse, StringComparison.OrdinalIgnoreCase));
             return selectedTopicArn?.SystemName ?? string.Empty;
         }
     }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/SQSQueueUrlCommand.cs
@@ -40,7 +40,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var currentValueStr = currentValue.ToString() ?? string.Empty;
             var queueUrls = await GetResources(recommendation, optionSetting);
 
-            var queueNames = queueUrls.Select(queue => queue.DisplayName).ToList();
+            var queueNames = queueUrls?.Select(queue => queue.DisplayName).ToList() ?? new List<string>();
             var currentName = string.Empty;
             if (currentValue.ToString()?.LastIndexOf('/') != -1)
             {
@@ -54,7 +54,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 title: "Select a SQS queue:",
                 defaultValue: currentName);
 
-            var selectedQueueUrl = queueUrls.FirstOrDefault(x => string.Equals(x.DisplayName, userResponse, StringComparison.OrdinalIgnoreCase));
+            var selectedQueueUrl = queueUrls?.FirstOrDefault(x => string.Equals(x.DisplayName, userResponse, StringComparison.OrdinalIgnoreCase));
             return selectedQueueUrl?.SystemName ?? string.Empty;
         }
     }

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -337,6 +337,10 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
             }
 
             var output = new GetExistingDeploymentsOutput();
+            if(state.NewRecommendations == null)
+            {
+                return Ok(output);
+            }
 
             var deployedApplicationQueryer = serviceProvider.GetRequiredService<IDeployedApplicationQueryer>();
             var session = CreateOrchestratorSession(state);


### PR DESCRIPTION
*Description of changes:*
To support M1 macs that only have .NET 6 ARM installed the CLI is updated to compile for both .NET Core 3.1 and .NET 6.

Adding .NET 6 triggered a few more possible null reference errors that made fixes for.

I have confirmed pointing the VS toolkit to the .NET 6 compiled version of the CLI works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
