### PR TITLE
fix: deployment workflow fails if there is no default vpc

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -343,6 +343,8 @@ namespace AWS.Deploy.CLI.Commands
             else
                 previousSettings = await _deployedApplicationQueryer.GetPreviousSettings(deployedApplication);
 
+            await orchestrator.ApplyAllReplacementTokens(selectedRecommendation, deployedApplication.Name);
+
             selectedRecommendation = await orchestrator.ApplyRecommendationPreviousSettings(selectedRecommendation, previousSettings);
 
             var header = $"Loading {deployedApplication.DisplayName} settings:";

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ElasticBeanstalkVpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ElasticBeanstalkVpcCommand.cs
@@ -1,0 +1,190 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using Amazon.ECS.Model;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.Data;
+using Newtonsoft.Json;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    /// <summary>
+    /// The <see cref="ElasticBeanstalkVpcCommand"/> type hint orchestrates the VPC object in Elastic Beanstalk environments.
+    /// </summary>
+    public class ElasticBeanstalkVpcCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public ElasticBeanstalkVpcCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities, IToolInteractiveService toolInteractiveService, IOptionSettingHandler optionSettingHandler)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+            _toolInteractiveService = toolInteractiveService;
+            _optionSettingHandler = optionSettingHandler;
+        }
+
+        private async Task<List<Vpc>> GetData()
+        {
+            return await _awsResourceQueryer.GetListOfVpcs();
+        }
+
+        public async Task<TypeHintResourceTable> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var vpcs = await GetData();
+            var resourceTable = new TypeHintResourceTable();
+
+            resourceTable.Rows =  vpcs.ToDictionary(x => x.VpcId, x => x.GetDisplayableVpc()).Select(x => new TypeHintResource(x.Key, x.Value)).ToList();
+
+            return resourceTable;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            _toolInteractiveService.WriteLine();
+
+            // Ask user if they want to Use a VPC
+            var useVpcOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("UseVPC"));
+            var useVpcValue = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, useVpcOptionSetting) ?? "false";
+            var useVpcAnswer = _consoleUtilities.AskYesNoQuestion(useVpcOptionSetting.Description, useVpcValue);
+            var useVpc = useVpcAnswer == YesNo.Yes;
+
+            // If user doesn't want to Use VPC, no need to continue
+            if (!useVpc)
+                return new ElasticBeanstalkVpcTypeHintResponse()
+                {
+                    UseVPC = false
+                };
+
+            // Retrieve all the available VPCs
+            var vpcs = await GetData();
+
+            // If there are no VPCs, create a new one
+            if (!vpcs.Any())
+            {
+                _toolInteractiveService.WriteLine();
+                _toolInteractiveService.WriteLine("There are no VPCs in the selected account. The only option is to create a new one.");
+                return new ElasticBeanstalkVpcTypeHintResponse
+                {
+                    UseVPC = true,
+                    CreateNew = true
+                };
+            }
+
+            // Ask user to select a VPC from the available ones
+            _toolInteractiveService.WriteLine();
+            var currentVpcTypeHintResponse = optionSetting.GetTypeHintData<ElasticBeanstalkVpcTypeHintResponse>();
+            var vpcOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("VpcId"));
+            var currentVpcValue = _optionSettingHandler.GetOptionSettingValue(recommendation, vpcOptionSetting).ToString();
+            var userInputConfigurationVPCs = new UserInputConfiguration<Vpc>(
+                idSelector: vpc => vpc.VpcId,
+                displaySelector: vpc => vpc.GetDisplayableVpc(),
+                defaultSelector: vpc =>
+                    !string.IsNullOrEmpty(currentVpcTypeHintResponse?.VpcId)
+                        ? vpc.VpcId == currentVpcTypeHintResponse.VpcId
+                        : vpc.IsDefault)
+            {
+                CanBeEmpty = false,
+                CreateNew = true
+            };
+            var vpc = _consoleUtilities.AskUserToChooseOrCreateNew<Vpc>(vpcs, "Select a VPC:", userInputConfigurationVPCs);
+
+            // Create a new VPC if the user wants to do that
+            if (vpc.CreateNew)
+                return new ElasticBeanstalkVpcTypeHintResponse
+                {
+                    UseVPC = true,
+                    CreateNew = true
+                };
+
+            // If for some reason an option was not selected, don't use a VPC
+            if (vpc.SelectedOption == null)
+                return new ElasticBeanstalkVpcTypeHintResponse
+                {
+                    UseVPC = false
+                };
+
+            // Retrieve available Subnets based on the selected VPC
+            var availableSubnets = (await _awsResourceQueryer.DescribeSubnets(vpc.SelectedOption.VpcId)).OrderBy(x => x.SubnetId).ToList();
+
+            // If there are no subnets, don't use a VPC
+            if (!availableSubnets.Any())
+            {
+                _toolInteractiveService.WriteLine();
+                _toolInteractiveService.WriteLine("The selected VPC does not have any Subnets. Please select a VPC with Subnets.");
+                return new ElasticBeanstalkVpcTypeHintResponse
+                {
+                    UseVPC = false
+                };
+            }
+
+            // Ask user to select subnets based on the selected VPC
+            var userInputConfigurationSubnets = new UserInputConfiguration<Subnet>(
+                idSelector: subnet => subnet.SubnetId,
+                displaySelector: subnet => $"{subnet.SubnetId.PadRight(24)} | {subnet.VpcId.PadRight(21)} | {subnet.AvailabilityZone}",
+                defaultSelector: subnet => false)
+            {
+                CanBeEmpty = false,
+                CreateNew = false
+            };
+            var subnetsOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("Subnets"));
+            _toolInteractiveService.WriteLine($"{subnetsOptionSetting.Id}:");
+            _toolInteractiveService.WriteLine(subnetsOptionSetting.Description);
+            var subnets = _consoleUtilities.AskUserForList<Subnet>(userInputConfigurationSubnets, availableSubnets, subnetsOptionSetting, recommendation);
+
+            // Retrieve available security groups based on the selected VPC
+            var availableSecurityGroups = (await _awsResourceQueryer.DescribeSecurityGroups(vpc.SelectedOption.VpcId)).OrderBy(x => x.VpcId).ToList();
+            if (!availableSecurityGroups.Any())
+                return new ElasticBeanstalkVpcTypeHintResponse
+                {
+                    UseVPC = true,
+                    CreateNew = false,
+                    VpcId = vpc.SelectedOption.VpcId,
+                    Subnets = subnets
+                };
+
+            // Get the length of the longest group name to do padding when displaying the security groups
+            var groupNamePadding = 0;
+            availableSecurityGroups.ForEach(x =>
+            {
+                if (x.GroupName.Length > groupNamePadding)
+                    groupNamePadding = x.GroupName.Length;
+            });
+
+            // Ask user to select security groups
+            var userInputConfigurationSecurityGroups = new UserInputConfiguration<SecurityGroup>(
+                idSelector: securityGroup => securityGroup.GroupId,
+                displaySelector: securityGroup => $"{securityGroup.GroupName.PadRight(groupNamePadding)} | {securityGroup.GroupId.PadRight(20)} | {securityGroup.VpcId}",
+                defaultSelector: securityGroup => false)
+            {
+                CanBeEmpty = false,
+                CreateNew = false
+            };
+            var securityGroupsOptionSetting = optionSetting.ChildOptionSettings.First(x => x.Id.Equals("SecurityGroups"));
+            _toolInteractiveService.WriteLine($"{securityGroupsOptionSetting.Id}:");
+            _toolInteractiveService.WriteLine(securityGroupsOptionSetting.Description);
+            var securityGroups = _consoleUtilities.AskUserForList<SecurityGroup>(userInputConfigurationSecurityGroups, availableSecurityGroups, securityGroupsOptionSetting, recommendation);
+
+            return new ElasticBeanstalkVpcTypeHintResponse
+            {
+                UseVPC = true,
+                CreateNew = false,
+                VpcId = vpc.SelectedOption.VpcId,
+                Subnets = subnets,
+                SecurityGroups = securityGroups
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingVpcCommand.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.EC2.Model;
+using AWS.Deploy.CLI.Extensions;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.Recipes;
@@ -13,6 +14,9 @@ using AWS.Deploy.Orchestration.Data;
 
 namespace AWS.Deploy.CLI.Commands.TypeHints
 {
+    /// <summary>
+    /// The <see cref="ExistingVpcCommand"/> type hint lists existing VPC in an account for an option setting of type <see cref="OptionSettingValueType.String"/>.
+    /// </summary>
     public class ExistingVpcCommand : ITypeHintCommand
     {
         private readonly IAWSResourceQueryer _awsResourceQueryer;
@@ -37,21 +41,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
             var resourceTable = new TypeHintResourceTable();
 
-            resourceTable.Rows = vpcs.ToDictionary(x => x.VpcId, x =>
-            {
-                var name = x.Tags?.FirstOrDefault(x => x.Key == "Name")?.Value ?? string.Empty;
-                var namePart =
-                    string.IsNullOrEmpty(name)
-                        ? ""
-                        : $" ({name}) ";
-
-                var isDefaultPart =
-                    x.IsDefault
-                        ? " *** Account Default VPC ***"
-                        : "";
-
-                return $"{x.VpcId}{namePart}{isDefaultPart}";
-            }).Select(x => new TypeHintResource(x.Key, x.Value)).ToList();
+            resourceTable.Rows = vpcs.ToDictionary(x => x.VpcId, x => x.GetDisplayableVpc()).Select(x => new TypeHintResource(x.Key, x.Value)).ToList();
 
             return resourceTable;
         }
@@ -63,21 +53,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
             var userInputConfig = new UserInputConfiguration<Vpc>(
                 idSelector: vpc => vpc.VpcId,
-                displaySelector: vpc =>
-                {
-                    var name = vpc.Tags?.FirstOrDefault(x => x.Key == "Name")?.Value ?? string.Empty;
-                    var namePart =
-                        string.IsNullOrEmpty(name)
-                            ? ""
-                            : $" ({name}) ";
-
-                    var isDefaultPart =
-                        vpc.IsDefault
-                            ? " *** Account Default VPC ***"
-                            : "";
-
-                    return $"{vpc.VpcId}{namePart}{isDefaultPart}";
-                },
+                displaySelector: vpc => vpc.GetDisplayableVpc(),
                 defaultSelector: vpc =>
                     !string.IsNullOrEmpty(currentVpcValue)
                         ? vpc.VpcId == currentVpcValue

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -71,6 +71,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.ExistingSecurityGroups, ActivatorUtilities.CreateInstance<ExistingSecurityGroupsCommand>(serviceProvider) },
                 { OptionSettingTypeHint.VPCConnector, ActivatorUtilities.CreateInstance<VPCConnectorCommand>(serviceProvider) },
                 { OptionSettingTypeHint.FilePath, ActivatorUtilities.CreateInstance<FilePathCommand>(serviceProvider) },
+                { OptionSettingTypeHint.ElasticBeanstalkVpc, ActivatorUtilities.CreateInstance<ElasticBeanstalkVpcCommand>(serviceProvider) },
             };
         }
 

