### PR TITLE
ci: No longer republish GitHub Pages documentation upon merge to dev

### DIFF
--- a/.github/workflows/doc-builder.yml
+++ b/.github/workflows/doc-builder.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - dev
       
   # Allow the workflow to be triggered also manually.
   workflow_dispatch:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently we republish the GitHub Pages site upon changes to either `main` (what's actually been released) or `dev` (staging branch for next release). 

1. For example, I recently merged https://github.com/aws/aws-dotnet-deploy/pull/671 to `dev`
2. Then https://github.com/aws/aws-dotnet-deploy/actions/runs/2678029950 ran
3. Then https://github.com/aws/aws-dotnet-deploy/commit/0f5ddeb7876b0f0f93a5ab490fe728848829144b was committed to `gh-pages`

This may lead to us accidentally publishing documentation ahead of the corresponding feature being released.

Now we'll only republish the GitHub pages site upon merging to `main`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
