### PR TITLE
feat: add validator to check if VPC has subnets in different AZs

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -60,6 +60,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="ComparisonValidator"/>
         /// </summary>
-        Comparison
+        Comparison,
+        /// <summary>
+        /// Must be paired with <see cref="VPCSubnetsInDifferentAZsValidator"/>
+        /// </summary>
+        VPCSubnetsInDifferentAZs
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/VPCSubnetsInDifferentAZsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/VPCSubnetsInDifferentAZsValidator.cs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that the selected VPC must have at least two subnets in two different Availability Zones
+    /// </summary>
+    public class VPCSubnetsInDifferentAZsValidator : IOptionSettingItemValidator
+    {
+        private static readonly string defaultValidationFailedMessage = "Selected VPC must have at least two subnets in two different Availability Zones.";
+        public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
+
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public VPCSubnetsInDifferentAZsValidator(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
+        {
+            var vpcId = input?.ToString();
+            if (string.IsNullOrEmpty(vpcId))
+                return ValidationResult.Failed("A VPC ID is not specified. Please select a valid VPC ID.");
+
+            var subnets = await _awsResourceQueryer.DescribeSubnets(vpcId);
+            var availabilityZones = new HashSet<string>();
+            foreach (var subnet in subnets)
+                availabilityZones.Add(subnet.AvailabilityZoneId);
+
+            if (availabilityZones.Count >= 2)
+                return ValidationResult.Valid();
+            else
+                return ValidationResult.Failed(ValidationFailedMessage);
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -59,7 +59,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.SubnetsInVpc, typeof(SubnetsInVpcValidator) },
             { OptionSettingItemValidatorList.SecurityGroupsInVpc, typeof(SecurityGroupsInVpcValidator) },
             { OptionSettingItemValidatorList.Uri, typeof(UriValidator) },
-            { OptionSettingItemValidatorList.Comparison, typeof(ComparisonValidator) }
+            { OptionSettingItemValidatorList.Comparison, typeof(ComparisonValidator) },
+            { OptionSettingItemValidatorList.VPCSubnetsInDifferentAZs, typeof(VPCSubnetsInDifferentAZsValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -324,6 +324,9 @@
                                 "Regex": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
                                 "ValidationFailedMessage": "Invalid VPC ID. The VPC ID must start with the \"vpc-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example vpc-abc88de9 is a valid VPC ID."
                             }
+                        },
+                        {
+                            "ValidatorType": "VPCSubnetsInDifferentAZs"
                         }
                     ],
                     "DependsOn": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -614,7 +614,8 @@
                                     "SubnetsInVpc",
                                     "SecurityGroupsInVpc",
                                     "Uri",
-                                    "Comparison"
+                                    "Comparison",
+                                    "VPCSubnetsInDifferentAZs"
                                 ]
                             }
                         },


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5893

*Description of changes:*
This PR tackles the deployment failure with the error: `At least two subnets in two different Availability Zones must be specified.`.
Added a validator for VPC ID in the fargate recipe to check if that VPC has more than 1 subnet and at least 2 subnets in different availability zones.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
