### PR TITLE
feat: Reduce AWS.Deploy.Tools NuGet packaged down to 5 megs from 63 megs

### DIFF
--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AWS.Deploy.Orchestration\AWS.Deploy.Orchestration.csproj" />
-    <ProjectReference Include="..\AWS.Deploy.Recipes.CDK.Common\AWS.Deploy.Recipes.CDK.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\AWS.Deploy.Recipes.CDK.Common\RecipeProps.cs" Link="RecipeProps.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AWSSDK.CloudControlApi" Version="3.7.2" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.83" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.1.25" />
@@ -33,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AWS.Deploy.Recipes.CDK.Common\AWS.Deploy.Recipes.CDK.Common.csproj" />
     <ProjectReference Include="..\AWS.Deploy.Recipes\AWS.Deploy.Recipes.csproj" />
     <ProjectReference Include="..\AWS.Deploy.DockerEngine\AWS.Deploy.DockerEngine.csproj" />
   </ItemGroup>

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -14,7 +14,6 @@ using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.CDK;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
-using AWS.Deploy.Recipes.CDK.Common;
 using Stack = Amazon.CloudFormation.Model.Stack;
 
 namespace AWS.Deploy.Orchestration

--- a/src/AWS.Deploy.Orchestration/TemplateEngine.cs
+++ b/src/AWS.Deploy.Orchestration/TemplateEngine.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
-using AWS.Deploy.Recipes.CDK.Common;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.Template;

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -14,7 +14,6 @@ using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.LocalUserSettings;
-using AWS.Deploy.Recipes.CDK.Common;
 
 namespace AWS.Deploy.Orchestration.Utilities
 {

--- a/src/AWS.Deploy.Orchestration/Utilities/TemplateMetadataReader.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/TemplateMetadataReader.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Amazon.CloudFormation.Model;
 using AWS.Deploy.Common;
-using AWS.Deploy.Recipes.CDK.Common;
 using Newtonsoft.Json;
 using YamlDotNet.RepresentationModel;
 


### PR DESCRIPTION
*Description of changes:*
When we updated to CDK V2 the NuGet package size for the CLI tool increased from about **5 megs** to **63 megs**. This was due to `AWS.Deploy.Recipes.CDK.Common` package having a dependency on `Amazon.CDK.Lib` and for V2 the `Amazon.CDK.Lib.dll` file is 71 megs.

The only think the CLI needs from `AWS.Deploy.Recipes.CDK.Common` is the POCO `RecipeProps` used for appsetings.json serialization. It has no reference to the CDK. I removed the references in the CLI to `AWS.Deploy.Recipes.CDK.Common` project and then did a source link to `RecipeProps.cs` file. Now file size is back down to 5 megs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