--- a/src/AWS.Deploy.CLI/Extensions/TypeHintUtilities.cs
+++ b/src/AWS.Deploy.CLI/Extensions/TypeHintUtilities.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using Amazon.EC2.Model;
+
+namespace AWS.Deploy.CLI.Extensions
+{
+    public static class TypeHintUtilities
+    {
+        public static string GetDisplayableVpc(this Vpc vpc)
+        {
+            var name = vpc.Tags?.FirstOrDefault(x => x.Key == "Name")?.Value ?? string.Empty;
+            var namePart =
+                string.IsNullOrEmpty(name)
+                    ? ""
+                    : $" ({name}) ";
+
+            var isDefaultPart =
+                vpc.IsDefault
+                    ? " *** Account Default VPC ***"
+                    : "";
+
+            return $"{vpc.VpcId}{namePart}{isDefaultPart}";
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/TypeHintResponses/ElasticBeanstalkVpcTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/ElasticBeanstalkVpcTypeHintResponse.cs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using AWS.Deploy.Common.Recipes;
+
+namespace AWS.Deploy.CLI.TypeHintResponses
+{
+    /// <summary>
+    /// <see cref="OptionSettingTypeHint.Vpc"/> type hint response
+    /// </summary>
+    public class ElasticBeanstalkVpcTypeHintResponse : IDisplayable
+    {
+        public bool UseVPC { get; set; }
+        public bool CreateNew { get; set; }
+        public string? VpcId { get; set; }
+        public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();
+        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
+
+        public string? ToDisplayString() => null;
+    }
+}

--- a/src/AWS.Deploy.CLI/TypeHintResponses/VPCConnectorTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/VPCConnectorTypeHintResponse.cs
@@ -15,6 +15,7 @@ namespace AWS.Deploy.CLI.TypeHintResponses
         public string? VpcConnectorId { get; set; }
         public bool UseVPCConnector { get; set; }
         public bool CreateNew { get; set; }
+        public bool CreateNewVpc { get; set; }
         public string? VpcId { get; set; }
         public SortedSet<string> Subnets { get; set; } = new SortedSet<string>();
         public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.ValueOverride.cs
@@ -13,14 +13,14 @@ namespace AWS.Deploy.Common.Recipes
     /// <see cref="GetValue{T}"/>, <see cref="GetValue"/> and <see cref="SetValueOverride"/> methods
     public partial class OptionSettingItem
     {
-        public T? GetValue<T>(IDictionary<string, string> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null)
+        public T? GetValue<T>(IDictionary<string, object> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null)
         {
             var value = GetValue(replacementTokens, displayableOptionSettings);
 
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(value));
         }
 
-        public object GetValue(IDictionary<string, string> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null)
+        public object GetValue(IDictionary<string, object> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null)
         {
             if (_value != null)
             {
@@ -60,7 +60,7 @@ namespace AWS.Deploy.Common.Recipes
             return DefaultValue;
         }
 
-        public T? GetDefaultValue<T>(IDictionary<string, string> replacementTokens)
+        public T? GetDefaultValue<T>(IDictionary<string, object> replacementTokens)
         {
             var value = GetDefaultValue(replacementTokens);
             if (value == null)
@@ -71,7 +71,7 @@ namespace AWS.Deploy.Common.Recipes
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(value));
         }
 
-        public object? GetDefaultValue(IDictionary<string, string> replacementTokens)
+        public object? GetDefaultValue(IDictionary<string, object> replacementTokens)
         {
             if (DefaultValue == null)
             {
@@ -179,14 +179,30 @@ namespace AWS.Deploy.Common.Recipes
             }
         }
 
-        private string ApplyReplacementTokens(IDictionary<string, string> replacementTokens, string defaultValue)
+        private object ApplyReplacementTokens(IDictionary<string, object> replacementTokens, object defaultValue)
         {
-            foreach (var token in replacementTokens)
+            var defaultValueString = defaultValue?.ToString();
+            if (!string.IsNullOrEmpty(defaultValueString))
             {
-                defaultValue = defaultValue.Replace(token.Key, token.Value);
+                if (Type != OptionSettingValueType.String)
+                {
+                    foreach (var token in replacementTokens)
+                    {
+                        if (defaultValueString.Equals(token.Key))
+                            defaultValue = token.Value;
+                    }
+                }
+                else
+                {
+                    foreach (var token in replacementTokens)
+                    {
+                        defaultValueString = defaultValueString.Replace(token.Key, token.Value.ToString());
+                    }
+                    defaultValue = defaultValueString;
+                }
             }
 
-            return defaultValue;
+            return defaultValue ?? string.Empty;
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -19,22 +19,22 @@ namespace AWS.Deploy.Common.Recipes
         /// <summary>
         /// Retrieve the value of an <see cref="OptionSettingItem"/> as a specified type.
         /// </summary>
-        T? GetValue<T>(IDictionary<string, string> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null);
+        T? GetValue<T>(IDictionary<string, object> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null);
 
         /// <summary>
         /// Retrieve the value of an <see cref="OptionSettingItem"/> as an object.
         /// </summary>
-        object GetValue(IDictionary<string, string> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null);
+        object GetValue(IDictionary<string, object> replacementTokens, IDictionary<string, bool>? displayableOptionSettings = null);
 
         /// <summary>
         /// Retrieve the default value of an <see cref="OptionSettingItem"/> as a specified type.
         /// </summary>
-        T? GetDefaultValue<T>(IDictionary<string, string> replacementTokens);
+        T? GetDefaultValue<T>(IDictionary<string, object> replacementTokens);
 
         /// <summary>
         /// Retrieve the default value of an <see cref="OptionSettingItem"/> as an object.
         /// </summary>
-        object? GetDefaultValue(IDictionary<string, string> replacementTokens);
+        object? GetDefaultValue(IDictionary<string, object> replacementTokens);
 
         /// <summary>
         /// Set the value of an <see cref="OptionSettingItem"/> while validating the provided input.

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -38,6 +38,7 @@ namespace AWS.Deploy.Common.Recipes
         ExistingSubnets,
         ExistingSecurityGroups,
         VPCConnector,
-        FilePath
+        FilePath,
+        ElasticBeanstalkVpc
     };
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidatorList.cs
@@ -68,6 +68,10 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="VPCSubnetsInDifferentAZsValidator"/>
         /// </summary>
-        VPCSubnetsInDifferentAZs
+        VPCSubnetsInDifferentAZs,
+        /// <summary>
+        /// Must be paired with <see cref="VpcExistsValidator"/>
+        /// </summary>
+        VpcExists
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/VpcExistsValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/VpcExistsValidator.cs
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
+
+namespace AWS.Deploy.Common.Recipes.Validation
+{
+    /// <summary>
+    /// Validates that a VPC exists in the account
+    /// </summary>
+    public class VpcExistsValidator : IOptionSettingItemValidator
+    {
+        private static readonly string defaultValidationFailedMessage = "A VPC could not be found.";
+        public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
+
+        /// <summary>
+        /// The value of the option setting that will cause the validator to fail if a VPC is not found.
+        /// </summary>
+        public object FailValue { get; set; } = true;
+
+        /// <summary>
+        /// The value type of the option setting and <see cref="FailValue"/>.
+        /// </summary>
+        public OptionSettingValueType ValueType { get; set; } = OptionSettingValueType.Bool;
+
+        /// <summary>
+        /// Indicates whether this validator will only check for the existence of the default VPC.
+        /// </summary>
+        public bool DefaultVpc { get; set; } = false;
+
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public VpcExistsValidator(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
+        {
+            // Check for the existence of VPCs which will cause the Validator to pass if VPCs exist
+            if (DefaultVpc)
+            {
+                var vpc = await _awsResourceQueryer.GetDefaultVpc();
+                if (vpc != null)
+                    return ValidationResult.Valid();
+            }
+            else
+            {
+                var vpcs = await _awsResourceQueryer.GetListOfVpcs();
+                if (vpcs.Any())
+                    return ValidationResult.Valid();
+            }
+
+            // If VPCs don't exist, based on the type, check if the option setting value is equal to the FailValue
+            var inputString = input?.ToString() ?? string.Empty;
+            if (ValueType == OptionSettingValueType.Bool)
+            {
+                if (bool.TryParse(inputString, out var inputBool) && FailValue is bool FailValueBool)
+                {
+                    if (inputBool == FailValueBool)
+                        return ValidationResult.Failed(ValidationFailedMessage);
+                    else
+                        return ValidationResult.Valid();
+                }
+                else
+                {
+                    return ValidationResult.Failed($"The option setting value or '{nameof(FailValue)}' are not of type '{ValueType}'.");
+                }
+            }
+            else
+            {
+                return ValidationResult.Failed($"The value '{ValueType}' for '{nameof(ValueType)}' is not supported.");
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -61,7 +61,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
             { OptionSettingItemValidatorList.SecurityGroupsInVpc, typeof(SecurityGroupsInVpcValidator) },
             { OptionSettingItemValidatorList.Uri, typeof(UriValidator) },
             { OptionSettingItemValidatorList.Comparison, typeof(ComparisonValidator) },
-            { OptionSettingItemValidatorList.VPCSubnetsInDifferentAZs, typeof(VPCSubnetsInDifferentAZsValidator) }
+            { OptionSettingItemValidatorList.VPCSubnetsInDifferentAZs, typeof(VPCSubnetsInDifferentAZsValidator) },
+            { OptionSettingItemValidatorList.VpcExists, typeof(VpcExistsValidator) }
         };
 
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()

--- a/src/AWS.Deploy.Common/Recommendation.cs
+++ b/src/AWS.Deploy.Common/Recommendation.cs
@@ -33,11 +33,11 @@ namespace AWS.Deploy.Common
 
         public DeploymentBundle DeploymentBundle { get; }
 
-        public readonly Dictionary<string, string> ReplacementTokens = new();
+        public readonly Dictionary<string, object> ReplacementTokens = new();
 
-        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, int computedPriority, Dictionary<string, string> additionalReplacements)
+        public Recommendation(RecipeDefinition recipe, ProjectDefinition projectDefinition, int computedPriority, Dictionary<string, object> additionalReplacements)
         {
-            additionalReplacements ??= new Dictionary<string, string>();
+            additionalReplacements ??= new Dictionary<string, object>();
             Recipe = recipe;
 
             ComputedPriority = computedPriority;
@@ -106,7 +106,7 @@ namespace AWS.Deploy.Common
             }
         }
 
-        public void AddReplacementToken(string key, string value)
+        public void AddReplacementToken(string key, object value)
         {
             ReplacementTokens[key] = value;
         }

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -17,6 +17,8 @@ namespace AWS.Deploy.Constants
         public const string REPLACE_TOKEN_ECR_IMAGE_TAG = "{DefaultECRImageTag}";
         public const string REPLACE_TOKEN_DOCKERFILE_PATH = "{DockerfilePath}";
         public const string REPLACE_TOKEN_DEFAULT_VPC_ID = "{DefaultVpcId}";
+        public const string REPLACE_TOKEN_HAS_DEFAULT_VPC = "{HasDefaultVpc}";
+        public const string REPLACE_TOKEN_HAS_NOT_VPCS = "{HasNotVpcs}";
 
         /// <summary>
         /// Id for the 'dotnet publish --configuration' recipe option

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -487,7 +487,7 @@ namespace AWS.Deploy.Orchestration.Data
                             }
                         }
                     })
-                .Vpcs.FirstAsync());
+                .Vpcs.FirstOrDefaultAsync());
         }
 
         public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(params BeanstalkPlatformType[]? platformTypes)

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -220,7 +220,23 @@ namespace AWS.Deploy.Orchestration
                     throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
 
                 var defaultVPC = await _awsResourceQueryer.GetDefaultVpc();
