### PR TITLE
feat: Add ability to save deployment settings to a config file

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -47,6 +47,8 @@ namespace AWS.Deploy.CLI.Commands
         private static readonly Option<string> _optionOutputDirectory = new(new[] { "-o", "--output" }, "Directory path in which the CDK deployment project will be saved.");
         private static readonly Option<string> _optionProjectDisplayName = new(new[] { "--project-display-name" }, "The name of the deployment project that will be displayed in the list of available deployment options.");
         private static readonly Option<string> _optionDeploymentProject = new(new[] { "--deployment-project" }, "The absolute or relative path of the CDK project that will be used for deployment");
+        private static readonly Option<string> _optionSaveSettings = new(new[] { "--save-settings" }, "The absolute or the relative JSON file path where the deployment settings will be saved. Only the settings modified by the user will be persisted");
+        private static readonly Option<string> _optionSaveAllSettings = new(new[] { "--save-all-settings" }, "The absolute or the relative JSON file path where the deployment settings will be saved. All deployment settings will be persisted");
         private static readonly object s_root_command_lock = new();
         private static readonly object s_child_command_lock = new();
 
@@ -180,6 +182,8 @@ namespace AWS.Deploy.CLI.Commands
                 deployCommand.Add(_optionDiagnosticLogging);
                 deployCommand.Add(_optionDisableInteractive);
                 deployCommand.Add(_optionDeploymentProject);
+                deployCommand.Add(_optionSaveSettings);
+                deployCommand.Add(_optionSaveAllSettings);
             }
 
             deployCommand.Handler = CommandHandler.Create(async (DeployCommandHandlerInput input) =>
@@ -252,7 +256,9 @@ namespace AWS.Deploy.CLI.Commands
                         deploymentProjectPath = Path.GetFullPath(deploymentProjectPath, targetApplicationDirectoryPath);
                     }
 
-                    await deploy.ExecuteAsync(input.ApplicationName ?? string.Empty, deploymentProjectPath, deploymentSettings);
+                    var saveSettingsConfig = Helpers.GetSaveSettingsConfiguration(input.SaveSettings, input.SaveAllSettings, targetApplicationDirectoryPath, _fileManager);
+
+                    await deploy.ExecuteAsync(input.ApplicationName ?? string.Empty, deploymentProjectPath, saveSettingsConfig, deploymentSettings);
 
                     return CommandReturnCodes.SUCCESS;
                 }

