### PR TITLE
fix: Persist deployment bundle settings across deployments

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -361,9 +361,14 @@ namespace AWS.Deploy.CLI.Commands
 
             IDictionary<string, object> previousSettings;
             if (deployedApplication.ResourceType == CloudApplicationResourceType.CloudFormationStack)
-                previousSettings = (await _cloudFormationTemplateReader.LoadCloudApplicationMetadata(deployedApplication.Name)).Settings;
+            {
+                var metadata = await _cloudFormationTemplateReader.LoadCloudApplicationMetadata(deployedApplication.Name);
+                previousSettings = metadata.Settings.Union(metadata.DeploymentBundleSettings).ToDictionary(x => x.Key, x => x.Value);
+            }
             else
+            {
                 previousSettings = await _deployedApplicationQueryer.GetPreviousSettings(deployedApplication);
+            }
 
             await orchestrator.ApplyAllReplacementTokens(selectedRecommendation, deployedApplication.Name);
 

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -38,6 +38,7 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IAWSUtilities), typeof(AWSUtilities), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICDKInstaller), typeof(CDKInstaller), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICDKManager), typeof(CDKManager), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICdkAppSettingsSerializer), typeof(CdkAppSettingsSerializer), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICdkProjectHandler), typeof(CdkProjectHandler), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICloudApplicationNameGenerator), typeof(CloudApplicationNameGenerator), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICommandLineWrapper), typeof(CommandLineWrapper), lifetime));

--- a/src/AWS.Deploy.Common/CloudApplicationMetadata.cs
+++ b/src/AWS.Deploy.Common/CloudApplicationMetadata.cs
@@ -27,6 +27,11 @@ namespace AWS.Deploy.Common
         /// </summary>
         public IDictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
 
