### PR TITLE
feat: update VPCs in all recipes to match app runner recipe

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -821,7 +821,7 @@ namespace AWS.Deploy.CLI.Commands
                         case OptionSettingValueType.Object:
                             foreach (var childSetting in setting.ChildOptionSettings)
                             {
-                                if (_optionSettingHandler.IsOptionSettingDisplayable(recommendation, childSetting))
+                                if (_optionSettingHandler.IsOptionSettingDisplayable(recommendation, childSetting) && (!recommendation.IsExistingCloudApplication || childSetting.Updatable))
                                     await ConfigureDeploymentFromCli(recommendation, childSetting);
                             }
                             break;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -101,18 +101,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         /// <summary>
         /// Virtual Private Cloud to launch container instance into a virtual network.
         /// </summary>
-        public string VpcId { get; set; }
-
-        /// <summary>
-        /// A list of IDs of subnets that Elastic Beanstalk should use when it associates your environment with a custom Amazon VPC.
-        /// Specify IDs of subnets of a single Amazon VPC.
-        /// </summary>
-        public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();
-
-        /// <summary>
-        /// Lists the Amazon EC2 security groups to assign to the EC2 instances in the Auto Scaling group to define firewall rules for the instances.
-        /// </summary>
-        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
+        public VPCConfiguration VPC { get; set; }
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.
@@ -137,7 +126,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             ElasticBeanstalkRollingUpdatesConfiguration elasticBeanstalkRollingUpdates,
             string cnamePrefix,
             Dictionary<string, string> elasticBeanstalkEnvironmentVariables,
-            string vpcId,
+            VPCConfiguration vpc,
             SortedSet<string> subnets,
             SortedSet<string> securityGroups,
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
@@ -156,9 +145,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             ElasticBeanstalkManagedPlatformUpdates = elasticBeanstalkManagedPlatformUpdates;
             ElasticBeanstalkRollingUpdates = elasticBeanstalkRollingUpdates;
             ElasticBeanstalkEnvironmentVariables = elasticBeanstalkEnvironmentVariables;
-            VpcId = vpcId;
-            Subnets = subnets;
-            SecurityGroups = securityGroups;
+            VPC = vpc;
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/VPCConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/VPCConfiguration.cs
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AspNetAppElasticBeanstalkLinux.Configurations
+{
+    public partial class VPCConfiguration
+    {
+        /// <summary>
+        /// If set, the deployment will use a VPC to connect to the Elastic Beanstalk service.
+        /// </summary>
+        public bool UseVPC { get; set; }
+
+        /// <summary>
+        /// The VPC ID to use for the Elastic Beanstalk service.
+        /// </summary>
+        public string? VpcId { get; set; }
+
+        /// <summary>
+        /// A list of IDs of subnets that Elastic Beanstalk should use when it associates your environment with a custom Amazon VPC.
+        /// Specify IDs of subnets of a single Amazon VPC.
+        /// </summary>
+        public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();
+
+        /// <summary>
+        /// Lists the Amazon EC2 security groups to assign to the EC2 instances in the Auto Scaling group to define firewall rules for the instances.
+        /// </summary>
+        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -375,31 +375,31 @@ namespace AspNetAppElasticBeanstalkLinux
                 }
             }
 
-            if (!string.IsNullOrEmpty(settings.VpcId))
+            if (settings.VPC.UseVPC)
             {
                 optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
                 {
                     Namespace = "aws:ec2:vpc",
                     OptionName = "VPCId",
-                    Value = settings.VpcId
+                    Value = settings.VPC.VpcId
                 });
 
-                if (settings.Subnets.Any())
+                if (settings.VPC.Subnets.Any())
                 {
                     optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
                     {
                         Namespace = "aws:ec2:vpc",
                         OptionName = "Subnets",
-                        Value = string.Join(",", settings.Subnets)
+                        Value = string.Join(",", settings.VPC.Subnets)
                     });
 
-                    if (settings.SecurityGroups.Any())
+                    if (settings.VPC.SecurityGroups.Any())
                     {
                         optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
                         {
                             Namespace = "aws:autoscaling:launchconfiguration",
                             OptionName = "SecurityGroups",
-                            Value = string.Join(",", settings.SecurityGroups)
+                            Value = string.Join(",", settings.VPC.SecurityGroups)
                         });
                     }
                 }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -321,7 +321,7 @@
                     "Description": "The ID of the existing VPC to use.",
                     "Type": "String",
                     "TypeHint": "ExistingVpc",
