### PR TITLE
feat: ApplyConfigSettings API now rejects updating readonly settings

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
+++ b/src/AWS.Deploy.ServerMode.Client/RestAPI.cs
@@ -746,6 +746,16 @@ namespace AWS.Deploy.ServerMode.Client
                             throw new ApiException<ProblemDetails>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudFormationHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/CloudFormationHelper.cs
@@ -25,6 +25,12 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
             return stack.StackStatus;
         }
 
+        public async Task<StackStatus> GetStackArn(string stackName)
+        {
+            var stack = await GetStackAsync(stackName);
+            return stack.StackId;
+        }
+
         public async Task<bool> IsStackDeleted(string stackName)
         {
             try


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5993

*Description of changes:*
ApplyConfigSettings API now rejects updating readonly settings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
