### PR TITLE
fix: failed setting updates in server mode return setting value instead of ID

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -266,7 +266,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 }
                 catch (Exception ex)
                 {
-                    output.FailedConfigUpdates.Add(input.UpdatedSettings[updatedSetting.FullyQualifiedId], ex.Message);
+                    output.FailedConfigUpdates.Add(updatedSetting.FullyQualifiedId, ex.Message);
                 }
             }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -101,6 +101,50 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
         }
 
         [Fact]
+        public async Task GetAndApplyAppRunnerSettings_FailedUpdatesReturnSettingId()
+        {
+            _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
+            var portNumber = 4027;
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ServerModeExtensions.ResolveCredentials);
+
+            var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
+            var cancelSource = new CancellationTokenSource();
+
+            var serverTask = serverCommand.ExecuteAsync(cancelSource.Token);
+            try
+            {
+                var baseUrl = $"http://localhost:{portNumber}/";
+                var restClient = new RestAPIClient(baseUrl, httpClient);
+
+                await restClient.WaitTillServerModeReady();
+
+                var sessionId = await restClient.StartDeploymentSession(projectPath, _awsRegion);
+
+                var logOutput = new StringBuilder();
+                await ServerModeExtensions.SetupSignalRConnection(baseUrl, sessionId, logOutput);
+
+                var fargateRecommendation = await restClient.GetRecommendationsAndSetDeploymentTarget(sessionId, "AspNetAppEcsFargate", _stackName);
+
+                var applyConfigSettingsResponse = await restClient.ApplyConfigSettingsAsync(sessionId, new ApplyConfigSettingsInput()
+                {
+                    UpdatedSettings = new Dictionary<string, string>()
+                    {
+                        {"DesiredCount", "test"}
+                    }
+                });
+                Assert.Single(applyConfigSettingsResponse.FailedConfigUpdates);
+                Assert.Equal("DesiredCount", applyConfigSettingsResponse.FailedConfigUpdates.Keys.First());
+            }
+            finally
+            {
+                cancelSource.Cancel();
+                _stackName = null;
+            }
+        }
+
+        [Fact]
         public async Task GetAndApplyAppRunnerSettings_VPCConnector()
         {
             _stackName = $"ServerModeWebAppRunner{Guid.NewGuid().ToString().Split('-').Last()}";


### PR DESCRIPTION
*Description of changes:*
A failed setting update using server mode's `ApplyConfigSettings` API was returning the setting value and the error message instead of the setting ID and error message. This caused the toolkit to not show a validation message for the setting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