-                    "DefaultValue": null,
+                    "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalk.recipe
@@ -730,81 +730,123 @@
             "Updatable": true
         },
         {
-            "Id": "VpcId",
+            "Id": "VPC",
             "Name": "Virtual Private Cloud (VPC)",
             "Category": "VPC",
-            "Description": "A VPC enables you to launch the application into a virtual network that you've defined.",
-            "Type": "String",
-            "TypeHint": "ExistingVpc",
-            "DefaultValue": null,
-            "AdvancedSetting": true,
-            "Updatable": false,
-            "Validators": [
-                {
-                    "ValidatorType": "Regex",
-                    "Configuration": {
-                        "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
-                        "AllowEmptyString": true,
-                        "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
-                    }
-                }
-            ]
-        },
-        {
-            "Id": "Subnets",
-            "Name": "Subnets",
-            "Category": "VPC",
-            "Description": "A list of IDs of subnets that Elastic Beanstalk should use when it associates your environment with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC.",
-            "Type": "List",
-            "TypeHint": "ExistingSubnets",
-            "ParentSettingId": "VpcId",
+            "Description": "A VPC enables you to launch the application into a virtual network that you've defined",
+            "Type": "Object",
             "AdvancedSetting": true,
             "Updatable": true,
-            "Validators": [
+            "ChildOptionSettings": [
                 {
-                    "ValidatorType": "Regex",
-                    "Configuration": {
-                        "Regex": "^subnet-([0-9a-f]{8}|[0-9a-f]{17})$",
-                        "AllowEmptyString": true,
-                        "ValidationFailedMessage": "Invalid Subnet ID. The Subnet ID must start with the \"subnet-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example subnet-abc88de9 is a valid Subnet ID."
-                    }
-                }
-            ],
-            "DependsOn": [
-                {
-                    "Id": "VpcId",
-                    "Operation": "NotEmpty"
-                }
-            ]
-        },
-        {
-            "Id": "SecurityGroups",
-            "Name": "Security Groups",
-            "Category": "VPC",
-            "Description": "Lists the Amazon EC2 security groups to assign to the EC2 instances in the Auto Scaling group to define firewall rules for the instances.",
-            "Type": "List",
-            "TypeHint": "ExistingSecurityGroups",
-            "ParentSettingId": "VpcId",
-            "AdvancedSetting": true,
-            "Updatable": true,
-            "Validators": [
-                {
-                    "ValidatorType": "Regex",
-                    "Configuration": {
-                        "Regex": "^sg-([0-9a-f]{8}|[0-9a-f]{17})$",
-                        "AllowEmptyString": true,
-                        "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
-                    }
-                }
-            ],
-            "DependsOn": [
+                    "Id": "UseVPC",
+                    "Name": "Use a VPC ",
+                    "Description": "Do you want to use a Virtual Private Cloud (VPC)?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": true,
+                    "Updatable": false
+                },
                 {
                     "Id": "VpcId",
-                    "Operation": "NotEmpty"
+                    "Name": "VPC ID",
+                    "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
+                    "Type": "String",
+                    "TypeHint": "ExistingVpc",
+                    "DefaultValue": "{DefaultVpcId}",
+                    "AdvancedSetting": true,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        }
+                    ]
                 },
                 {
                     "Id": "Subnets",
-                    "Operation": "NotEmpty"
+                    "Name": "Subnets",
+                    "Description": "A list of IDs of subnets that Elastic Beanstalk should use when it associates your environment with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC.",
+                    "Type": "List",
+                    "TypeHint": "ExistingSubnets",
+                    "ParentSettingId": "VPC.VpcId",
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Required"
+                        },
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^subnet-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "ValidationFailedMessage": "Invalid Subnet ID. The Subnet ID must start with the \"subnet-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example subnet-abc88de9 is a valid Subnet ID."
+                            }
+                        },
+                        {
+                            "ValidatorType": "SubnetsInVpc",
+                            "Configuration": {
+                                "VpcId": "VPC.VpcId"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        },
+                        {
+                            "Id": "VPC.VpcId",
+                            "Operation": "NotEmpty"
+                        }
+                    ]
+                },
+                {
+                    "Id": "SecurityGroups",
+                    "Name": "Security Groups",
+                    "Description": "Lists the Amazon EC2 security groups to assign to the EC2 instances in the Auto Scaling group to define firewall rules for the instances.",
+                    "Type": "List",
+                    "TypeHint": "ExistingSecurityGroups",
+                    "ParentSettingId": "VPC.VpcId",
+                    "AdvancedSetting": true,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Required"
+                        },
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^sg-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
+                            }
+                        },
+                        {
+                            "ValidatorType": "SecurityGroupsInVpc",
+                            "Configuration": {
+                                "VpcId": "VPC.VpcId"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        },
+                        {
+                            "Id": "VPC.VpcId",
+                            "Operation": "NotEmpty"
+                        }
+                    ]
                 }
             ]
         }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -297,7 +297,7 @@
                     "Description": "The ID of the existing VPC to use.",
                     "Type": "String",
                     "TypeHint": "ExistingVpc",
-                    "DefaultValue": null,
+                    "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -305,7 +305,6 @@
                             "ValidatorType": "Regex",
                             "Configuration": {
                                 "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
-                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
                             }
                         }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -373,7 +373,7 @@
                     "Description": "The ID of the existing VPC to use.",
                     "Type": "String",
                     "TypeHint": "ExistingVpc",
-                    "DefaultValue": null,
+                    "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": false,
                     "Validators": [
@@ -381,7 +381,6 @@
                             "ValidatorType": "Regex",
                             "Configuration": {
                                 "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
-                                "AllowEmptyString": true,
                                 "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
                             }
                         }

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingVpcCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingVpcCommandTest.cs
@@ -54,7 +54,7 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
 
             var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
-            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VpcId");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VPC.VpcId");
 
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>());
             var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
@@ -93,7 +93,7 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
 
             var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_RECIPE_ID);
 
-            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VpcId");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VPC.VpcId");
 
             var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
             {


### PR DESCRIPTION
*Description of changes:*
We recently updated the VPC Connector setting in App Runner which involved adding a default VPC for VPC ID, updating validators and adding dependencies. These updates have now been applied to the rest of the recipes where applicable.
For beanstalk recipe, this will cause a breaking change as the VPC setting has now been turned into an Object type which included the "UseVPC" setting which is set to false by default. So deployments already using a VPC will need to delete and recreate their stacks as the VPC setting is not updatable in beanstalk.
Additionally, child option settings "Updatable" value was being ignored if parent setting's "Updatable" is true. This change fixes the behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
