### PR TITLE
Add additional troubleshooting guide entries for docker build issues

### DIFF
--- a/site/content/troubleshooting-guide/docker-issues.md
+++ b/site/content/troubleshooting-guide/docker-issues.md
@@ -3,25 +3,71 @@ This section of the troubleshooting guide explains how to determine, diagnose, a
 
 ## Docker not running in Linux mode
 
-**Why is this happening**: If you are on a Windows operating system, it is likely that you are running Docker in a Windows container. AWS.Deploy.Tools requires Docker to be running in Linux container mode.
+**Why is this happening**: If you are on a Windows operating system, it is likely that you are running Docker in Windows container mode. AWS.Deploy.Tools requires Docker to be running in Linux container mode.
 
 **Resolution**: See [here](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers) to switch between Windows and Linux containers.
 
 ## Failed to build Docker Image
 
-**Why is this happening**:
-Sometimes the Docker build command may fail due to the following reasons:
+There are multiple reasons your deployment may fail during the Docker build step.
 
-* **Invalid Docker execution directory**
-The Docker execution directory is the working directory for the Docker build command and this is where all relative paths in the Dockerfile are resolved from. By default, the execution directory is set to the project solution directory. However, it is possible that the Dockerfile is referencing projects outside the solution directory. Setting an invalid Docker execution directory would result in Docker build failure
+### **Invalid Dockerfile** 
+**Why is this happening**: If there is a syntax error or invalid argument in your Dockerfile, the Docker build command may fail with an error message like this:
 
-* **Missing project dependencies**
-The Docker build command may also fail if all project dependencies are not specified in the Dockerfile. 
+```
+failed to solve with frontend dockerfile.v0: failed to create LLB definition: <additional error message>
+``` 
+**Resolution**:
+Correct any syntax errors or invalid arguments in your Dockerfile. Consult [Docker's Dockerfile reference](https://docs.docker.com/engine/reference/builder/) for the expected syntax for each instruction.
+
+---
+
+### Invalid Docker execution directory
+**Why is this happening**: The Docker execution directory is the [working directory for the Docker build command](https://docs.docker.com/engine/reference/commandline/build/#build-with-path). All relative paths in the Dockerfile are resolved from this directory. By default, the execution directory is set to your project's solution directory. However it is possible that the Dockerfile is referencing projects outside of your solution directory, which may result in an error message like this:
+
+```
+failed to compute cache key: "/Path/To/A/Dependency.csproj" not found: not found
+```
 
 **Resolution**:
+AWS.Deploy.Tools allows you to specify an alternative Docker execution directory. Try setting an execution directory that can correctly evaluate all relative paths in the Dockerfile. If you are using the CLI version of AWS.Deploy.Tools, set the "Docker Execution Directory" under "Advanced Settings." If you are using the "Publish to AWS" feature in the AWS Toolkit for Visual Studio, set the "Docker Execution Directory" under the "Project Build" settings.
 
-* AWS.Deploy.Tools gives you the ability to specify a Docker execution directory of your choice. Try setting a different execution directory that can correctly evaluate all relative paths in the Dockerfile.
-* A good starting point to include all dependencies would be to inspect the solution file and add the relevant projects in the Dockerfile. If a custom Dockerfile is not provided, AWS.Deploy.Tools can generate one for container based deployments. It will inspect the solution file and include all projects defined in it to the generated Dockerfile. This Dockerfile is persisted on disk. In the future, if you add a new project to the solution file, you must manually add a new entry for it in the persisted Dockerfile.
+---
+
+### Missing project dependencies
+**Why is this happening**: 
+The Docker build command may fail during the `RUN dotnet build` instruction if all of your project dependencies are not specified in the Dockerfile. 
+
+**Resolution**:
+Ensure all dependencies from your project and solution files are included in your Dockerfile. A good starting point is to inspect the solution file and add the relevant projects to the Dockerfile. 
+
+If a custom Dockerfile is not initally provided, AWS.Deploy.Tools will generate one if you select a container-based deployment. The generated Dockerfile will include the projects currently defined in your solution file. This Dockerfile is persisted on disk. If you add a new dependency to the solution file in the future, you must manually add a new entry for it in the persisted Dockerfile.
+
+---
+
+### Failed to restore package references
+
+**Why is this happening**:
+The Docker build command may fail during the `RUN dotnet restore` instruction if the container does not have connectivity to the NuGet.
+
+You may see an error message like:
+
+```
+Unable to load the service index for source https://api.nuget.org/v3/index.json
+```
+
+or
+
+```
+Failed to download package <package name> from https://api.nuget.org/
+```
+
+**Resolution**:
+Your container may be unable to access the internet or NuGet for a variety of network-related reasons. If you are using Docker Desktop, consult the [Docker troubleshooting guide and documentation](https://docs.docker.com/desktop/faqs/general/#where-can-i-find-information-about-diagnosing-and-troubleshooting-docker-desktop-issues).
+
+If your container is able to access the internet but the package restore is failing because you are using a private NuGet feed, you may need to configure credentials for the private feed within the Dockerfile.
+
+---
 
 ## Failed to push Docker Image
 **Why is this happening**: AWS.Deploy.Tools builds the Docker image and pushes it to Amazon Elastic Container Registry (Amazon ECR). 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6060

*Description of changes:* Adding additional entries for the troubleshooting guide for issues related to `docker build`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