--- a/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/DeployCommandHandlerInput.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandHandlerInput/DeployCommandHandlerInput.cs
@@ -10,13 +10,54 @@ namespace AWS.Deploy.CLI.Commands.CommandHandlerInput
 {
     public class DeployCommandHandlerInput
     {
+        /// <summary>
+        /// AWS credential profile used to make calls to AWS.
+        /// </summary>
         public string? Profile { get; set; }
+
+        /// <summary>
+        /// AWS region to deploy the application to. For example, us-west-2.
+        /// </summary>
         public string? Region { get; set; }
+
+        /// <summary>
+        /// Path to the project to deploy.
+        /// </summary>
         public string? ProjectPath { get; set; }
+
+        /// <summary>
+        /// Name of the cloud application.
+        /// </summary>
         public string? ApplicationName { get; set; }
+
+        /// <summary>
+        /// Path to the deployment settings file to be applied.
+        /// </summary>
         public string? Apply { get; set; }
+
+        /// <summary>
+        /// Flag to enable diagnostic output.
+        /// </summary>
         public bool Diagnostics { get; set; }
+
+        /// <summary>
+        /// Flag to disable interactivity to execute commands without any prompts.
+        /// </summary>
         public bool Silent { get; set; }
+
+        /// <summary>
+        /// The absolute or relative path of the CDK project that will be used for deployment.
+        /// </summary>
         public string? DeploymentProject { get; set; }
+
+        /// <summary>
+        /// The absolute or the relative JSON file path where the deployment settings will be saved. Only the settings modified by the user are persisted.
+        /// </summary>
+        public string? SaveSettings { get; set; }
+
+        /// <summary>
+        /// The absolute or the relative JSON file path where the deployment settings will be saved. All deployment settings are persisted.
+        /// </summary>
+        public string? SaveAllSettings { get; set; }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -113,7 +113,7 @@ namespace AWS.Deploy.CLI.Commands
             _deploymentSettingsHandler = deploymentSettingsHandler;
         }
 
-        public async Task ExecuteAsync(string applicationName, string deploymentProjectPath, DeploymentSettings? deploymentSettings = null)
+        public async Task ExecuteAsync(string applicationName, string deploymentProjectPath, SaveSettingsConfiguration saveSettingsConfig, DeploymentSettings? deploymentSettings = null)
         {
             var (orchestrator, selectedRecommendation, cloudApplication) = await InitializeDeployment(applicationName, deploymentSettings, deploymentProjectPath);
 
@@ -129,6 +129,12 @@ namespace AWS.Deploy.CLI.Commands
             }
 
             await CreateDeploymentBundle(orchestrator, selectedRecommendation, cloudApplication);
+
+            if (saveSettingsConfig.SettingsType != SaveSettingsType.None)
+            {
+                await _deploymentSettingsHandler.SaveSettings(saveSettingsConfig, selectedRecommendation, cloudApplication, _session);
+                _toolInteractiveService.WriteLine($"{Environment.NewLine}Successfully saved the deployment settings at {saveSettingsConfig.FilePath}");
+            }
 
             await orchestrator.DeployRecommendation(cloudApplication, selectedRecommendation);
 
@@ -193,11 +199,27 @@ namespace AWS.Deploy.CLI.Commands
                 cloudApplicationName = deploymentSettings?.ApplicationName ?? string.Empty;
 
             // Prompt the user with a choice to re-deploy to existing targets or deploy to a new cloud application.
-            if (string.IsNullOrEmpty(cloudApplicationName))
+            // This prompt is NOT needed if the user is just pushing the docker image to ECR.
+            if (string.IsNullOrEmpty(cloudApplicationName) && !string.Equals(deploymentSettings?.RecipeId, Constants.RecipeIdentifier.PUSH_TO_ECR_RECIPE_ID))
                 cloudApplicationName = AskForCloudApplicationNameFromDeployedApplications(compatibleApplications);
 
             // Find existing application with the same CloudApplication name.
-            var deployedApplication = allDeployedApplications.FirstOrDefault(x => string.Equals(x.Name, cloudApplicationName));
+            CloudApplication? deployedApplication = null;
+            if (!string.IsNullOrEmpty(deploymentSettings?.RecipeId))
+            {
+                // if the recommendation is specified via a config file then find the deployed application by matching the deployment type along with the cloudApplicationName
+                var recommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, deploymentSettings.RecipeId));
+                if (recommendation == null)
+                {
+                    var errorMsg = "The recipe ID specified in the deployment settings file does not match any compatible deployment recipes.";
+                    throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNeedsAdjusting, errorMsg);
+                }
+                deployedApplication = allDeployedApplications.FirstOrDefault(x => string.Equals(x.Name, cloudApplicationName) && x.DeploymentType == recommendation.Recipe.DeploymentType);
+            }
+            else
+            {
+                deployedApplication = allDeployedApplications.FirstOrDefault(x => string.Equals(x.Name, cloudApplicationName));
+            }
 
             Recommendation? selectedRecommendation = null;
             if (deployedApplication != null)

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -124,7 +124,8 @@ namespace AWS.Deploy.Common
         FailedToGetOptionSettingValue = 10010200,
         ECRRepositoryNameIsNull = 10010300,
         FailedToReadCdkBootstrapVersion = 10010400,
-        UnsupportedOptionSettingType = 10010500
+        UnsupportedOptionSettingType = 10010500,
+        FailedToSaveDeploymentSettings = 10010600
     }
 
     public class ProjectFileNotFoundException : DeployToolException
