### PR TITLE
feat: add validators to check if Subnets and Security Groups are part of the same VPC

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -44,6 +44,14 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="InstanceTypeValidator"/>
         /// </summary>
-        InstanceType
+        InstanceType,
+        /// <summary>
+        /// Must be paired with <see cref="SubnetsInVpcValidator"/>
+        /// </summary>
+        SubnetsInVpc,
+        /// <summary>
+        /// Must be paired with <see cref="SecurityGroupsInVpcValidator"/>
+        /// </summary>
+        SecurityGroupsInVpc
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/SecurityGroupsInVpcValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/SecurityGroupsInVpcValidator.cs
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.Extensions;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that the selected security groups are part of the selected VPC
+    /// </summary>
+    public class SecurityGroupsInVpcValidator : IOptionSettingItemValidator
+    {
+        private static readonly string defaultValidationFailedMessage = "The selected security groups are not part of the selected VPC.";
+        public string VpcId { get; set; } = "";
+        public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
+
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public SecurityGroupsInVpcValidator(IAWSResourceQueryer awsResourceQueryer, IOptionSettingHandler optionSettingHandler)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _optionSettingHandler = optionSettingHandler;
+        }
+
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
+        {
+            if (string.IsNullOrEmpty(VpcId))
+                return ValidationResult.Failed($"The '{nameof(SecurityGroupsInVpcValidator)}' validator is missing the '{nameof(VpcId)}' configuration.");
+            var vpcIdSetting = _optionSettingHandler.GetOptionSetting(recommendation, VpcId);
+            var vpcId = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, vpcIdSetting);
+            if (string.IsNullOrEmpty(vpcId))
+                return ValidationResult.Failed("The VpcId setting is not set or is empty. Make sure to set the VPC Id first.");
+
+            var securityGroupIds = (await _awsResourceQueryer.DescribeSecurityGroups(vpcId)).Select(x => x.GroupId);
+            if (input?.TryDeserialize<SortedSet<string>>(out var inputList) ?? false)
+            {
+                foreach (var securityGroup in inputList!)
+                {
+                    if (!securityGroupIds.Contains(securityGroup))
+                        return ValidationResult.Failed("The selected security group(s) are invalid since they do not belong to the currently selected VPC.");
+                }
+
+                return ValidationResult.Valid();
+            }
+
+            return new ValidationResult
+            {
+                IsValid = securityGroupIds.Contains(input?.ToString()),
+                ValidationFailedMessage = ValidationFailedMessage
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/SubnetsInVpcValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/SubnetsInVpcValidator.cs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.EC2;
+using Amazon.EC2.Model;
+using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.Extensions;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that the selected subnets are part of the selected VPC
+    /// </summary>
+    public class SubnetsInVpcValidator : IOptionSettingItemValidator
+    {
+        private static readonly string defaultValidationFailedMessage = "The selected subnets are not part of the selected VPC.";
+        public string VpcId { get; set; } = "";
+        public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
+
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public SubnetsInVpcValidator(IAWSResourceQueryer awsResourceQueryer, IOptionSettingHandler optionSettingHandler)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _optionSettingHandler = optionSettingHandler;
+        }
+
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
+        {
+            if (string.IsNullOrEmpty(VpcId))
+                return ValidationResult.Failed($"The '{nameof(SubnetsInVpcValidator)}' validator is missing the '{nameof(VpcId)}' configuration.");
+            var vpcIdSetting = _optionSettingHandler.GetOptionSetting(recommendation, VpcId);
+            var vpcId = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, vpcIdSetting);
+            if (string.IsNullOrEmpty(vpcId))
+                return ValidationResult.Failed("The VpcId setting is not set or is empty. Make sure to set the VPC Id first.");
+
+            var subnetIds = (await _awsResourceQueryer.DescribeSubnets(vpcId)).Select(x => x.SubnetId);
+            if (input?.TryDeserialize<SortedSet<string>>(out var inputList) ?? false)
+            {
+                foreach (var subnet in inputList!)
+                {
+                    if (!subnetIds.Contains(subnet))
+                        return ValidationResult.Failed("The selected subnet(s) are invalid since they do not belong to the currently selected VPC.");
+                }
+
+                return ValidationResult.Valid();
+            }
+
+            return new ValidationResult
+            {
+                IsValid = subnetIds.Contains(input?.ToString()),
+                ValidationFailedMessage = ValidationFailedMessage
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -55,7 +55,9 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.ExistingResource, typeof(ExistingResourceValidator) },
             { OptionSettingItemValidatorList.FileExists, typeof(FileExistsValidator) },
             { OptionSettingItemValidatorList.StringLength, typeof(StringLengthValidator) },
-            { OptionSettingItemValidatorList.InstanceType, typeof(InstanceTypeValidator) }
+            { OptionSettingItemValidatorList.InstanceType, typeof(InstanceTypeValidator) },
+            { OptionSettingItemValidatorList.SubnetsInVpc, typeof(SubnetsInVpcValidator) },
+            { OptionSettingItemValidatorList.SecurityGroupsInVpc, typeof(SecurityGroupsInVpcValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -49,23 +49,17 @@ namespace AWS.Deploy.Orchestration
                     .Where(x => !x.IsValid)
                     .ToList();
 
-                // Only update the validation object if there is no InvalidValue set.
-                // In the case where a user tries to set an Invalid Value, this is the value that will be on the UI.
-                // We don't want to update that value in the background if it is triggered by a dependent setting validation
-                // since it won't be reflected on the UI.
-                if (optionSetting.Validation.InvalidValue == null)
+                if (failedValidators.Any())
                 {
-                    if (failedValidators.Any())
-                    {
-                        optionSetting.Validation.ValidationStatus = ValidationStatus.Invalid;
-                        optionSetting.Validation.ValidationMessage = string.Join(Environment.NewLine, failedValidators.Select(x => x.ValidationFailedMessage)).Trim();
-                        optionSetting.Validation.InvalidValue = optionSettingValue;
-                    }
-                    else
-                    {
-                        optionSetting.Validation.ValidationStatus = ValidationStatus.Valid;
-                        optionSetting.Validation.ValidationMessage = string.Empty;
-                    }
+                    optionSetting.Validation.ValidationStatus = ValidationStatus.Invalid;
+                    optionSetting.Validation.ValidationMessage = string.Join(Environment.NewLine, failedValidators.Select(x => x.ValidationFailedMessage)).Trim();
+                    optionSetting.Validation.InvalidValue = optionSettingValue;
+                }
+                else
+                {
+                    optionSetting.Validation.ValidationStatus = ValidationStatus.Valid;
+                    optionSetting.Validation.ValidationMessage = string.Empty;
+                    optionSetting.Validation.InvalidValue = null;
                 }
                 settingValidatorFailedResults.AddRange(failedValidators);
                 settingValidatorFailedResults.AddRange(RunOptionSettingValidators(recommendation, optionSetting.ChildOptionSettings));

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -516,6 +516,12 @@
                                 "Regex": "^subnet-([0-9a-f]{8}|[0-9a-f]{17})$",
                                 "ValidationFailedMessage": "Invalid Subnet ID. The Subnet ID must start with the \"subnet-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example subnet-abc88de9 is a valid Subnet ID."
                             }
+                        },
+                        {
+                            "ValidatorType": "SubnetsInVpc",
+                            "Configuration": {
+                                "VpcId": "VPCConnector.VpcId"
+                            }
                         }
                     ],
                     "DependsOn": [
@@ -551,6 +557,12 @@
                             "Configuration": {
                                 "Regex": "^sg-([0-9a-f]{8}|[0-9a-f]{17})$",
                                 "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
+                            }
+                        },
+                        {
+                            "ValidatorType": "SecurityGroupsInVpc",
+                            "Configuration": {
+                                "VpcId": "VPCConnector.VpcId"
                             }
                         }
                     ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -611,7 +611,9 @@
                                     "ExistingResource",
                                     "FileExists",
                                     "StringLength",
-                                    "InstanceType"
+                                    "InstanceType",
+                                    "SubnetsInVpc",
+                                    "SecurityGroupsInVpc"
                                 ]
                             }
                         },


### PR DESCRIPTION
*Description of changes:*
This change is to fix a behavior in the toolkit where a user selects subnets and security groups and then changes the selected VPC which invalidates the already selected subnets and security groups. This adds a validator that checks if the selected subnets and security groups are part of the selected vpc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
