### PR TITLE
fix: proper cdk version is not installed in the local deployment project directory

### DIFF
--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs
@@ -38,7 +38,7 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
             var projFiles = orchestrator._directoryManager.GetProjFiles(cdkProject);
             var cdkVersion = orchestrator._cdkVersionDetector.Detect(projFiles);
 
-            await orchestrator._cdkManager.EnsureCompatibleCDKExists(Constants.CDK.DeployToolWorkspaceDirectoryRoot, cdkVersion);
+            await orchestrator._cdkManager.EnsureCompatibleCDKExists(recommendation.Recipe.PersistedDeploymentProject ? cdkProject : Constants.CDK.DeployToolWorkspaceDirectoryRoot, cdkVersion);
 
             try
             {


### PR DESCRIPTION
*Description of changes:*
The integration test `AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject.RedeploymentTests.AttemptWorkFlow` has been failing due to a `cdk` issue with the following error:
```
Configuring AWS Cloud Development Kit (CDK)
CDK version 2.13.0 found in global node_modules.
Confirmed CDK Bootstrap CloudFormation stack already exists.
Deploying AWS CDK project
npx: installed 2 in 1.876s
Unexpected token '?'



We had an issue deploying your application to AWS. Check the deployment output for more details. Deployment took 3.19s.
   at AWS.Deploy.Orchestration.CdkProjectHandler.DeployCdkProject(OrchestratorSession session, CloudApplication cloudApplication, String cdkProjectPath, Recommendation recommendation) in /codebuild/output/src183934029/src/github.com/aws/aws-dotnet-deploy/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs:line 174
   at AWS.Deploy.Orchestration.DeploymentCommands.CdkDeploymentCommand.ExecuteAsync(Orchestrator orchestrator, CloudApplication cloudApplication, Recommendation recommendation) in /codebuild/output/src183934029/src/github.com/aws/aws-dotnet-deploy/src/AWS.Deploy.Orchestration/DeploymentCommands/CdkDeploymentCommand.cs:line 53
   at AWS.Deploy.Orchestration.Orchestrator.DeployRecommendation(CloudApplication cloudApplication, Recommendation recommendation) in /codebuild/output/src183934029/src/github.com/aws/aws-dotnet-deploy/src/AWS.Deploy.Orchestration/Orchestrator.cs:line 201
   at AWS.Deploy.CLI.Commands.DeployCommand.ExecuteAsync(String applicationName, String deploymentProjectPath, UserDeploymentSettings userDeploymentSettings) in /codebuild/output/src183934029/src/github.com/aws/aws-dotnet-deploy/src/AWS.Deploy.CLI/Commands/DeployCommand.cs:line 131
   at AWS.Deploy.CLI.Commands.CommandFactory.<BuildDeployCommand>b__41_0(DeployCommandHandlerInput input) in /codebuild/output/src183934029/src/github.com/aws/aws-dotnet-deploy/src/AWS.Deploy.CLI/Commands/CommandFactory.cs:line 249

[xUnit.net 00:05:42.07]     AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject.RedeploymentTests.AttemptWorkFlow [FAIL]
  Failed AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject.RedeploymentTests.AttemptWorkFlow [5 m 38 s]
  Error Message:
   Assert.Equal() Failure
Expected: 0
Actual:   1
  Stack Trace:
     at AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject.RedeploymentTests.AttemptWorkFlow() in /codebuild/output/src183934029/src/github.com/aws/aws-dotnet-deploy/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RedeploymentTests.cs:line 83
--- End of stack trace from previous location where exception was thrown ---
```

Doing some digging, it seems CDK has dropped support for Node 12 https://stackoverflow.com/questions/61630058/aws-cdk-unexpected-token
https://github.com/aws/jsii/releases/tag/v1.60.0
The integration test seems to be running a CDK version other than the one the deploy tool is installing. The deploy tool mechanism installs the required CDK version in the `.aws-dotnet-deploy` folder in the user directory. In the case of the deployment project, the directory to be used should be the deployment project. This PR does the necessary changes to support this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