@@ -291,6 +292,14 @@ namespace AWS.Deploy.Common
     public class InvalidFilePath : DeployToolException
     {
         public InvalidFilePath(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Throw if an error occurred while saving the deployment settings to a config file
+    /// </summary>
+    public class FailedToSaveDeploymentSettingsException : DeployToolException
+    {
+        public FailedToSaveDeploymentSettingsException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     public static class ExceptionExtensions

--- a/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
+++ b/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
@@ -27,6 +27,13 @@ namespace AWS.Deploy.Common.Recipes
         Task SetOptionSettingValue(Recommendation recommendation, OptionSettingItem optionSettingItem, object value, bool skipValidation = false);
 
         /// <summary>
+        /// This method is used to set values for <see cref="OptionSettingItem"/> bases on the fullyQualifiedId of the option setting.
+        /// Due to different validations that could be put in place, access to other services may be needed.
+        /// This method is meant to control access to those services and determine the value to be set.
+        /// </summary>
+        Task SetOptionSettingValue(Recommendation recommendation, string fullyQualifiedId, object value, bool skipValidation = false);
+
+        /// <summary>
         /// This method retrieves the <see cref="OptionSettingItem"/> related to a specific <see cref="Recommendation"/>.
         /// </summary>
         OptionSettingItem GetOptionSetting(Recommendation recommendation, string? jsonPath);
@@ -71,6 +78,11 @@ namespace AWS.Deploy.Common.Recipes
         /// Checks whether the Option Setting Item can be displayed as part of the settings summary of the previous deployment.
         /// </summary>
         bool IsSummaryDisplayable(Recommendation recommendation, OptionSettingItem optionSettingItem);
-    }
 
+        /// <summary>
+        /// Checks whether the option setting item has been modified by the user. If it has been modified, then it will hold a non-default value
+        /// </summary>
+        /// <returns>true if the option setting item has been modified or false otherwise</returns>
+        bool IsOptionSettingModified(Recommendation recommendation, OptionSettingItem optionSetting);
+    }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingValueType.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingValueType.cs
@@ -3,6 +3,14 @@
 
 namespace AWS.Deploy.Common.Recipes
 {
+    /// <summary>
+    /// <para>Specifies the type of value held by the OptionSettingItem.</para>
+    /// <para>The following peices will also need to be updated when adding a new OptionSettingValueType</para>
+    /// <para>1. DeployCommand.ConfigureDeploymentFromCli(Recommendation recommendation, OptionSettingItem setting)</para>
+    /// <para>2. OptionSettingItem.SetValue(IOptionSettingHandler optionSettingHandler, object valueOverride, IOptionSettingItemValidator[] validators, Recommendation recommendation, bool skipValidation)</para>
+    /// <para>3. OptionSettingHandler.IsOptionSettingDisplayable(Recommendation recommendation, OptionSettingItem optionSetting)</para>
+    /// <para>4. OptionSettingHandler.IsOptionSettingModified(Recommendation recommendation, OptionSettingItem optionSetting)</para>
+    /// </summary>
     public enum OptionSettingValueType
     {
         String,

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -8,6 +8,7 @@ namespace AWS.Deploy.Constants
     {
         // Recipe IDs
         public const string EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkEnvironment";
+        public const string PUSH_TO_ECR_RECIPE_ID = "PushContainerImageEcr";
 
         // Replacement Tokens
         public const string REPLACE_TOKEN_STACK_NAME = "{StackName}";

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -171,6 +171,8 @@ namespace AWS.Deploy.Orchestration
                 }
             }
 
+            // The docker build command will fail if a relative path is provided
+            dockerExecutionDirectory = _directoryManager.GetAbsolutePath(projectDirectory, dockerExecutionDirectory);
             return dockerExecutionDirectory;
         }
 

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -327,6 +327,10 @@ namespace AWS.Deploy.Orchestration
 
             await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation, imageTag);
 
+            // These option settings need to be persisted back as they are not always provided by the user and we have custom logic to determine their values
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, Constants.Docker.DockerExecutionDirectoryOptionId, recommendation.DeploymentBundle.DockerExecutionDirectory);
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, Constants.Docker.DockerfileOptionId, recommendation.DeploymentBundle.DockerfilePath);
+
             _interactiveService.LogSectionStart("Pushing container image to Elastic Container Registry (ECR)", "Using the docker CLI to log on to ECR and push the local image to ECR.");
             await _deploymentBundleHandler.PushDockerImageToECR(recommendation, respositoryName, imageTag);
         }