+        /// <summary>
+        /// Comprises of option settings that are part of the deployment bundle definition.
+        /// </summary>
+        public IDictionary<string, object> DeploymentBundleSettings { get; set; } = new Dictionary<string , object>();
+
         public CloudApplicationMetadata(string recipeId, string recipeVersion)
         {
             RecipeId = recipeId;

--- a/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
+++ b/src/AWS.Deploy.Common/Recipes/IOptionSettingHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes.Validation;
 
 namespace AWS.Deploy.Common.Recipes
@@ -84,5 +85,12 @@ namespace AWS.Deploy.Common.Recipes
         /// </summary>
         /// <returns>true if the option setting item has been modified or false otherwise</returns>
         bool IsOptionSettingModified(Recommendation recommendation, OptionSettingItem optionSetting);
+
+        /// <summary>
+        /// <para>Returns a Dictionary containing the  configurable option settings for the specified recommendation. The returned dictionary can contain specific types of option settings depending on the value of <see cref="OptionSettingsType"/>.</para>
+        /// <para>The key in the dictionary is the fully qualified ID of each option setting</para>
+        /// <para>The value in the dictionary is the value of each option setting</para>
+        /// </summary>
+        Dictionary<string, object> GetOptionSettingsMap(Recommendation recommendation, ProjectDefinition projectDefinition, IDirectoryManager directoryManager, OptionSettingsType optionSettingsType = OptionSettingsType.All);
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingsType.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingsType.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AWS.Deploy.Common.Recipes
+{
+    /// <summary>
+    /// This enum is used to specify the type of option settings that are retrieved when invoking <see cref="IOptionSettingHandler.GetOptionSettingsMap(Recommendation, ProjectDefinition, IO.IDirectoryManager, OptionSettingsType)"/>
+    /// </summary>
+    public enum OptionSettingsType
+    {
+        /// <summary>
+        /// Theses option settings are part of the individual recipe files.
+        /// </summary>
+        Recipe,
+
+        /// <summary>
+        /// These option settings are part of the deployment bundle definitions.
+        /// </summary>
+        DeploymentBundle,
+
+        /// <summary>
+        /// Comprises of all types of option settings
+        /// </summary>
+        All
+    }
+}

--- a/src/AWS.Deploy.Constants/CloudFormationIdentifier.cs
+++ b/src/AWS.Deploy.Constants/CloudFormationIdentifier.cs
@@ -23,9 +23,14 @@ namespace AWS.Deploy.Constants
         public const string STACK_DESCRIPTION_PREFIX = "AWSDotnetDeployCDKStack";
 
         /// <summary>
-        /// The CloudFormation template metadata key used to hold the last used settings to deploy the application.
+        /// The CloudFormation template metadata key used to hold the last used recipe option settings to deploy the application.
         /// </summary>
         public const string STACK_METADATA_SETTINGS = "aws-dotnet-deploy-settings";
+
+        /// <summary>
+        /// The CloudFormation template metadata key used to hold the last used deployment bundle settings to deploy the application.
+        /// </summary>
+        public const string STACK_METADATA_DEPLOYMENT_BUNDLE_SETTINGS = "aws-dotnet-deploy-deployment-bundle-settings";
 
         /// <summary>
         /// The CloudFormation template metadata key for storing the id of the AWS .NET deployment tool recipe.

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.Orchestration
     {
         private readonly IOrchestratorInteractiveService _interactiveService;
         private readonly ICommandLineWrapper _commandLineWrapper;
-        private readonly CdkAppSettingsSerializer _appSettingsBuilder;
+        private readonly ICdkAppSettingsSerializer _appSettingsBuilder;
         private readonly IDirectoryManager _directoryManager;
         private readonly IAWSResourceQueryer _awsResourceQueryer;
         private readonly IFileManager _fileManager;
@@ -42,7 +42,9 @@ namespace AWS.Deploy.Orchestration
             IOrchestratorInteractiveService interactiveService,
             ICommandLineWrapper commandLineWrapper,
             IAWSResourceQueryer awsResourceQueryer,
+            ICdkAppSettingsSerializer cdkAppSettingsSerializer,
             IFileManager fileManager,
+            IDirectoryManager directoryManager,
             IOptionSettingHandler optionSettingHandler,
             IDeployToolWorkspaceMetadata workspaceMetadata,
             ICloudFormationTemplateReader cloudFormationTemplateReader)
@@ -50,8 +52,8 @@ namespace AWS.Deploy.Orchestration
             _interactiveService = interactiveService;
             _commandLineWrapper = commandLineWrapper;
             _awsResourceQueryer = awsResourceQueryer;
-            _appSettingsBuilder = new CdkAppSettingsSerializer(optionSettingHandler);
-            _directoryManager = new DirectoryManager();
+            _appSettingsBuilder = cdkAppSettingsSerializer;
+            _directoryManager = directoryManager;
             _fileManager = fileManager;
             _workspaceMetadata = workspaceMetadata;
             _cloudFormationTemplateReader = cloudFormationTemplateReader;

--- a/src/AWS.Deploy.Orchestration/Utilities/Helpers.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/Helpers.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.Orchestration.Utilities
 {
@@ -94,7 +96,7 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// <param name="saveSettingsPath">Absolute or relative JSON file path where the deployment settings will be saved. Only the settings modified by the user are persisted.</param>
         /// <param name="saveAllSettingsPath">Absolute or relative JSON file path where the deployment settings will be saved. All deployment settings are persisted.</param>
         /// <param name="projectDirectoryPath">Absolute path to the user's .NET project directory</param>
-        /// <param name="deploymentSettingsHandler"><see cref="IDeploymentSettingsHandler"/></param>
+        /// <param name="fileManager"><see cref="IFileManager"/></param>
         /// <returns><see cref="SaveSettingsConfiguration"/></returns>
         public static SaveSettingsConfiguration GetSaveSettingsConfiguration(string? saveSettingsPath, string? saveAllSettingsPath, string projectDirectoryPath, IFileManager fileManager)
         {

--- a/src/AWS.Deploy.Orchestration/Utilities/TemplateMetadataReader.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/TemplateMetadataReader.cs
@@ -114,6 +114,12 @@ namespace AWS.Deploy.Orchestration.Utilities
                 var jsonString = cfTemplate.Metadata[Constants.CloudFormationIdentifier.STACK_METADATA_SETTINGS];
                 cloudApplicationMetadata.Settings = JsonConvert.DeserializeObject<IDictionary<string, object>>(jsonString ?? "") ?? new Dictionary<string, object>();
 
+                if (cfTemplate.Metadata.ContainsKey(Constants.CloudFormationIdentifier.STACK_METADATA_DEPLOYMENT_BUNDLE_SETTINGS))
+                {
+                    jsonString = cfTemplate.Metadata[Constants.CloudFormationIdentifier.STACK_METADATA_DEPLOYMENT_BUNDLE_SETTINGS];
+                    cloudApplicationMetadata.DeploymentBundleSettings = JsonConvert.DeserializeObject<IDictionary<string, object>>(jsonString ?? "") ?? new Dictionary<string, object>();
+                }
+
                 return cloudApplicationMetadata;
             }
             catch (Exception e)
@@ -147,6 +153,12 @@ namespace AWS.Deploy.Orchestration.Utilities
 
                 var jsonString = ((YamlScalarNode)metadataNode.Children[new YamlScalarNode(Constants.CloudFormationIdentifier.STACK_METADATA_SETTINGS)]).Value;
                 cloudApplicationMetadata.Settings = JsonConvert.DeserializeObject<IDictionary<string, object>>(jsonString ?? "") ?? new Dictionary<string, object>();
+
+                if (metadataNode.Children.ContainsKey(Constants.CloudFormationIdentifier.STACK_METADATA_DEPLOYMENT_BUNDLE_SETTINGS))
+                {
+                    jsonString = ((YamlScalarNode)metadataNode.Children[new YamlScalarNode(Constants.CloudFormationIdentifier.STACK_METADATA_DEPLOYMENT_BUNDLE_SETTINGS)]).Value;
+                    cloudApplicationMetadata.DeploymentBundleSettings = JsonConvert.DeserializeObject<IDictionary<string, object>>(jsonString ?? "") ?? new Dictionary<string, object>();
+                }
 
                 return cloudApplicationMetadata;
             }

--- a/src/AWS.Deploy.Recipes.CDK.Common/CDKRecipeSetup.cs
+++ b/src/AWS.Deploy.Recipes.CDK.Common/CDKRecipeSetup.cs
@@ -28,7 +28,7 @@ namespace AWS.Deploy.Recipes.CDK.Common
             stack.Tags.SetTag(Constants.CloudFormationIdentifier.STACK_TAG, $"{recipeConfiguration.RecipeId}");
 
             // Serializes all AWS .NET deployment tool settings.
-            var json = JsonSerializer.Serialize(
+            var recipeSettingsJson = JsonSerializer.Serialize(
                 recipeConfiguration.Settings,
                 new JsonSerializerOptions
                 {
@@ -47,9 +47,15 @@ namespace AWS.Deploy.Recipes.CDK.Common
             }
 
             // Save the settings, recipe id and version as metadata to the CloudFormation template.
-            metadata[Constants.CloudFormationIdentifier.STACK_METADATA_SETTINGS] = json;
+            metadata[Constants.CloudFormationIdentifier.STACK_METADATA_SETTINGS] = recipeSettingsJson;
             metadata[Constants.CloudFormationIdentifier.STACK_METADATA_RECIPE_ID] = recipeConfiguration.RecipeId;
             metadata[Constants.CloudFormationIdentifier.STACK_METADATA_RECIPE_VERSION] = recipeConfiguration.RecipeVersion;
+
+            // Save the deployment bundle settings.
+            if (!string.IsNullOrEmpty(recipeConfiguration.DeploymentBundleSettings))
+            {
+                metadata[Constants.CloudFormationIdentifier.STACK_METADATA_DEPLOYMENT_BUNDLE_SETTINGS] = recipeConfiguration.DeploymentBundleSettings;
+            }
 
             // For the CDK to pick up the changes to the metadata .NET Dictionary you have to reassign the Metadata property.
             stack.TemplateOptions.Metadata = metadata;

--- a/src/AWS.Deploy.Recipes.CDK.Common/RecipeProps.cs
+++ b/src/AWS.Deploy.Recipes.CDK.Common/RecipeProps.cs
@@ -14,57 +14,62 @@ namespace AWS.Deploy.Recipes.CDK.Common
         /// <summary>
         /// The name of the CloudFormation stack
         /// </summary>
-        public string StackName { get; set; }
+        string StackName { get; set; }
 
         /// <summary>
         /// The path to the .NET project to deploy to AWS.
         /// </summary>
-        public string ProjectPath { get; set; }
+        string ProjectPath { get; set; }
 
         /// <summary>
         /// The ECR Repository Name where the docker image will be pushed to.
         /// </summary>
-        public string? ECRRepositoryName { get; set; }
+        string? ECRRepositoryName { get; set; }
 
         /// <summary>
         /// The ECR Image Tag of the docker image.
         /// </summary>
-        public string? ECRImageTag { get; set; }
+        string? ECRImageTag { get; set; }
 
         /// <summary>
         /// The path of the zip file containing the assemblies produced by the dotnet publish command.
         /// </summary>
-        public string? DotnetPublishZipPath { get; set; }
+        string? DotnetPublishZipPath { get; set; }
 
         /// <summary>
         /// The directory containing the assemblies produced by the dotnet publish command.
         /// </summary>
-        public string? DotnetPublishOutputDirectory { get; set; }
+        string? DotnetPublishOutputDirectory { get; set; }
 
         /// <summary>
         /// The ID of the recipe being used to deploy the application.
         /// </summary>
-        public string RecipeId { get; set; }
+        string RecipeId { get; set; }
 
         /// <summary>
         /// The version of the recipe being used to deploy the application.
         /// </summary>
-        public string RecipeVersion { get; set; }
+        string RecipeVersion { get; set; }
 
         /// <summary>
         /// The configured settings made by the frontend. These are recipe specific and defined in the recipe's definition.
         /// </summary>
-        public T Settings { get; set; }
+        T Settings { get; set; }
+
+        /// <summary>
+        /// These option settings are part of the deployment bundle definition
+        /// </summary>
+        string? DeploymentBundleSettings { get; set; }
 
         /// <summary>
         /// The Region used during deployment. 
         /// </summary>
-        public string? AWSRegion { get; set; }
+        string? AWSRegion { get; set; }
 
         /// <summary>
         /// The account ID used during deployment.
         /// </summary>
-        public string? AWSAccountId { get; set; }
+        string? AWSAccountId { get; set; }
     }
 
     /// <summary>
@@ -119,6 +124,11 @@ namespace AWS.Deploy.Recipes.CDK.Common
         public T Settings { get; set; }
 
         /// <summary>
+        /// These option settings are part of the deployment bundle definition
+        /// </summary>
+        public string? DeploymentBundleSettings { get; set; }
+
+        /// <summary>
         /// The Region used during deployment. 
         /// </summary>
         public string? AWSRegion { get; set; }
@@ -147,7 +157,7 @@ namespace AWS.Deploy.Recipes.CDK.Common
             RecipeVersion = recipeVersion;
             AWSAccountId = awsAccountId;
             AWSRegion = awsRegion;
-            Settings = settings;   
+            Settings = settings;
         }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingsMapTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingsMapTests.cs
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class GetOptionSettingsMapTests
+    {
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IFileManager _fileManager;
+        private readonly IProjectDefinitionParser _projectDefinitionParser;
+
+        public GetOptionSettingsMapTests()
+        {
+            _serviceProvider = new Mock<IServiceProvider>();
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
+            _directoryManager = new DirectoryManager();
+            _fileManager = new FileManager();
+            _projectDefinitionParser = new ProjectDefinitionParser(_fileManager, _directoryManager);
+        }
+
+        [Fact]
+        public async Task GetOptionSettingsMap()
+        {
+            // ARRANGE - select recommendation
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
+            var recommendations = await engine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, "AspNetAppAppRunner"));
+
+            // ARRANGE - get project definition
+            var projectPath = SystemIOUtilities.ResolvePath("WebAppWithDockerFile");
+            var projectDefinition = await _projectDefinitionParser.Parse(projectPath);
+
+            // ARRANGE - Modify option setting items
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ServiceName", "MyAppRunnerService", true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "Port", "100", true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ECRRepositoryName", "my-ecr-repository", true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DockerfilePath", Path.Combine(projectPath, "Dockerfile"), true);
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DockerExecutionDirectory", projectPath, true);
+
+            // ACT and ASSERT - OptionSettingType.All
+            var container = _optionSettingHandler.GetOptionSettingsMap(selectedRecommendation, projectDefinition, _directoryManager);
+            Assert.Equal("MyAppRunnerService", container["ServiceName"]);
+            Assert.Equal(100, container["Port"]);
+            Assert.Equal("my-ecr-repository", container["ECRRepositoryName"]);
+            Assert.Equal("Dockerfile", container["DockerfilePath"]); // path relative to projectPath
+            Assert.Equal(".", container["DockerExecutionDirectory"]); // path relative to projectPath
+
+            // ACT and ASSERT - OptionSettingType.Recipe
+            container = _optionSettingHandler.GetOptionSettingsMap(selectedRecommendation, projectDefinition, _directoryManager, OptionSettingsType.Recipe);
+            Assert.Equal("MyAppRunnerService", container["ServiceName"]);
+            Assert.Equal(100, container["Port"]);
+            Assert.False(container.ContainsKey("Dockerfile"));
+            Assert.False(container.ContainsKey("DockerExecutionDirectory"));
+            Assert.False(container.ContainsKey("ECRRepositoryName"));
+
+            // ACT and ASSERT - OptionSettingType.DeploymentBundle
+            container = _optionSettingHandler.GetOptionSettingsMap(selectedRecommendation, projectDefinition, _directoryManager, OptionSettingsType.DeploymentBundle);
+            Assert.Equal("my-ecr-repository", container["ECRRepositoryName"]);
+            Assert.Equal("Dockerfile", container["DockerfilePath"]); // path relative to projectPath
+            Assert.Equal(".", container["DockerExecutionDirectory"]); // path relative to projectPath
+            Assert.False(container.ContainsKey("ServiceName"));
+            Assert.False(container.ContainsKey("Port"));
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/TemplateMetadataReaderTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TemplateMetadataReaderTests.cs
@@ -53,6 +53,10 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var applicationIAMRole = JsonConvert.DeserializeObject<IAMRoleTypeHintResponse>(metadata.Settings["ApplicationIAMRole"].ToString());
             Assert.True(applicationIAMRole.CreateNew);
+
+            Assert.Equal("Dockerfile", metadata.DeploymentBundleSettings["DockerfilePath"]);
+            Assert.Equal(".", metadata.DeploymentBundleSettings["DockerExecutionDirectory"]);
+            Assert.Equal("webappwithdockerfile", metadata.DeploymentBundleSettings["ECRRepositoryName"]);
         }
 
         [Fact]