-                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID, defaultVPC.VpcId);
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID, defaultVPC?.VpcId ?? string.Empty);
+            }
+            if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_HAS_DEFAULT_VPC))
+            {
+                if (_awsResourceQueryer == null)
+                    throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
+
+                var defaultVPC = await _awsResourceQueryer.GetDefaultVpc();
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_HAS_DEFAULT_VPC, defaultVPC != null);
+            }
+            if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_HAS_NOT_VPCS))
+            {
+                if (_awsResourceQueryer == null)
+                    throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
+
+                var vpcs = await _awsResourceQueryer.GetListOfVpcs();
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_HAS_NOT_VPCS, !vpcs.Any());
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/RecommendationEngine/RecommendationEngine.cs
+++ b/src/AWS.Deploy.Orchestration/RecommendationEngine/RecommendationEngine.cs
@@ -24,9 +24,9 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
             _recipeHandler = recipeHandler;
         }
 
-        public async Task<List<Recommendation>> ComputeRecommendations(List<string>? recipeDefinitionPaths = null, Dictionary<string, string>? additionalReplacements = null)
+        public async Task<List<Recommendation>> ComputeRecommendations(List<string>? recipeDefinitionPaths = null, Dictionary<string, object>? additionalReplacements = null)
         {
-            additionalReplacements ??= new Dictionary<string, string>();
+            additionalReplacements ??= new Dictionary<string, object>();
 
             var recommendations = new List<Recommendation>();
             var availableRecommendations = await _recipeHandler.GetRecipeDefinitions(recipeDefinitionPaths);

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
@@ -90,7 +90,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
                 if (!optionSetting.Updatable)
                     continue;
 
-                var optionSettingValue = optionSetting.GetValue<string>(new Dictionary<string, string>());
+                var optionSettingValue = optionSetting.GetValue<string>(new Dictionary<string, object>());
 
                 additionalSettings.Add(new ConfigurationOptionSetting
                 {

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/VPCConnectorConfiguration.cs
@@ -29,6 +29,11 @@ namespace AspNetAppAppRunner.Configurations
         public string? VpcConnectorId { get; set; }
 
         /// <summary>
+        /// If set, creates a new VPC whose Subnets and Security Groups will be used to create a new VPC Connector.
+        /// </summary>
+        public bool CreateNewVpc { get; set; }
+
+        /// <summary>
         /// The VPC ID to use for the App Runner service.
         /// </summary>
         public string? VpcId { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/VPCConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/VPCConfiguration.cs
@@ -15,6 +15,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         public bool UseVPC { get; set; }
 
         /// <summary>
+        /// Creates a new VPC if set to true.
+        /// </summary>
+        public bool CreateNew { get; set; }
+
+        /// <summary>
         /// The VPC ID to use for the Elastic Beanstalk service.
         /// </summary>
         public string? VpcId { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Configurations/VPCConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Configurations/VPCConfiguration.cs
@@ -15,6 +15,11 @@ namespace AspNetAppElasticBeanstalkWindows.Configurations
         public bool UseVPC { get; set; }
 
         /// <summary>
+        /// Creates a new VPC if set to true.
+        /// </summary>
+        public bool CreateNew { get; set; }
+
+        /// <summary>
         /// The VPC ID to use for the Elastic Beanstalk service.
         /// </summary>
         public string? VpcId { get; set; }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppAppRunner",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "ASP.NET Core App to AWS App Runner",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -469,6 +469,36 @@
                     ]
                 },
                 {
+                    "Id": "CreateNewVpc",
+                    "Name": "Create New VPC",
+                    "Description": "Do you want to create a new VPC to use for the VPC Connector?",
+                    "Type": "Bool",
+                    "DefaultValue": "{HasNotVpcs}",
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": false,
+                                "DefaultVpc": false,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "You must create a new VPC since there are no existing VPCs to be used."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPCConnector.UseVPCConnector",
+                            "Value": true
+                        },
+                        {
+                            "Id": "VPCConnector.CreateNew",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
                     "Id": "VpcId",
                     "Name": "VPC ID",
                     "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
@@ -494,6 +524,10 @@
                         {
                             "Id": "VPCConnector.CreateNew",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPCConnector.CreateNewVpc",
+                            "Value": false
                         }
                     ]
                 },
@@ -532,6 +566,10 @@
                         {
                             "Id": "VPCConnector.CreateNew",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPCConnector.CreateNewVpc",
+                            "Value": false
                         },
                         {
                             "Id": "VPCConnector.VpcId",
@@ -574,6 +612,10 @@
                         {
                             "Id": "VPCConnector.CreateNew",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPCConnector.CreateNewVpc",
+                            "Value": false
                         },
                         {
                             "Id": "VPCConnector.VpcId",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppEcsFargate",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "ASP.NET Core App to Amazon ECS using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -289,18 +289,40 @@
                     "Name": "Use default VPC",
                     "Description": "Do you want to use the default VPC for the deployment?",
                     "Type": "Bool",
-                    "DefaultValue": true,
+                    "DefaultValue": "{HasDefaultVpc}",
                     "AdvancedSetting": false,
-                    "Updatable": false
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": true,
+                                "DefaultVpc": true,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "A default VPC could not be found."
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "CreateNew",
                     "Name": "Create New VPC",
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
-                    "DefaultValue": false,
+                    "DefaultValue": "{HasNotVpcs}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": false,
+                                "DefaultVpc": false,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "You must create a new VPC since there are no existing VPCs to be used."
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppElasticBeanstalkLinux",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "ASP.NET Core App to AWS Elastic Beanstalk on Linux",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "DotnetPublishZipFile",
@@ -744,6 +744,7 @@
             "Category": "VPC",
             "Description": "A VPC enables you to launch the application into a virtual network that you've defined",
             "Type": "Object",
+            "TypeHint": "ElasticBeanstalkVpc",
             "AdvancedSetting": true,
             "Updatable": true,
             "ChildOptionSettings": [
@@ -757,9 +758,35 @@
                     "Updatable": false
                 },
                 {
+                    "Id": "CreateNew",
+                    "Name": "Create New VPC",
+                    "Description": "Do you want to create a new VPC?",
+                    "Type": "Bool",
+                    "DefaultValue": "{HasNotVpcs}",
+                    "AdvancedSetting": true,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": false,
+                                "DefaultVpc": false,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "You must create a new VPC since there are no existing VPCs to be used."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
                     "Id": "VpcId",
                     "Name": "VPC ID",
-                    "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
+                    "Description": "A list of VPC IDs that Elastic Beanstalk should use when it associates your service with a custom Amazon VPC.",
                     "Type": "String",
                     "TypeHint": "ExistingVpc",
                     "DefaultValue": "{DefaultVpcId}",
@@ -778,12 +805,16 @@
                         {
                             "Id": "VPC.UseVPC",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
                         }
                     ]
                 },
                 {
                     "Id": "Subnets",
-                    "Name": "Subnets",
+                    "Name": "EC2 Instance Subnets",
                     "Description": "A list of IDs of subnets that Elastic Beanstalk should use when it associates your environment with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC.",
                     "Type": "List",
                     "TypeHint": "ExistingSubnets",
@@ -812,6 +843,10 @@
                         {
                             "Id": "VPC.UseVPC",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
                         },
                         {
                             "Id": "VPC.VpcId",
@@ -850,6 +885,10 @@
                         {
                             "Id": "VPC.UseVPC",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
                         },
                         {
                             "Id": "VPC.VpcId",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppElasticBeanstalkWindows",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "ASP.NET Core App to AWS Elastic Beanstalk on Windows",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "DotnetPublishZipFile",
@@ -739,6 +739,7 @@
             "Category": "VPC",
             "Description": "A VPC enables you to launch the application into a virtual network that you've defined",
             "Type": "Object",
+            "TypeHint": "ElasticBeanstalkVpc",
             "AdvancedSetting": true,
             "Updatable": true,
             "ChildOptionSettings": [
@@ -752,9 +753,35 @@
                     "Updatable": false
                 },
                 {
+                    "Id": "CreateNew",
+                    "Name": "Create New VPC",
+                    "Description": "Do you want to create a new VPC?",
+                    "Type": "Bool",
+                    "DefaultValue": "{HasNotVpcs}",
+                    "AdvancedSetting": true,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": false,
+                                "DefaultVpc": false,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "You must create a new VPC since there are no existing VPCs to be used."
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
                     "Id": "VpcId",
                     "Name": "VPC ID",
-                    "Description": "A list of VPC IDs that App Runner should use when it associates your service with a custom Amazon VPC.",
+                    "Description": "A list of VPC IDs that Elastic Beanstalk should use when it associates your service with a custom Amazon VPC.",
                     "Type": "String",
                     "TypeHint": "ExistingVpc",
                     "DefaultValue": "{DefaultVpcId}",
@@ -773,12 +800,16 @@
                         {
                             "Id": "VPC.UseVPC",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
                         }
                     ]
                 },
                 {
                     "Id": "Subnets",
-                    "Name": "Subnets",
+                    "Name": "EC2 Instance Subnets",
                     "Description": "A list of IDs of subnets that Elastic Beanstalk should use when it associates your environment with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC.",
                     "Type": "List",
                     "TypeHint": "ExistingSubnets",
@@ -807,6 +838,10 @@
                         {
                             "Id": "VPC.UseVPC",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
                         },
                         {
                             "Id": "VPC.VpcId",
@@ -845,6 +880,10 @@
                         {
                             "Id": "VPC.UseVPC",
                             "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
                         },
                         {
                             "Id": "VPC.VpcId",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "ConsoleAppEcsFargateScheduleTask",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "Scheduled Task on Amazon Elastic Container Service (ECS) using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -272,18 +272,40 @@
                     "Name": "Use default VPC",
                     "Description": "Do you want to use the default VPC?",
                     "Type": "Bool",
-                    "DefaultValue": true,
+                    "DefaultValue": "{HasDefaultVpc}",
                     "AdvancedSetting": false,
-                    "Updatable": false
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": true,
+                                "DefaultVpc": true,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "A default VPC could not be found."
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "CreateNew",
                     "Name": "Create New VPC",
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
-                    "DefaultValue": false,
+                    "DefaultValue": "{HasNotVpcs}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": false,
+                                "DefaultVpc": false,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "You must create a new VPC since there are no existing VPCs to be used."
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "ConsoleAppEcsFargateService",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "Service on Amazon Elastic Container Service (ECS) using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -341,18 +341,40 @@
                     "Name": "Use default VPC",
                     "Description": "Do you want to use the default VPC for the deployment?",
                     "Type": "Bool",
-                    "DefaultValue": true,
+                    "DefaultValue": "{HasDefaultVpc}",
                     "AdvancedSetting": false,
-                    "Updatable": false
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": true,
+                                "DefaultVpc": true,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "A default VPC could not be found."
+                            }
+                        }
+                    ]
                 },
                 {
                     "Id": "CreateNew",
                     "Name": "Create New VPC",
                     "Description": "Do you want to create a new VPC?",
                     "Type": "Bool",
-                    "DefaultValue": false,
+                    "DefaultValue": "{HasNotVpcs}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "VpcExists",
+                            "Configuration": {
+                                "FailValue": false,
+                                "DefaultVpc": false,
+                                "ValueType": "Bool",
+                                "ValidationFailedMessage": "You must create a new VPC since there are no existing VPCs to be used."
+                            }
+                        }
+                    ],
                     "DependsOn": [
                         {
                             "Id": "Vpc.IsDefault",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -544,7 +544,8 @@
                         "DynamoDBTableName",
                         "SQSQueueUrl",
                         "SNSTopicArn",
-                        "FilePath"
+                        "FilePath",
+                        "ElasticBeanstalkVpc"
                     ]
                 },
                 "DefaultValue": {
@@ -645,7 +646,8 @@
                                     "SecurityGroupsInVpc",
                                     "Uri",
                                     "Comparison",
-                                    "VPCSubnetsInDifferentAZs"
+                                    "VPCSubnetsInDifferentAZs",
+                                    "VpcExists"
                                 ]
                             }
                         },
@@ -743,6 +745,31 @@
                                     "properties": {
                                         "Configuration": {
                                             "properties": {
+                                                "ValidationFailedMessage": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": { "ValidatorType": { "const": "VpcExists" } }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "Configuration": {
+                                            "properties": {
+                                                "FailValue": {
+                                                    "type": "boolean"
+                                                },
+                                                "DefaultVpc": {
+                                                    "type": "boolean"
+                                                },
+                                                "ValueType": {
+                                                    "type": "string"
+                                                },
                                                 "ValidationFailedMessage": {
                                                     "type": "string"
                                                 }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/DockerfilePathValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/DockerfilePathValidationTests.cs
@@ -86,7 +86,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
             var projectDefintion = new ProjectDefinition(null, projectPath, "", "");
-            var recommendation = new Recommendation(_recipeDefinition, projectDefintion, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, projectDefintion, 100, new Dictionary<string, object>());
             var validator = new DockerfilePathValidator(_directoryManager, _fileManager);
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = dockerExecutionDirectory;

--- a/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/Recipes/Validation/ECSFargateOptionSettingItemValidationTests.cs
@@ -42,7 +42,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.Recipes.Validation
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider));
 
             _recipe = new RecipeDefinition("Fargate", "0.1", "Fargate", DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "");
-            _recommendation = new Recommendation(_recipe, null, 100, new Dictionary<string, string>());
+            _recommendation = new Recommendation(_recipe, null, 100, new Dictionary<string, object>());
         }
 
         [Theory]

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -79,7 +79,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
 
             var cloudApplication = new CloudApplication("ConsoleAppTask", String.Empty, CloudApplicationResourceType.CloudFormationStack, string.Empty);
             var imageTag = "imageTag";
@@ -103,7 +103,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
 
             recommendation.DeploymentBundle.DockerExecutionDirectory = projectPath;
 
@@ -131,7 +131,7 @@ namespace AWS.Deploy.CLI.UnitTests
             {
                 new OptionSettingItem("DockerfilePath", "", "", "")
             };
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
 
             var dockerfilePath = Path.Combine(projectPath, "Docker", "Dockerfile");
             var expectedDockerExecutionDirectory = Directory.GetParent(Path.GetFullPath(recommendation.ProjectPath)).Parent.Parent;
@@ -153,7 +153,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
             var repositoryName = "repository";
 
             await _deploymentBundleHandler.PushDockerImageToECR(recommendation, repositoryName, "ConsoleAppTask:latest");
@@ -166,7 +166,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
 
             recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = false;
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = "Release";
@@ -189,7 +189,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await _projectDefinitionParser.Parse(projectPath);
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, string>());
+            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
 
             recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
             recommendation.DeploymentBundle.DotnetPublishBuildConfiguration = "Release";

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -462,16 +462,19 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var beanstalkRecommendation = recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_LINUX_RECIPE_ID);
             var useVpcOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VPC.UseVPC");
