### PR TITLE
Docs for PR #636 - new exception when generating a Dockerfile with project references located outside of the solution directory

### DIFF
--- a/site/content/docs/docker/docker-generation.md
+++ b/site/content/docs/docker/docker-generation.md
@@ -1,6 +1,6 @@
 # Dockerfile Generation
 
-**IF YOUR PROJECT DOES NOT CONTAIN A DOCKERFILE, THE DEPLOYMENT TOOL WILL AUTOMATICALLY GENERATE IT,** otherwise an existing Dockerfile will be used for deployment.
+**IF YOUR PROJECT DOES NOT CONTAIN A DOCKERFILE, THE DEPLOYMENT TOOL WILL ATTEMPT TO AUTOMATICALLY GENERATE IT,** otherwise an existing Dockerfile will be used for deployment.
 
 The Dockerfile that deployment tools generates uses Docker's multistage build process. This allows efficient and smaller container images that only contain the bits that are required to run your application.
 

--- a/site/content/docs/support.md
+++ b/site/content/docs/support.md
@@ -16,7 +16,7 @@ The table below provides a matrix of supported .NET application types and AWS Co
 * Supports deployments of .NET applications as a service (e.g. web application or a background processor) or as a scheduled task (e.g. end-of-day process) to Amazon Elastic Container Service (Amazon ECS) with compute power managed by AWS Fargate serverless compute engine.
 * Recommended if you want to deploy a service or a scheduled task as a container image on Linux.
 
-> **Note: This compute requires a Dockerfile. IF YOUR PROJECT DOES NOT CONTAIN A DOCKERFILE, THE DEPLOYMENT TOOL WILL AUTOMATICALLY GENERATE IT,** otherwise an existing Dockerfile will be used.
+> **Note: This compute requires a Dockerfile. IF YOUR PROJECT DOES NOT CONTAIN A DOCKERFILE, THE DEPLOYMENT TOOL WILL ATTEMPT TO AUTOMATICALLY GENERATE IT,** otherwise an existing Dockerfile will be used.
 
 [**Amazon Elastic Container Service (Amazon ECS)**](https://aws.amazon.com/ecs/) is a fully managed container orchestration service that helps you easily deploy, manage, and scale containerized applications.
 
@@ -27,7 +27,7 @@ The table below provides a matrix of supported .NET application types and AWS Co
 * Supports deployments of containerized ASP.NET Core applications to AWS App Runner.
 * Recommended if you want to deploy your application as a container image on a fully managed environment.
 
-> **Note: This compute requires a Dockerfile. IF YOUR PROJECT DOES NOT CONTAIN A DOCKERFILE, THE DEPLOYMENT TOOL WILL AUTOMATICALLY GENERATE IT,** otherwise an existing Dockerfile will be used.
+> **Note: This compute requires a Dockerfile. IF YOUR PROJECT DOES NOT CONTAIN A DOCKERFILE, THE DEPLOYMENT TOOL WILL ATTEMPT TO AUTOMATICALLY GENERATE IT,** otherwise an existing Dockerfile will be used.
 
 [**AWS App Runner**](https://aws.amazon.com/apprunner/) is a fully managed service that makes it easy for developers to quickly deploy containerized web applications and APIs, at scale and with no prior infrastructure experience required. With App Runner, rather than thinking about servers or scaling, you have more time to focus on your applications.
 

--- a/site/content/troubleshooting-guide/docker-issues.md
+++ b/site/content/troubleshooting-guide/docker-issues.md
@@ -32,3 +32,9 @@ If you are missing the required AWS Identity and Access Management (IAM) permiss
 Failed to push Docker Image
 ```
 **Resolution**: See [here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html) for guidance on how to set IAM policy statements to allow actions on Amazon ECR repositories.
+
+## Failed to generate a Dockerfile
+
+**Why is this happening** You may see this if your project has project references (.csproj, .vbproj) that are located in a higher folder than the solution file (.sln) that AWS.Deploy.Tools is using to generate a Dockerfile. In this case AWS.Deploy.Tools will not generate a Dockerfile to avoid a large build context that can result in long builds.
+
+**Resolution**: If you would still like to deploy to an [AWS service that requires Docker](../docs/support.md), you must create your own Dockerfile and set an appropriate "Docker Execution Directory" in the deployment options. Alternatively you may choose another deployment target that does not require Docker, such as AWS Elastic Beanstalk.


### PR DESCRIPTION
*Issue #, if available:*  DOTNET-6011

*Description of changes:* Documentation changes for https://github.com/aws/aws-dotnet-deploy/pull/636


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
