### PR TITLE
fix: Instance type and windows platform arn type hints to accommodate recent API changes.

### DIFF
--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/InstanceTypeCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/InstanceTypeCommandTest.cs
@@ -94,9 +94,9 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
 
             var resources = await command.GetResources(beanstalkRecommendation, instanceTypeSetting);
 
-            Assert.Contains(resources, x => string.Equals("t1.any", x.SystemName, StringComparison.OrdinalIgnoreCase));
-            Assert.Contains(resources, x => string.Equals("t1.x86_64", x.SystemName, StringComparison.OrdinalIgnoreCase));
-            Assert.DoesNotContain(resources, x => string.Equals("t1.arm64", x.SystemName, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(resources.Rows, x => string.Equals("t1.any", x.SystemName, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(resources.Rows, x => string.Equals("t1.x86_64", x.SystemName, StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(resources.Rows, x => string.Equals("t1.arm64", x.SystemName, StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact]
@@ -153,9 +153,9 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
 
             var resources = await command.GetResources(beanstalkRecommendation, instanceTypeSetting);
 
-            Assert.Contains(resources, x => string.Equals("t1.any", x.SystemName, StringComparison.OrdinalIgnoreCase));
-            Assert.Contains(resources, x => string.Equals("t1.x86_64", x.SystemName, StringComparison.OrdinalIgnoreCase));
-            Assert.Contains(resources, x => string.Equals("t1.arm64", x.SystemName, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(resources.Rows, x => string.Equals("t1.any", x.SystemName, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(resources.Rows, x => string.Equals("t1.x86_64", x.SystemName, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(resources.Rows, x => string.Equals("t1.arm64", x.SystemName, StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact]


### PR DESCRIPTION
*Description of changes:*
The interface for type hints changes during the creation of the recent WIndows Beanstalk PR. This PR gets the new type hints compliant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