@@ -76,6 +80,10 @@ namespace AWS.Deploy.CLI.UnitTests
 
             // ASSERT
             Assert.Equal("aws-elasticbeanstalk-role", metadata.Settings["ApplicationIAMRole"].ToString());
+
+            Assert.Equal("Dockerfile", metadata.DeploymentBundleSettings["DockerfilePath"]);
+            Assert.Equal(".", metadata.DeploymentBundleSettings["DockerExecutionDirectory"]);
+            Assert.Equal("webappwithdockerfile", metadata.DeploymentBundleSettings["ECRRepositoryName"]);
         }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/TestFiles/ReadJsonTemplateMetadata.json
+++ b/test/AWS.Deploy.CLI.UnitTests/TestFiles/ReadJsonTemplateMetadata.json
@@ -2,6 +2,7 @@
   "Description": "AWSDotnetDeployCDKStack",
   "Metadata": {
     "aws-dotnet-deploy-settings": "{\"ApplicationIAMRole\":{\"CreateNew\":true,\"RoleArn\":null},\"EnvironmentType\":\"SingleInstance\",\"InstanceType\":\"\",\"BeanstalkEnvironment\":{\"CreateNew\":true,\"EnvironmentName\":\"WebApp1-dev\"},\"BeanstalkApplication\":{\"CreateNew\":true,\"ApplicationName\":\"WebApp1\"},\"ElasticBeanstalkPlatformArn\":\"arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/2.2.10\",\"LoadBalancerType\":\"application\",\"EC2KeyPair\":\"\",\"ElasticBeanstalkManagedPlatformUpdates\":{\"ManagedActionsEnabled\":true,\"PreferredStartTime\":\"Sun:00:00\",\"UpdateLevel\":\"minor\"},\"XRayTracingSupportEnabled\":false,\"ReverseProxy\":\"nginx\",\"EnhancedHealthReporting\":\"enhanced\",\"HealthCheckURL\":\"/\",\"ElasticBeanstalkRollingUpdates\":{\"RollingUpdatesEnabled\":false,\"RollingUpdateType\":\"Time\",\"MaxBatchSize\":null,\"MinInstancesInService\":null,\"PauseTime\":null,\"Timeout\":\"PT30M\"},\"CNamePrefix\":\"\",\"ElasticBeanstalkEnvironmentVariables\":{}}",
+    "aws-dotnet-deploy-deployment-bundle-settings": "{\"DockerBuildArgs\":\"\",\"DockerfilePath\":\"Dockerfile\",\"DockerExecutionDirectory\":\".\",\"ECRRepositoryName\":\"webappwithdockerfile\"}",
     "aws-dotnet-deploy-recipe-id": "AspNetAppElasticBeanstalkLinux",
     "aws-dotnet-deploy-recipe-version": "0.1.0"
   },

