### PR TITLE
feat: added validation for Preferred Start Time in Beanstalk recipe

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -470,6 +470,15 @@
                     "DefaultValue": "Sun:00:00",
                     "AdvancedSetting": true,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):(0[0-9]|1\\d|2[0-3]):(0[0-9]|1\\d|2\\d|3\\d|4\\d|5\\d)$",
+                                "ValidationFailedMessage": "Invalid Preferred Start Time. You need to specify a day and time in the 'day:hour:minute' format such as 'Sun:00:00'."
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "ElasticBeanstalkManagedPlatformUpdates.ManagedActionsEnabled",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -459,6 +459,15 @@
                     "DefaultValue": "Sun:00:00",
                     "AdvancedSetting": true,
                     "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):(0[0-9]|1\\d|2[0-3]):(0[0-9]|1\\d|2\\d|3\\d|4\\d|5\\d)$",
+                                "ValidationFailedMessage": "Invalid Preferred Start Time. You need to specify a day and time in the 'day:hour:minute' format such as 'Sun:00:00'."
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "ElasticBeanstalkManagedPlatformUpdates.ManagedActionsEnabled",

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ElasticBeanStalkOptionSettingItemValidationTests.cs
@@ -47,6 +47,23 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
         }
 
         [Theory]
+        [InlineData("Sun:00:00", true)]
+        [InlineData("sun:00:00", false)]
+        [InlineData("Suns:00:00", false)]
+        [InlineData("Mon:23:59", true)]
+        [InlineData("Mon:24:00", false)]
+        [InlineData("Mon:00:60", false)]
+        [InlineData("", false)]
+        [InlineData("test", false)]
+        public async Task PreferredStartTimeValidationTest(string value, bool isValid)
+        {
+            var optionSettingItem = new OptionSettingItem("id", "fullyQualifiedId", "name", "description");
+            // valid examples are in the 'day:hour:minute' pattern such as 'Sun:00:00'
+            optionSettingItem.Validators.Add(GetRegexValidatorConfig("^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):(0[0-9]|1\\d|2[0-3]):(0[0-9]|1\\d|2\\d|3\\d|4\\d|5\\d)$"));
+            await Validate(optionSettingItem, value, isValid);
+        }
+
+        [Theory]
         [InlineData("abc-123", true)]
         [InlineData("abc-ABC-123-xyz", true)]
         [InlineData("abc", false)] // invalid length less than 4 characters.


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6095

*Description of changes:*
added regex validation for Preferred Start Time with the pattern "Mon:00:00" in Beanstalk recipe

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
