### PR TITLE
docs: Add emoji support to the docs website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,3 +71,7 @@ theme:
   icon:
     logo: aws-logo-light
   favicon: assets/images/aws-logo-light.svg
+
+markdown_extensions:
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji

--- a/site/content/docs/support.md
+++ b/site/content/docs/support.md
@@ -4,11 +4,11 @@ The table below provides a matrix of supported .NET application types and AWS Co
 
 |                   | .NET Console App   | 	ASP.NET Core    | Blazor WebAssembly   |
 | :---              |    :----:     |          :---:    |    :---:  |
-| Amazon Elastic Container Service (ECS) service (Linux)| X             | X                 |           |
-| Amazon Elastic Container Service (ECS) task (Linux)	| X             | X                 |           |
-| AWS App Runner (Linux)   |              | X                 |           |
-| AWS Elastic Beanstalk (Linux and Windows)     |               | X                 |           |
-| Amazon S3 & Amazon CloudFront        |               |                   |   X       |
+| Amazon Elastic Container Service (ECS) service (Linux)| :heavy_check_mark:             | :heavy_check_mark:               |           |
+| Amazon Elastic Container Service (ECS) task (Linux)	| :heavy_check_mark:             | :heavy_check_mark:                |           |
+| AWS App Runner (Linux)   |              | :heavy_check_mark:                 |           |
+| AWS Elastic Beanstalk (Linux and Windows)     |               | :heavy_check_mark:                 |           |
+| Amazon S3 & Amazon CloudFront        |               |                   |   :heavy_check_mark:       |
 
 
 ### Amazon ECS using AWS Fargate


### PR DESCRIPTION
*Description of changes:*
Currently, the supported application types in the _Support Matrix_  section are denoted by a _"X"_. This can be confusing to customers as they may think that these application types are **not supported**
![image](https://user-images.githubusercontent.com/36622308/175633731-c1e30a61-cda7-4406-bc0e-847db3dc5915.png)


This PR adds emoji support to the documentation and replaces the _"X"_ with a check-mark emoji
![image](https://user-images.githubusercontent.com/36622308/175634777-c99f2b6f-1017-44d6-a88b-3b27f5bccda8.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
