### PR TITLE
fix: deployments created in preview version don't work in GA version

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -123,7 +123,8 @@ namespace AWS.Deploy.Common
         FailedToCreateDeepCopy = 10010100,
         FailedToGetOptionSettingValue = 10010200,
         ECRRepositoryNameIsNull = 10010300,
-        FailedToReadCdkBootstrapVersion = 10010400
+        FailedToReadCdkBootstrapVersion = 10010400,
+        UnsupportedOptionSettingType = 10010500
     }
 
     public class ProjectFileNotFoundException : DeployToolException
@@ -218,6 +219,14 @@ namespace AWS.Deploy.Common
     public class ValidationFailedException : DeployToolException
     {
         public ValidationFailedException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Thrown if <see cref="OptionSettingItem.SetValue"/> is setting a value with an incompatible type.
+    /// </summary>
+    public class UnsupportedOptionSettingType : DeployToolException
+    {
+        public UnsupportedOptionSettingType(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 
     /// <summary>

--- a/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
@@ -142,7 +142,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var recommendation = _recommendations.First(r => r.Recipe.Id == Constants.ASPNET_CORE_BEANSTALK_LINUX_RECIPE_ID);
 
             var optionSetting = recommendation.Recipe.OptionSettings.First(x => x.Id.Equals("ElasticBeanstalkEnvironmentVariables"));
-            await Assert.ThrowsAsync<JsonReaderException>(async () => await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, "string"));
+            await Assert.ThrowsAsync<UnsupportedOptionSettingType>(async () => await _optionSettingHandler.SetOptionSettingValue(recommendation, optionSetting, "string"));
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6124

*Description of changes:*
The issue was caused by a breaking change we introduced when we changed the Type of the Security group settings in the fargate recipe. The type changed from `string` to `List` which broke the workflow when the tool tried to apply previous settings on redeployments. This change skips broken settings when applying previous settings and it gives users a message that we were unable to set that setting. I also added a validation error when this happens so that the VS Toolkit tells the user that there is an issue with one of the settings, giving the user the option to either fix the issue before deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
