### PR TITLE
fix: Make validation state for the recommendation is not written in deployment project recipe.

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -164,6 +164,7 @@ namespace AWS.Deploy.Common.Recipes
         /// <summary>
         /// The validation state of the setting that contains the validation status and message.
         /// </summary>
+        [JsonIgnore]
         public OptionSettingValidation Validation { get; set; }
 
         public OptionSettingItem(string id, string fullyQualifiedId, string name, string description)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When saving a deployment project all of the settings in the recipe get added `Validation` property which makes no sense in a recipe context because there is no value in the context of a recipe. The fix was to just add the `JsonIgnore` attribute in `OptionSettingItem`. This won't affect serialization in ServerMode because we don't directly pass `OptionSettingItem` through the API. 

```
    {
      "Id": "ECSServiceName",
      "ParentSettingId": "ClusterName",
      "Name": "ECS Service Name",
      "Category": "General",
      "Description": "The name of the ECS service running in the cluster.",
      "Type": "String",

...

      ],
      "Validation": {
        "ValidationStatus": 0,
        "ValidationMessage": ""
      }
    },
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
