### PR TITLE
fix: Do not validate against terminated Beanstalk environments

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/ExistingResourceValidator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.CloudControlApi.Model;
 using AWS.Deploy.Common.Data;
+using Amazon.ElasticBeanstalk;
 
 namespace AWS.Deploy.Common.Recipes.Validation
 {
@@ -40,7 +41,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
 
                 case "AWS::ElasticBeanstalk::Environment":
                     var beanstalkEnvironments = await _awsResourceQueryer.ListOfElasticBeanstalkEnvironments(environmentName: resourceName);
-                    if (beanstalkEnvironments.Any(x => x.EnvironmentName.Equals(resourceName)))
+                    if (beanstalkEnvironments.Any(x => x.EnvironmentName.Equals(resourceName) && x.Status != EnvironmentStatus.Terminated))
                         return ValidationResult.Failed($"An Elastic Beanstalk environment already exists with the name '{resourceName}'. Check the AWS Console for more information on the existing resource.");
                     break;
 


### PR DESCRIPTION
*Description of changes:*
`_awsResourceQueryer.ListOfElasticBeanstalkEnvironments(...)` can return environments that were freshly terminated. 
If a user tries to deploy with an environment name that was used by a previously terminated environment, then the `ExistingResourceValidator` fails.

This PR prevents validating against terminated Beanstalk environments.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
