### PR TITLE
chore: Remove docs placeholders for future content

### DIFF
--- a/site/content/docs/cicd.md
+++ b/site/content/docs/cicd.md
@@ -14,10 +14,6 @@ To specify the services to deploy and their configurations for your environment,
 
 Storing deployment settings in a JSON file also allows those settings to be version controlled.
 
-This section defines the JSON definitions and syntax that you construct and use a deployment settings file.
-
-TODO
-
 ### Invoking from CI/CD
 
 The `--apply` switch on deploy command allows you to specify a deployment settings file.

--- a/site/content/docs/project.md
+++ b/site/content/docs/project.md
@@ -29,14 +29,11 @@ The `AppStack class` is the recommended place to add new AWS resources or custom
 
   > Note: Most of the code is located in the generated folder. We don’t recommend you edit the files in there directly, and instead use it for reference. If you want to take updates from the original recipe the deployment project was created from, you can just copy the code into the generated folder.
 
-In the example below, we’ll show you how to add a DynamoDB table....
-
-TODO
 
 ### Customizing deployment settings
-You can also add new settings that will be presented to the user during deployment.
+You can also add new settings that will be presented to the user during deployment. Modify the generated `.recipe` file to correspond to the changes you made to the CDK project.
 
-TODO
+The schema for the recipe file can be found [here](https://github.com/aws/aws-dotnet-deploy/blob/main/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json).
 
 
 ### Specifying external project

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     ".*"
   ],


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This is a non-release sync of `dev` -> `main` to update the docs site via https://github.com/aws/aws-dotnet-deploy/pull/669

This will move the version bump commit, but we do not intend to release 1.1.X yet.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
