### PR TITLE
fix: Fix integration tests failure from setting a custom workspace

### DIFF
--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/TestEnvironmentVariableManager.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/TestEnvironmentVariableManager.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AWS.Deploy.Orchestration.Utilities;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public class TestEnvironmentVariableManager : IEnvironmentVariableManager
+    {
+        public readonly Dictionary<string, string> store = new Dictionary<string, string>();
+
+        public string GetEnvironmentVariable(string variable)
+        {
+            return store.ContainsKey(variable) ? store[variable] : null;
+        }
+
+        public void SetEnvironmentVariable(string variable, string value)
+        {
+            if (string.Equals(variable, "AWS_DOTNET_DEPLOYTOOL_WORKSPACE"))
+                store[variable] = value;
+            else
+                Environment.SetEnvironmentVariable(variable, value);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/Utilities.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/Utilities.cs
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using AWS.Deploy.Orchestration.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace AWS.Deploy.CLI.IntegrationTests.Helpers
+{
+    public static class Utilities
+    {
+        /// <summary>
+        /// This method sets a custom workspace which will be used by the deploy tool to create and run the CDK project and any temporary files during the deployment.
+        /// It also adds a nuget.config file that references a private nuget-cache. This cache holds the latest (in-development/unreleased) version of AWS.Deploy.Recipes.CDK.Common.nupkg file
+        /// </summary>
+        public static void OverrideDefaultWorkspace(ServiceProvider serviceProvider, string customWorkspace)
+        {
+            var environmentVariableManager = serviceProvider.GetRequiredService<IEnvironmentVariableManager>();
+            environmentVariableManager.SetEnvironmentVariable("AWS_DOTNET_DEPLOYTOOL_WORKSPACE", customWorkspace);
+            Directory.CreateDirectory(customWorkspace);
+
+            var nugetCachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aws-dotnet-deploy", "Projects", "nuget-cache");
+            nugetCachePath = nugetCachePath.Replace(Path.DirectorySeparatorChar, '/');
+
+            var nugetConfigContent = $@"
+<?xml version=""1.0"" encoding=""utf-8"" ?>
+<configuration>
+    <packageSources>
+        <add key=""deploy-tool-cache"" value=""{nugetCachePath}"" />
+    </packageSources>
+</configuration>
+".Trim();
+
+            File.WriteAllText(Path.Combine(customWorkspace, "nuget.config"), nugetConfigContent);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -52,9 +52,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             _customWorkspace = Path.Combine(Path.GetTempPath(), $"deploy-tool-workspace{Guid.NewGuid().ToString().Split('-').Last()}");
-            var environmentVariableManager = serviceProvider.GetRequiredService<IEnvironmentVariableManager>();
-            environmentVariableManager.SetEnvironmentVariable("AWS_DOTNET_DEPLOYTOOL_WORKSPACE", _customWorkspace);
-            Directory.CreateDirectory(_customWorkspace);
+            Helpers.Utilities.OverrideDefaultWorkspace(serviceProvider, _customWorkspace);
 
             _app = serviceProvider.GetService<App>();
             Assert.NotNull(_app);
@@ -202,24 +200,6 @@ namespace AWS.Deploy.CLI.IntegrationTests
         ~WebAppNoDockerFileTests()
         {
             Dispose(false);
-        }
-    }
-
-    public class TestEnvironmentVariableManager : IEnvironmentVariableManager
-    {
-        public readonly Dictionary<string, string> store = new Dictionary<string, string>();
-
-        public string GetEnvironmentVariable(string variable)
-        {
-            return store.ContainsKey(variable) ? store[variable] : null;
-        }
-
-        public void SetEnvironmentVariable(string variable, string value)
-        {
-            if (string.Equals(variable, "AWS_DOTNET_DEPLOYTOOL_WORKSPACE"))
-                store[variable] = value;
-            else
-                Environment.SetEnvironmentVariable(variable, value);
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*
The `WebAppNoDockerFileTests` integ tests sets up a custom workspace to use the deploy tool. However, the custom workspace cannot reference the private nuget cache created at - `<USERPROFILE>/.aws-dotnet-deploy/Projects/nuget-cache`.
As a result, the integ tests cannot find the latest (in-development/unreleased) version of `AWS.Deploy.Recipes.CDK.Common.nupkg`

This PR creates a `nuget.config` file inside the custom workspace and adds a reference to the above mentioned nuget-cache


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
