### PR TITLE
Reduce the memory allocation for the Blazor Lambda publishing function

### DIFF
--- a/site/content/troubleshooting-guide/index.md
+++ b/site/content/troubleshooting-guide/index.md
@@ -96,3 +96,13 @@ StagingBucket cdk-hnb659fds-assets-123456789101-us-west-2 already exists
 ```
 
 **Resolution**: Open the AWS Console, go to S3 service, and manually delete the 'CDKToolkit' S3 bucket. Once the bucket is deleted, go ahead and deploy your application.
+
+## MemorySize Constraint for Blazor WebAssembly
+When attempting to deploy using the Blazor WebAssembly App recipe, you may see a deployment failure such as:
+```
+Resource handler returned message: "'MemorySize' value failed to satisfy constraint: Member must have value less than or equal to 3008
+```
+
+**Why this is happening:** The [BucketDeployment](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_deployment.BucketDeployment.html) CDK Construct used to deploy the Blazor recipe uses an AWS Lambda function to replicate the application files from the CDK bucket to the deployment bucket. In some versions of the deploy tool the default memory limit for this Lambda function exceeded the 3008MB quota placed on new AWS accounts.
+
+**Resolution:** See [Lambda: Concurrency and memory quotas](https://docs.aws.amazon.com/lambda/latest/dg/troubleshooting-deployment.html#troubleshooting-deployment-quotas) for how to request a quota increase.

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs
@@ -214,7 +214,7 @@ namespace BlazorWasm
             {
                 Sources = new ISource[] { Source.Asset(Path.Combine(props.DotnetPublishOutputDirectory, "wwwroot")) },
                 DestinationBucket = ContentS3Bucket,
-                MemoryLimit = 4096,
+                MemoryLimit = 3008,
 
                 Distribution = CloudFrontDistribution,
                 DistributionPaths = new string[] { "/*" }


### PR DESCRIPTION
*Issue #, if available:* #684 and DOTNET-6190

*Description of changes:* The Blazor recipe uses [CDK's "BucketDeployment" construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_deployment.BucketDeployment.html). An option of that construct is [`memoryLimit`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_deployment.BucketDeployment.html#memorylimit), which controls _"The amount of memory (in MiB) to allocate to the AWS Lambda function which replicates the files from the CDK bucket to the destination bucket."_ We default that to 4096MB [here](https://github.com/aws/aws-dotnet-deploy/blob/b044bd05f3528ee412cec58619c33d077ca84de1/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs#L217), without a way to override it.

Per Lambda docs [here](https://docs.aws.amazon.com/lambda/latest/dg/troubleshooting-deployment.html#troubleshooting-deployment-quotas) (as well as various re:Post and StackOverflow questions) new accounts are limited to 3008MB which may be raised automatically due to usage.

Per @normj when discussing internally, we still want to try to avoid exposing the memory limit as an option setting since it's related to the CDK publish as opposed to actually serving the application.
* Though we may need to reconsider that stance if we get reports of deployments timing out with the new size.

*Testing*: I did not introduce new automated tests, as I was only able to reproduce the failure case in a brand new AWS account. I was able to deploy successfully in a new account after this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
