### PR TITLE
build: update the PR check infra to support node 14

### DIFF
--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -3,10 +3,9 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 14
     commands:
       # install .NET SDK
-      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 5.0
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0
       - export PATH="$PATH:$HOME/.dotnet"
   pre_build:

--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -95,7 +95,7 @@ Resources:
         ComputeType: BUILD_GENERAL1_LARGE
         Type: LINUX_CONTAINER
         ImagePullCredentialsType: CODEBUILD
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/standard:5.0
         EnvironmentVariables:
         - Name: TEST_RUNNER_ROLE_ARN
           Type: PLAINTEXT


### PR DESCRIPTION
*Description of changes:*
Since CDK has dropped support for Node 12, we need to update our PR check infra to the minimum supported Node version which is 14.
I needed to switch to an Ubuntu image instead of AL2 since AL2 only supports Node 12.
I also removed installing NET 5 since it is already installed on the Ubuntu image.
https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