--- a/src/AWS.Deploy.Orchestration/SaveSettingsConfiguration.cs
+++ b/src/AWS.Deploy.Orchestration/SaveSettingsConfiguration.cs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common;
+
+namespace AWS.Deploy.Orchestration
+{
+    /// <summary>
+    /// This enum controls which settings are persisted when <see cref="DeploymentSettingsHandler.SaveSettings(SaveSettingsConfiguration, Recommendation, CloudApplication, OrchestratorSession)"/> is invoked
+    /// </summary>
+    public enum SaveSettingsType
+    {
+        None,
+        Modified,
+        All
+    }
+
+    public class SaveSettingsConfiguration
+    {
+        /// <summary>
+        /// Specifies which settings are persisted when <see cref="DeploymentSettingsHandler.SaveSettings(SaveSettingsConfiguration, Recommendation, CloudApplication, OrchestratorSession)"/> is invoked
+        /// </summary>
+        public readonly SaveSettingsType SettingsType;
+
+        /// <summary>
+        /// The absolute file path where deployment settings will be persisted
+        /// </summary>
+        public readonly string FilePath;
+
+        public SaveSettingsConfiguration(SaveSettingsType settingsType, string filePath)
+        {
+            SettingsType = settingsType;
+            FilePath = filePath;
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_Container.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_Container.json
@@ -1,0 +1,34 @@
+{
+  "AWSProfile": "default",
+  "AWSRegion": "us-west-2",
+  "ApplicationName": "MyAppStack",
+  "RecipeId": "AspNetAppAppRunner",
+  "Settings": {
+    "ServiceName": "MyAppRunnerService",
+    "Port": 100,
+    "StartCommand": "",
+    "ApplicationIAMRole": {
+      "CreateNew": true
+    },
+    "ServiceAccessIAMRole": {
+      "CreateNew": true
+    },
+    "Cpu": "1024",
+    "Memory": "2048",
+    "EncryptionKmsKey": "",
+    "HealthCheckProtocol": "TCP",
+    "HealthCheckPath": "",
+    "HealthCheckInterval": 5,
+    "HealthCheckTimeout": 2,
+    "HealthCheckHealthyThreshold": 3,
+    "HealthCheckUnhealthyThreshold": 3,
+    "VPCConnector": {
+      "UseVPCConnector": false
+    },
+    "AppRunnerEnvironmentVariables": "",
+    "DockerBuildArgs": "",
+    "DockerfilePath": "DockerAssets/Dockerfile",
+    "DockerExecutionDirectory": "DockerAssets",
+    "ECRRepositoryName": "my-ecr-repository"
+  }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_Container_ModifiedOnly.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_Container_ModifiedOnly.json
@@ -1,0 +1,13 @@
+{
+  "AWSProfile": "default",
+  "AWSRegion": "us-west-2",
+  "ApplicationName": "MyAppStack",
+  "RecipeId": "AspNetAppAppRunner",
+  "Settings": {
+    "ServiceName": "MyAppRunnerService",
+    "Port": 100,
+    "DockerfilePath": "DockerAssets/Dockerfile",
+    "DockerExecutionDirectory": "DockerAssets",
+    "ECRRepositoryName": "my-ecr-repository"
+  }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
@@ -1,0 +1,46 @@
+{
+  "AWSProfile": "default",
+  "AWSRegion": "us-west-2",
+  "ApplicationName": "MyAppStack",
+  "RecipeId": "AspNetAppElasticBeanstalkLinux",
+  "Settings": {
+    "BeanstalkApplication": "MyBeanstalkApplication",
+    "BeanstalkEnvironment": {
+      "EnvironmentName": "MyBeanstalkEnvironment"
+    },
+    "InstanceType": "",
+    "EnvironmentType": "LoadBalanced",
+    "LoadBalancerType": "application",
+    "ApplicationIAMRole": {
+      "CreateNew": true
+    },
+    "ServiceIAMRole": {
+      "CreateNew": true
+    },
+    "EC2KeyPair": "",
+    "ElasticBeanstalkPlatformArn": "Latest-ARN",
+    "ElasticBeanstalkManagedPlatformUpdates": {
+      "ManagedActionsEnabled": true,
+      "PreferredStartTime": "Sun:00:00",
+      "UpdateLevel": "minor"
+    },
+    "XRayTracingSupportEnabled": true,
+    "ReverseProxy": "nginx",
+    "EnhancedHealthReporting": "enhanced",
+    "HealthCheckURL": "/",
+    "ElasticBeanstalkRollingUpdates": {
+      "RollingUpdatesEnabled": false
+    },
+    "CNamePrefix": "",
+    "ElasticBeanstalkEnvironmentVariables": {
+      "key1": "value1",
+      "key2": "value2"
+    },
+    "VPC": {
+      "UseVPC": false
+    },
+    "DotnetBuildConfiguration": "Release",
+    "DotnetPublishArgs": "",
+    "SelfContainedBuild": false
+  }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer_ModifiedOnly.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer_ModifiedOnly.json
@@ -1,0 +1,17 @@
+{
+  "AWSProfile": "default",
+  "AWSRegion": "us-west-2",
+  "ApplicationName": "MyAppStack",
+  "RecipeId": "AspNetAppElasticBeanstalkLinux",
+  "Settings": {
+    "BeanstalkEnvironment": {
+      "EnvironmentName": "MyBeanstalkEnvironment"
+    },
+    "EnvironmentType": "LoadBalanced",
+    "XRayTracingSupportEnabled": true,
+    "ElasticBeanstalkEnvironmentVariables": {
+      "key1": "value1",
+      "key2": "value2"
+    }
+  }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_PushImageECR.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_PushImageECR.json
@@ -1,0 +1,12 @@
+{
+  "AWSProfile": "default",
+  "AWSRegion": "us-west-2",
+  "RecipeId": "PushContainerImageEcr",
+  "Settings": {
+    "ImageTag": 123456789,
+    "DockerBuildArgs": "",
+    "DockerfilePath": "DockerAssets/Dockerfile",
+    "DockerExecutionDirectory": "DockerAssets",
+    "ECRRepositoryName": "my-ecr-repository"
+  }
+}

--- a/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestFileManager.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/IO/TestFileManager.cs
@@ -51,6 +51,8 @@ namespace AWS.Deploy.CLI.Common.UnitTests.IO
                 return Exists(Path.Combine(directory, path));
             }
         }
+
+        public bool IsFileValidPath(string filePath) => throw new NotImplementedException();
     }
 
     public static class TestFileManagerExtensions

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ECSFargateDeploymentTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using Amazon.CloudFormation;
 using Amazon.ECS;
 using Amazon.ECS.Model;
@@ -59,14 +60,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
         [Fact]
         public async Task PerformDeployment()
         {
-            // Deploy
+            var stackNamePlaceholder = "{StackName}";
+            _stackName = $"WebAppWithDockerFile{Guid.NewGuid().ToString().Split('-').Last()}";
+            _clusterName = $"{_stackName}-cluster";
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
             var configFilePath = Path.Combine(Directory.GetParent(projectPath).FullName, "ECSFargateConfigFile.json");
-            var suffix = ConfigFileHelper.ReplacePlaceholders(configFilePath);
+            ConfigFileHelper.ApplyReplacementTokens(new Dictionary<string, string> { { stackNamePlaceholder, _stackName } }, configFilePath);
 
-            _stackName = $"EcsFargate{suffix}";
-            _clusterName = $"MyNewCluster{suffix}";
-
+            // Deploy
             var deployArgs = new[] { "deploy", "--project-path", projectPath, "--apply", configFilePath, "--silent", "--diagnostics" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ConfigFileHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ConfigFileHelper.cs
@@ -2,20 +2,83 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.RecommendationEngine;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.Helpers
 {
     public class ConfigFileHelper
     {
-        public static string ReplacePlaceholders(string configFilePath)
+        /// <summary>
+        /// Applies replacement tokens to a file
+        /// </summary>
+        public static void ApplyReplacementTokens(Dictionary<string, string> replacements, string filePath)
         {
-            var suffix = Guid.NewGuid().ToString().Split('-').Last();
-            var json = File.ReadAllText(configFilePath);
-            json = json.Replace("{Suffix}", suffix);
-            File.WriteAllText(configFilePath, json);
-            return suffix;
+            var content = File.ReadAllText(filePath);
+            foreach (var replacement in replacements)
+            {
+                content = content.Replace(replacement.Key, replacement.Value);
+            }
+            File.WriteAllText(filePath, content);
+        }
+
+        /// <summary>
+        /// This method create a JSON config file from the specified recipeId and option setting values
+        /// </summary>
+        /// <param name="serviceProvider">The dependency injection container</param>
+        /// <param name="applicationName">The cloud application name used to uniquely identify the app within AWS. Ex - CloudFormation stack name</param>
+        /// <param name="recipeId">The recipeId for the deployment recommendation</param>
+        /// <param name="optionSettings">This is a dictionary with FullyQualifiedId as key and their corresponsing option setting values</param>
+        /// <param name="projectPath">The path to the .NET application that will be deployed</param>
+        /// <param name="configFilePath">The absolute JSON file path where the deployment settings are persisted</param>
+        public static async Task CreateConfigFile(IServiceProvider serviceProvider, string applicationName, string recipeId, Dictionary<string, object> optionSettings, string projectPath, string configFilePath, SaveSettingsType saveSettingsType)
+        {
+            var parser = serviceProvider.GetService<IProjectDefinitionParser>();
+            var optionSettingHandler = serviceProvider.GetRequiredService<IOptionSettingHandler>();
+            var deploymentSettingHandler = serviceProvider.GetRequiredService<IDeploymentSettingsHandler>();
+
+            var orchestratorSession = new OrchestratorSession(parser.Parse(projectPath).Result);
+            var cloudApplication = new CloudApplication(applicationName, "", CloudApplicationResourceType.CloudFormationStack, recipeId);
+
+            var recommendationEngine = new RecommendationEngine(orchestratorSession, serviceProvider.GetService<IRecipeHandler>());
+            var recommendations = await recommendationEngine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, recipeId));
+
+            foreach (var item in optionSettings)
+            {
+                await optionSettingHandler.SetOptionSettingValue(selectedRecommendation, item.Key, item.Value, skipValidation: true);
+            }
+
+            await deploymentSettingHandler.SaveSettings(new SaveSettingsConfiguration(saveSettingsType, configFilePath), selectedRecommendation, cloudApplication, orchestratorSession);
+        }
+
+        /// <summary>
+        /// Verifies that the file contents are the same by accounting for os-specific new line delimiters.
+        /// </summary>
+        /// <returns>true if the contents match, false otherwise</returns>
+        public static async Task<bool> VerifyConfigFileContents(string expectedContentPath, string actualContentPath)
+        {
+            var expectContent = await File.ReadAllTextAsync(expectedContentPath);
+            var actualContent = await File.ReadAllTextAsync(actualContentPath);
+            actualContent = SanitizeFileContents(actualContent);
+            expectContent = SanitizeFileContents(expectContent);
+            return string.Equals(expectContent, actualContent);
+        }
+
+        private static string SanitizeFileContents(string content)
+        {
+            return content.Replace("\r\n", Environment.NewLine)
+                .Replace("\n", Environment.NewLine)
+                .Replace("\r\r\n", Environment.NewLine)
+                .Trim();
         }
     }
 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -72,6 +72,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
         public async Task DefaultConfigurations()
         {
             _stackName = $"WebAppNoDockerFile{Guid.NewGuid().ToString().Split('-').Last()}";
+            var saveSettingsFilePath = Path.Combine(Path.GetTempPath(), $"DeploymentSettings-{Guid.NewGuid().ToString().Split('-').Last()}.json");
 
             // Arrange input for deploy
             await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
@@ -80,7 +81,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
             // Deploy
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
-            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics", "--save-settings", saveSettingsFilePath };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 
             // Verify application is deployed and running
@@ -104,6 +105,9 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.True(File.Exists(Path.Combine(_customWorkspace, "CDKBootstrapTemplate.yaml")));
             Assert.True(Directory.Exists(Path.Combine(_customWorkspace, "temp")));
             Assert.True(Directory.Exists(Path.Combine(_customWorkspace, "Projects")));
+
+            // Verify existence of the saved deployment settings file
+            Assert.True(File.Exists(saveSettingsFilePath));
 
             // list
             var listArgs = new[] { "list-deployments", "--diagnostics" };

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppWithDockerFileTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Collections.Generic;
 using Amazon.CloudFormation;
 using Amazon.ECS;
 using Amazon.ECS.Model;
@@ -123,13 +124,13 @@ namespace AWS.Deploy.CLI.IntegrationTests
         [Fact]
         public async Task AppRunnerDeployment()
         {
+            var stackNamePlaceholder = "{StackName}";
             _stackName = $"WebAppWithDockerFile{Guid.NewGuid().ToString().Split('-').Last()}";
-
-            // Deploy
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppWithDockerFile", "WebAppWithDockerFile.csproj"));
             var configFilePath = Path.Combine(Directory.GetParent(projectPath).FullName, "AppRunnerConfigFile.json");
-            ConfigFileHelper.ReplacePlaceholders(configFilePath);
+            ConfigFileHelper.ApplyReplacementTokens(new Dictionary<string, string> { { stackNamePlaceholder, _stackName } }, configFilePath);
 
+            // Deploy
             var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics", "--apply", configFilePath, "--silent" };
             Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
 

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -97,7 +97,7 @@ namespace AWS.Deploy.CLI.UnitTests
         [Fact]
         public async Task BuildDockerImage_DockerExecutionDirectorySet()
         {
-            var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
+            var projectPath = new DirectoryInfo(SystemIOUtilities.ResolvePath("ConsoleAppTask")).FullName;
             var project = await _projectDefinitionParser.Parse(projectPath);
             var options = new List<OptionSettingItem>()
             {

--- a/test/AWS.Deploy.CLI.UnitTests/IsOptionSettingModifiedTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/IsOptionSettingModifiedTests.cs
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Constants;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class IsOptionSettingModifiedTests
+    {
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+
+        public IsOptionSettingModifiedTests()
+        {
+            _serviceProvider = new Mock<IServiceProvider>();
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
+        }
+
+        [Fact]
+        public async Task IsOptionSettingModified_ElasticBeanstalk()
+        {
+            // ARRANGE - select recommendation
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+            var recommendations = await engine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, "AspNetAppElasticBeanstalkLinux"));
+
+            // ARRANGE - add replacement tokens
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN, "Latest-ARN");
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_STACK_NAME, "MyAppStack");
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID, "vpc-12345678");
+
+            // ARRANGE - modify settings so that they are different from their default values
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "BeanstalkEnvironment.EnvironmentName", "MyEnvironment", skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "EnvironmentType", "LoadBalanced", skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ApplicationIAMRole.CreateNew", false, skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ApplicationIAMRole.RoleArn", "MyRoleArn", skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "XRayTracingSupportEnabled", true, skipValidation: true);
+            var modifiedSettingsId = new HashSet<string>
+            {
+                "BeanstalkEnvironment", "EnvironmentType", "ApplicationIAMRole", "XRayTracingSupportEnabled"
+            };
+
+            // ACT and ASSERT
+            foreach (var optionSetting in selectedRecommendation.GetConfigurableOptionSettingItems())
+            {
+                if (modifiedSettingsId.Contains(optionSetting.FullyQualifiedId))
+                {
+                    Assert.True(_optionSettingHandler.IsOptionSettingModified(selectedRecommendation, optionSetting));
+                }
+                else
+                {
+                    Assert.False(_optionSettingHandler.IsOptionSettingModified(selectedRecommendation, optionSetting));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task IsOptionSettingModified_ECSFargate()
+        {
+            // ARRANGE - select recommendation
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+            var recommendations = await engine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, "AspNetAppEcsFargate"));
+
+            // ARRANGE - add replacement tokens
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_STACK_NAME, "MyAppStack");
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID, "vpc-12345678");
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_HAS_DEFAULT_VPC, true);
+
+            // ARRANGE - modify settings so that they are different from their default values
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ECSServiceName", "MyECSService", skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DesiredCount", 10, skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ECSCluster.CreateNew", false, skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ECSCluster.ClusterArn", "MyClusterArn", skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DockerfilePath", "Path/To/DockerFile", skipValidation: true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DockerExecutionDirectory", "Path/To/ExecutionDirectory", skipValidation: true);
+            var modifiedSettingsId = new HashSet<string>
+            {
+                "ECSServiceName", "DesiredCount", "ECSCluster", "DockerfilePath", "DockerExecutionDirectory"
+            };
+
+            // ACT and ASSERT
+            foreach (var optionSetting in selectedRecommendation.GetConfigurableOptionSettingItems())
+            {
+                if (modifiedSettingsId.Contains(optionSetting.FullyQualifiedId))
+                {
+                    Assert.True(_optionSettingHandler.IsOptionSettingModified(selectedRecommendation, optionSetting));
+                }
+                else
+                {
+                    Assert.False(_optionSettingHandler.IsOptionSettingModified(selectedRecommendation, optionSetting));
+                }
+            }
+        }
+    }
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/GetSaveSettingsConfigurationTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/GetSaveSettingsConfigurationTests.cs
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Orchestration.Utilities;
+using AWS.Deploy.Common;
+using Moq;
+using Xunit;
+using System.IO;
+using AWS.Deploy.Common.IO;
+
+namespace AWS.Deploy.Orchestration.UnitTests
+{
+    public class GetSaveSettingsConfigurationTests
+    {
+        [Fact]
+        public void GetSaveSettingsConfiguration_InvalidConfiguration_ThrowsException()
+        {
+            // ARRANGE
+            var saveSettingsPath = "Path/To/JSONFile/1";
+            var saveAllSettingsPath = "Path/To/JSONFile/2";
+            var projectDirectory = "Path/To/ProjectDirectory";
+            var fileManager = new Mock<IFileManager>();
+            fileManager.Setup(x => x.IsFileValidPath(It.IsAny<string>())).Returns(true);
+
+            //ACT and ASSERT
+            // Its throws an exception because saveSettings and saveSettingsAll both hold a non-null value
+            Assert.Throws<FailedToSaveDeploymentSettingsException>(() => Helpers.GetSaveSettingsConfiguration(saveSettingsPath, saveAllSettingsPath, projectDirectory, fileManager.Object));
+        }
+
+        [Fact]
+        public void GetSaveSettingsConfiguration_ModifiedSettings()
+        {
+            // ARRANGE
+            var temp = Path.GetTempPath();
+            var saveSettingsPath = Path.Combine(temp, "Path", "To", "JSONFile");
+            var projectDirectory = Path.Combine(temp, "Path", "To", "ProjectDirectory");
+            var fileManager = new Mock<IFileManager>();
+            fileManager.Setup(x => x.IsFileValidPath(It.IsAny<string>())).Returns(true);
+
+            // ACT
+            var saveSettingsConfiguration = Helpers.GetSaveSettingsConfiguration(saveSettingsPath, null, projectDirectory, fileManager.Object);
+
+            // ASSERT
+            Assert.Equal(SaveSettingsType.Modified, saveSettingsConfiguration.SettingsType);
+            Assert.Equal(saveSettingsPath, saveSettingsConfiguration.FilePath);
+        }
+
+        [Fact]
+        public void GetSaveSettingsConfiguration_AllSettings()
+        {
+            // ARRANGE
+            var temp = Path.GetTempPath();
+            var saveAllSettingsPath = Path.Combine(temp, "Path", "To", "JSONFile");
+            var projectDirectory = Path.Combine(temp, "Path", "To", "ProjectDirectory");
+            var fileManager = new Mock<IFileManager>();
+            fileManager.Setup(x => x.IsFileValidPath(It.IsAny<string>())).Returns(true);
+
+            // ACT
+            var saveSettingsConfiguration = Helpers.GetSaveSettingsConfiguration(null, saveAllSettingsPath, projectDirectory, fileManager.Object);
+
+            // ASSERT
+            Assert.Equal(SaveSettingsType.All, saveSettingsConfiguration.SettingsType);
+            Assert.Equal(saveAllSettingsPath, saveSettingsConfiguration.FilePath);
+        }
+
+        [Fact]
+        public void GetSaveSettingsConfiguration_None()
+        {
+            // ARRANGE
+            var temp = Path.GetTempPath();
+            var projectDirectory = Path.Combine(temp, "Path", "To", "ProjectDirectory");
+            var fileManager = new Mock<IFileManager>();
+            fileManager.Setup(x => x.IsFileValidPath(It.IsAny<string>())).Returns(true);
+
+            // ACT
+            var saveSettingsConfiguration = Helpers.GetSaveSettingsConfiguration(null, null, projectDirectory, fileManager.Object);
+
+            // ASSERT
+            Assert.Equal(SaveSettingsType.None, saveSettingsConfiguration.SettingsType);
+            Assert.Equal(string.Empty, saveSettingsConfiguration.FilePath);
+        }
+    }
+}

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestFileManager.cs
@@ -41,6 +41,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
         public FileStream OpenRead(string filePath) => throw new NotImplementedException();
         public string GetExtension(string filePath) => throw new NotImplementedException();
         public long GetSizeInBytes(string filePath) => throw new NotImplementedException();
