### PR TITLE
fix: deployment bundle settings don't have a fully qualified id

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -123,6 +123,12 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         public string? BaseRecipeId { get; set; }
 
+        /// <summary>
+        /// The settings that are specific to the Deployment Bundle.
+        /// These settings are populated by the <see cref="IRecipeHandler"/>.
+        /// </summary>
+        public List<OptionSettingItem> DeploymentBundleSettings = new();
+
         public RecipeDefinition(
             string id,
             string version,

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -33,11 +33,9 @@ namespace AWS.Deploy.Common
 
         public DeploymentBundle DeploymentBundle { get; }
 
-        public readonly List<OptionSettingItem> DeploymentBundleSettings = new ();
-
         public readonly Dictionary<string, string> ReplacementTokens = new();
 
-        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, List<OptionSettingItem> deploymentBundleSettings, int computedPriority, Dictionary<string, string> additionalReplacements)
+        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, int computedPriority, Dictionary<string, string> additionalReplacements)
         {
             additionalReplacements ??= new Dictionary<string, string>();
             Recipe = recipe;
@@ -46,7 +44,6 @@ namespace AWS.Deploy.Common
 
             ProjectDefinition = projectDefinition;
             DeploymentBundle = new DeploymentBundle();
-            DeploymentBundleSettings = deploymentBundleSettings;
 
             CollectRecommendationReplacementTokens(GetConfigurableOptionSettingItems().ToList());
 
@@ -87,10 +84,7 @@ namespace AWS.Deploy.Common
                 }
             }
 
-            if (DeploymentBundleSettings == null)
-                return Recipe.OptionSettings;
-
-            return Recipe.OptionSettings.Union(DeploymentBundleSettings);
+            return Recipe.OptionSettings;
         }
 
         private void CollectRecommendationReplacementTokens(List<OptionSettingItem> optionSettings)

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/DockerfilePathValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/DockerfilePathValidationTests.cs
@@ -86,7 +86,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
             var projectDefintion = new ProjectDefinition(null, projectPath, "", "");
-            var recommendation = new Recommendation(_recipeDefinition, projectDefintion, options, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, projectDefintion, 100, new Dictionary<string, string>());
             var validator = new DockerfilePathValidator(_directoryManager, _fileManager);
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -79,7 +79,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
-            var recommendation = new Recommendation(_recipeDefinition, project, options, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
 
             var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             var imageTag = "imageTag";
@@ -103,7 +103,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
-            var recommendation = new Recommendation(_recipeDefinition, project, options, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = projectPath;
 
@@ -131,7 +131,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
-            var recommendation = new Recommendation(_recipeDefinition, project, options, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
 
             var dockerfilePath = Path.Combine(projectPath, "Docker", "Dockerfile");
             var expectedDockerExecutionDirectory = Directory.GetParent(Path.GetFullPath(recommendation.ProjectPath)).Parent.Parent;
@@ -153,7 +153,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
             var repositoryName = "repository";
 
             await _deploymentBundleHandler.PushDockerImageToECR(recommendation, repositoryName, "ConsoleAppTask:latest");
@@ -166,7 +166,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
 
             recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = false;
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = "Release";
@@ -189,7 +189,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, new List<OptionSettingItem>(), 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
 
             recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = "Release";

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
@@ -111,7 +111,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
 
             var recommendations = new List<Recommendation>
             {
-                new Recommendation(new RecipeDefinition("AspNetAppEcsFargate", "0.2.0",  "ASP.NET Core ECS", DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "" ), null, null, 100, new Dictionary<string, string>())
+                new Recommendation(new RecipeDefinition("AspNetAppEcsFargate", "0.2.0",  "ASP.NET Core ECS", DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "" ), null, 100, new Dictionary<string, string>())
                 {
 
                 }
@@ -180,7 +180,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                                                                 PersistedDeploymentProject = true,
                                                                 BaseRecipeId = "AspNetAppEcsFargate"
                                                             },
-                                                            null, null, 100, new Dictionary<string, string>())
+                                                            null, 100, new Dictionary<string, string>())
                 {
 
                 }


### PR DESCRIPTION
*Description of changes:*
The deployment bundle settings are not handled by the RecipeHandler and as a result, they don't have a fully qualified ID or the dependency tree. At the moment they don't have dependencies, but they could in the future. This PR moves the creation of the deployment bundle settings to the RecipeHandler and makes them part of the Recipe and not the Recommendation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
