### PR TITLE
fix: Fixed environment variables not being set correctly in AWS App Runner deployments

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Recipe.cs
@@ -143,7 +143,7 @@ namespace AspNetAppAppRunner
                         {
                             Port = settings.Port.ToString(),
                             StartCommand = !string.IsNullOrWhiteSpace(settings.StartCommand) ? settings.StartCommand : null,
-                            RuntimeEnvironmentVariables = runtimeEnvironmentVariables
+                            RuntimeEnvironmentVariables = runtimeEnvironmentVariables.ToArray()
                         }
                     }
                 }

--- a/testapps/WebAppWithDockerFile/AppRunnerConfigFile.json
+++ b/testapps/WebAppWithDockerFile/AppRunnerConfigFile.json
@@ -1,0 +1,11 @@
+{
+    "ApplicationName": "AppAppRunner{Suffix}",
+    "RecipeId": "AspNetAppAppRunner",
+    "OptionSettingsConfig": {
+        "ServiceName": "MyNewService{Suffix}",
+        "AppRunnerEnvironmentVariables": {
+            "TEST_Key1": "Value1",
+            "TEST_Key2": "Value2"
+        }
+    }
+}

--- a/testapps/WebAppWithDockerFile/Controllers/EnvVarController.cs
+++ b/testapps/WebAppWithDockerFile/Controllers/EnvVarController.cs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace WebAppWithDockerFile.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class EnvVarController : ControllerBase
+    {
+        ILogger<EnvVarController> _logger;
+
+        public EnvVarController(ILogger<EnvVarController> logger)
+        {
+            this._logger = logger;
+        }
+
+        [HttpGet()]
+        public string Default(string name)
+        {
+            return "Hello";
+        }
+
+        [HttpGet("{name}")]
+        public IActionResult Get(string name)
+        {
+            _logger.LogInformation("Fetching environment variable " + name);
+            // Only expose environment variables starting with TEST_
+            if (!name.StartsWith("TEST_"))
+            {
+                _logger.LogError("Fetch failed because environment variable name didn't start with TEST_");
+                return BadRequest();
+            }
+            return Ok(Environment.GetEnvironmentVariable(name));
+        }
+    }
+}

--- a/testapps/WebAppWithDockerFile/Startup.cs
+++ b/testapps/WebAppWithDockerFile/Startup.cs
@@ -21,6 +21,7 @@ namespace WebAppWithDockerFile
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddControllers();
             services.AddRazorPages();
         }
 
@@ -47,6 +48,7 @@ namespace WebAppWithDockerFile
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapControllers();
                 endpoints.MapRazorPages();
             });
         }

--- a/testapps/WebAppWithDockerFile/WebAppWithDockerFile.csproj
+++ b/testapps/WebAppWithDockerFile/WebAppWithDockerFile.csproj
@@ -12,6 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="AppRunnerConfigFile.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Update="ECSFargateConfigFile.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
*Description of changes:*
The App Runner recipe allows users to configure environment variables but the environment variables were not being correctly being set on the App Runner CDK construct causing them to be ignored. The CDK project was passing the environment variables as a `List` but it needed to be an array.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
