### PR TITLE
fix: recipe validators are not run in server mode

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -34,6 +34,7 @@ using AWS.Deploy.CLI.Commands.TypeHints;
 using AWS.Deploy.Common.TypeHintData;
 using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.CLI.ServerMode.Controllers
 {
@@ -535,11 +536,20 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 throw new SelectedRecommendationIsNullException("The selected recommendation is null or invalid.");
 
             var optionSettingHandler = serviceProvider.GetRequiredService<IOptionSettingHandler>();
+            var validatorFactory = serviceProvider.GetRequiredService<IValidatorFactory>();
             var settingValidatorFailedResults = optionSettingHandler.RunOptionSettingValidators(state.SelectedRecommendation);
-            if (settingValidatorFailedResults.Any())
+            var recipeValidatorFailedResults =
+                        validatorFactory.BuildValidators(state.SelectedRecommendation.Recipe)
+                            .Select(async validator => await validator.Validate(state.SelectedRecommendation, orchestratorSession))
+                            .Select(x => x.Result)
+                            .Where(x => !x.IsValid)
+                            .ToList();
+            if (settingValidatorFailedResults.Any() || recipeValidatorFailedResults.Any())
             {
                 var settingValidationErrorMessage = $"The deployment configuration needs to be adjusted before it can be deployed:{Environment.NewLine}";
                 foreach (var result in settingValidatorFailedResults)
+                    settingValidationErrorMessage += $" - {result.ValidationFailedMessage}{Environment.NewLine}{Environment.NewLine}";
+                foreach (var result in recipeValidatorFailedResults)
                     settingValidationErrorMessage += $" - {result.ValidationFailedMessage}{Environment.NewLine}{Environment.NewLine}";
                 settingValidationErrorMessage += $"{Environment.NewLine}Please adjust your settings";
                 return Problem(settingValidationErrorMessage);

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -55,6 +55,52 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
         }
 
         [Fact]
+        public async Task GetAndApplyAppRunnerSettings_RecipeValidatorsAreRun()
+        {
+            _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
+            var portNumber = 4026;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ServerModeExtensions.ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await restClient.WaitTillServerModeReady();
+
+                var sessionId = await restClient.StartDeploymentSession(projectPath, _awsRegion);
+
+                var logOutput = new StringBuilder();
+                await ServerModeExtensions.SetupSignalRConnection(baseUrl, sessionId, logOutput);
+
+                var fargateRecommendation = await restClient.GetRecommendationsAndSetDeploymentTarget(sessionId, "AspNetAppEcsFargate", _stackName);
+
+                var applyConfigSettingsResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"TaskCpu", "4096"}
+                    }
+                });
+                Assert.Empty(applyConfigSettingsResponse.FailedConfigUpdates);
+
+                var exceptionThrown = await Assert.ThrowsAsync<ApiException>(async () => await restClient.StartDeploymentAsync(sessionId));
+                Assert.Contains("Cpu value 4096 is not compatible with memory value 512.", exceptionThrown.Response);
+            }
+            finally
+            {
+                cancelSource.Cancel();
+                _stackName = null;
+            }
+        }
+
+        [Fact]
         public async Task GetAndApplyAppRunnerSettings_VPCConnector()
         {
             _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5926

*Description of changes:*
This change runs the recipe validators in the StartDeployment API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