+        public bool IsFileValidPath(string filePath) => throw new NotImplementedException();
     }
 
     public static class TestFileManagerExtensions

--- a/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
+++ b/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile.json
@@ -1,18 +1,15 @@
 {
-    "ApplicationName": "ElasticBeanStalk{Suffix}",
-    "RecipeId": "AspNetAppElasticBeanstalkLinux",
-    "Settings": {
-        "BeanstalkApplication": {
-            "CreateNew": true,
-            "ApplicationName": "MyApplication{Suffix}"
-        },
-        "BeanstalkEnvironment": {
-            "EnvironmentName": "MyEnvironment{Suffix}"
-        },
-        "EnvironmentType": "LoadBalanced",
-        "LoadBalancerType": "application",
-        "ApplicationIAMRole": {
-            "CreateNew": true
-        }
-    }
+  "ApplicationName": "{StackName}",
+  "RecipeId": "AspNetAppElasticBeanstalkLinux",
+  "Settings": {
+    "BeanstalkApplication": {
+      "CreateNew": true,
+      "ApplicationName": "{StackName}-app"
+    },
+    "BeanstalkEnvironment": {
+      "EnvironmentName": "{StackName}-dev"
+    },
+    "EnvironmentType": "LoadBalanced",
+    "XRayTracingSupportEnabled": true
   }
+}