+            var createNewOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VPC.CreateNew");
             var vpcIdOptionSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VPC.VpcId");
             var subnetsSetting = _optionSettingHandler.GetOptionSetting(beanstalkRecommendation, "VPC.Subnets");
 
             // Before dependency aren't satisfied
             Assert.True(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, useVpcOptionSetting));
+            Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, createNewOptionSetting));
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, vpcIdOptionSetting));
             Assert.False(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, subnetsSetting));
 
             // Satisfy dependencies
             await _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, useVpcOptionSetting, true);
+            await _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, createNewOptionSetting, false);
             await _optionSettingHandler.SetOptionSettingValue(beanstalkRecommendation, vpcIdOptionSetting, "vpc-1234abcd");
             Assert.True(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, vpcIdOptionSetting));
             Assert.True(_optionSettingHandler.IsOptionSettingDisplayable(beanstalkRecommendation, subnetsSetting));

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/VPCConnectorCommandTest.cs
@@ -151,6 +151,7 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
             {
                 "y",
                 "y",
+                "n",
                 "1",
                 "1",
                 "1",

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
@@ -111,7 +111,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
 
             var recommendations = new List<Recommendation>
             {
-                new Recommendation(new RecipeDefinition("AspNetAppEcsFargate", "0.2.0",  "ASP.NET Core ECS", DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "" ), null, 100, new Dictionary<string, string>())
+                new Recommendation(new RecipeDefinition("AspNetAppEcsFargate", "0.2.0",  "ASP.NET Core ECS", DeploymentTypes.CdkProject, DeploymentBundleTypes.Container, "", "", "", "", "" ), null, 100, new Dictionary<string, object>())
                 {
 
                 }
@@ -180,7 +180,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                                                                 PersistedDeploymentProject = true,
                                                                 BaseRecipeId = "AspNetAppEcsFargate"
                                                             },
-                                                            null, 100, new Dictionary<string, string>())
+                                                            null, 100, new Dictionary<string, object>())
                 {
 
                 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6108

*Description of changes:*
* Added support for replacement tokens that are not of type String
* Added new replacement token to check if there is a default VPC
* Recipes that use Fargate now UseDefault VPC if there is a default VPC, if not then CreateNew will be selected by default.
* All other recipes have been updated to support creating a new VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