--- a/test/AWS.Deploy.CLI.UnitTests/TestFiles/ReadYamlTemplateMetadata.yml
+++ b/test/AWS.Deploy.CLI.UnitTests/TestFiles/ReadYamlTemplateMetadata.yml
@@ -1,6 +1,7 @@
 Description: AWSDotnetDeployCDKStack
 Metadata:
   aws-dotnet-deploy-settings: '{"ApplicationIAMRole":"aws-elasticbeanstalk-role","EnvironmentType":"SingleInstance","InstanceType":"t2.micro","EnvironmentName":"BeanstalkTest2-dev","ApplicationName":"BeanstalkTest2","SolutionStackName":"64bit Amazon Linux 2 v2.1.2 running .NET Core","LoadBalancerType":"application","UseExistingApplication":false,"EC2KeyPair":""}'
+  aws-dotnet-deploy-deployment-bundle-settings: '{"DockerBuildArgs": "","DockerfilePath": "Dockerfile","DockerExecutionDirectory": ".","ECRRepositoryName": "webappwithdockerfile"}'
   aws-dotnet-deploy-recipe-id: AspNetAppElasticBeanstalkLinux
   aws-dotnet-deploy-recipe-version: 0.1.0
 Parameters:


### PR DESCRIPTION
*Issue #, if available:*
* DOTNET-6032
* https://github.com/aws/aws-dotnet-deploy/issues/153

*Description of changes:*
This PR persists deployment bundle option settings across re-deployments.

It achieves this by writing the deployment bundle option settings in the CloudFormation template metadata under the `aws-dotnet-deploy-deployment-bundle-settings` property.
![image](https://user-images.githubusercontent.com/36622308/190033530-0a325f23-a369-43aa-acce-dcd4f6c46e38.png)

**Note** - All file and directory paths are written relative to the user's .NET project directory path.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