--- a/testapps/WebAppWithDockerFile/AppRunnerConfigFile.json
+++ b/testapps/WebAppWithDockerFile/AppRunnerConfigFile.json
@@ -1,8 +1,8 @@
 {
-    "ApplicationName": "AppAppRunner{Suffix}",
+    "ApplicationName": "{StackName}",
     "RecipeId": "AspNetAppAppRunner",
     "Settings": {
-        "ServiceName": "MyNewService{Suffix}",
+        "ServiceName": "{StackName}-service",
         "AppRunnerEnvironmentVariables": {
             "TEST_Key1": "Value1",
             "TEST_Key2": "Value2"

--- a/testapps/WebAppWithDockerFile/ECSFargateConfigFile.json
+++ b/testapps/WebAppWithDockerFile/ECSFargateConfigFile.json
@@ -1,13 +1,13 @@
 {
-    "ApplicationName": "EcsFargate{Suffix}",
+    "ApplicationName": "{StackName}",
     "RecipeId": "AspNetAppEcsFargate",
     "Settings":{
         "ECSCluster":
         {
             "CreateNew": true,
-            "NewClusterName": "MyNewCluster{Suffix}"
+            "NewClusterName": "{StackName}-cluster"
         },
-        "ECSServiceName": "MyNewService{Suffix}",
+        "ECSServiceName": "{StackName}-service",
         "DesiredCount": 3,
         "ApplicationIAMRole":
         {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6021

*Description of changes:*
This PR adds the ability to save deployment settings to a config file using the following command:
`dotnet aws deploy [--save-settings | --save-all-settings] <deployment_settings_path> --project-path <project_path>`

Documentation PR - https://github.com/aws/aws-dotnet-deploy/pull/668 (needs to be updated to include the `--save-settings-all` switch)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
