### PR TITLE
ci: add PR check to make sure RestApi client is updated

### DIFF
--- a/.github/workflows/DetectRestAPIClientChanges.yml
+++ b/.github/workflows/DetectRestAPIClientChanges.yml
@@ -1,0 +1,44 @@
+name: Detect Rest API Client Changes
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Setup .NET Core 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Setup .NET Core 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Run Client Generator
+      run: |
+        cd ./src/AWS.Deploy.ServerMode.ClientGenerator
+        dotnet run --project ./AWS.Deploy.ServerMode.ClientGenerator.csproj
+    - name: Verify Changed files
+      uses: tj-actions/verify-changed-files@v9.1
+      id: verify-changed-files
+      with:
+        files: |
+            RestAPI.cs
+    - name: Fail if RestAPI Changes Detected
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      run: |
+        echo "There are changes in RestApi.cs. Make sure to run the generator and commit the updated RestApi.cs."
+        exit 1


### PR DESCRIPTION
*Description of changes:*
This PR adds a GitHub workflow to check for changes in RestAPI client and make sure that future PRs don't miss updating the RestAPI client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
