### PR TITLE
Support deploying using AWS IAM Identity Center single sign-on (SSO) credentials

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -21,6 +21,8 @@
 ** Amazon.JSII.Runtime; version 1.54.0 -- https://www.nuget.org/packages/Amazon.JSII.Runtime
 ** AWSSDK.CloudControlApi; version 3.7.2 -- https://www.nuget.org/packages/AWSSDK.CloudControlApi/
 ** AWSSDK.SimpleSystemsManagement; version 3.7.16 -- https://www.nuget.org/packages/AWSSDK.SimpleSystemsManagement/
+** AWSSDK.SSO; version 3.7.0.201 -- https://www.nuget.org/packages/AWSSDK.SSO
+** AWSSDK.SSOOIDC; version 3.7.1.4 -- https://www.nuget.org/packages/AWSSDK.SSOOIDC
  
 Apache License
 Version 2.0, January 2004
@@ -253,6 +255,10 @@ limitations under the License.
     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * For AWSSDK.SimpleSystemsManagement see also this required NOTICE:
     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.SSO see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* For AWSSDK.SSOOIDC see also this required NOTICE:
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 ------
 
@@ -334,8 +340,6 @@ Copyright (c) 2016 .NET Foundation
 Copyright (c) 2016 .NET Foundation
 ** Microsoft.Extensions.Configuration.Json; version 3.1.7 -- https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterhttps://www.nuget.org/packages/Microsoft.Extensions.Configuration.Jsonfaces
 Copyright (c) .NET Foundation and Contributors
-** System.Text.Json; version 6.0.4 -- https://www.nuget.org/packages/System.Text.Json
-Copyright (c) .NET Foundation and Contributors
 ** Microsoft.Extensions.DependencyInjection; version 6.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection
 Copyright (c) .NET Foundation and Contributors
 **  Microsoft.Extensions.DependencyInjection.Abstractions; version 6.0.0 -- https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions
@@ -344,7 +348,9 @@ Copyright (c) .NET Foundation and Contributors
 Copyright (c) .NET Foundation and Contributors
 ** Microsoft.OpenApi; version 1.2.3 -- https://www.nuget.org/packages/Microsoft.OpenApi/
 Copyright (c) Microsoft Corporation.
-
+** System.Text.Json; version 6.0.4 -- https://www.nuget.org/packages/System.Text.Json
+Copyright (c) .NET Foundation and Contributors
+ 
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.25" />
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.7.14" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.35" />
+    <PackageReference Include="AWSSDK.SSO" Version="3.7.0.201" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />


### PR DESCRIPTION
*Issue #, if available:* #675 and DOTNET-6153

*Description of changes:* This introduces the SDK's SSO and SSOOIDC packages to support profiles configured to use [SSO](https://docs.aws.amazon.com/sdkref/latest/guide/access-sso.html) credentials.

We were previously swallowing the `Assembly AWSSDK.SSO could not be found or loaded` exception here:
https://github.com/aws/aws-dotnet-deploy/blob/48ef3bc4eef59896c2b17db5b6895fa4c3a575b1/src/AWS.Deploy.CLI/AWSUtilities.cs#L120-L124

I've also updated our internal attribution tool and regenerated the THIRD_PARTY_LICENSES file.

I did not introduce new automated testing, we don't have long-lived SSO setup in our test account and it'd require a fair amount of manipulation to set everything up automatically. **Let me know if you think it'd be worth it though.**

I did manually test via both the CLI and by replacing the deploy tool within VS Toolkit 1.35.2.0.
* https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
