### PR TITLE
feat: add support for deploying to existing windows Beanstalk environments

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/DeployCommand.cs
@@ -367,7 +367,7 @@ namespace AWS.Deploy.CLI.Commands
             }
             else
             {
-                previousSettings = await _deployedApplicationQueryer.GetPreviousSettings(deployedApplication);
+                previousSettings = await _deployedApplicationQueryer.GetPreviousSettings(deployedApplication, selectedRecommendation);
             }
 
             await orchestrator.ApplyAllReplacementTokens(selectedRecommendation, deployedApplication.Name);

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -442,7 +442,7 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 }
                 else
                 {
-                    previousSettings = await deployedApplicationQueryer.GetPreviousSettings(existingDeployment);
+                    previousSettings = await deployedApplicationQueryer.GetPreviousSettings(existingDeployment, state.SelectedRecommendation);
                 }
 
                 state.SelectedRecommendation = await orchestrator.ApplyRecommendationPreviousSettings(state.SelectedRecommendation, previousSettings);

--- a/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
+++ b/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
@@ -22,6 +22,14 @@ namespace AWS.Deploy.Constants
         public const string HealthCheckURLOptionNameSpace = "aws:elasticbeanstalk:application";
         public const string HealthCheckURLOptionName = "Application Healthcheck URL";
 
+        public const string LinuxPlatformType = ".NET Core";
+        public const string WindowsPlatformType = "Windows Server";
+
+        public const string IISAppPathOptionId = "IISAppPath";
+        public const string IISWebSiteOptionId = "IISWebSite";
+
+        public const string WindowsManifestName = "aws-windows-deployment-manifest.json";
+
         /// <summary>
         /// This list stores a named tuple of OptionSettingId, OptionSettingNameSpace and OptionSettingName.
         /// <para>OptionSettingId refers to the Id property for an option setting item in the recipe file.</para>
@@ -33,6 +41,20 @@ namespace AWS.Deploy.Constants
             new (EnhancedHealthReportingOptionId, EnhancedHealthReportingOptionNameSpace, EnhancedHealthReportingOptionName),
             new (XRayTracingOptionId, XRayTracingOptionNameSpace, XRayTracingOptionName),
             new (ProxyOptionId, ProxyOptionNameSpace, ProxyOptionName),
+            new (HealthCheckURLOptionId, HealthCheckURLOptionNameSpace, HealthCheckURLOptionName)
+        };
+
+        /// <summary>
+        /// This is the list of option settings available for Windows Beanstalk deployments.
+        /// This list stores a named tuple of OptionSettingId, OptionSettingNameSpace and OptionSettingName.
+        /// <para>OptionSettingId refers to the Id property for an option setting item in the recipe file.</para>
+        /// <para>OptionSettingNameSpace and OptionSettingName provide a way to configure the environments metadata and update its behaviour.</para>
+        /// <para>A comprehensive list of all configurable settings can be found <see href="https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/beanstalk-environment-configuration-advanced.html">here</see></para>
+        /// </summary>
+        public static List<(string OptionSettingId, string OptionSettingNameSpace, string OptionSettingName)> WindowsOptionSettingQueryList = new()
+        {
+            new (EnhancedHealthReportingOptionId, EnhancedHealthReportingOptionNameSpace, EnhancedHealthReportingOptionName),
+            new (XRayTracingOptionId, XRayTracingOptionNameSpace, XRayTracingOptionName),
             new (HealthCheckURLOptionId, HealthCheckURLOptionNameSpace, HealthCheckURLOptionName)
         };
     }

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -8,6 +8,7 @@ namespace AWS.Deploy.Constants
     {
         // Recipe IDs
         public const string EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkEnvironment";
+        public const string EXISTING_BEANSTALK_WINDOWS_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkWindowsEnvironment";
         public const string PUSH_TO_ECR_RECIPE_ID = "PushContainerImageEcr";
 
         // Replacement Tokens

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -530,11 +530,11 @@ namespace AWS.Deploy.Orchestration.Data
             var allPlatformSummaries = new List<PlatformSummary>();
             if (platformTypes.Contains(BeanstalkPlatformType.Linux))
             {
-                allPlatformSummaries.AddRange(await fetchPlatforms(".NET Core"));
+                allPlatformSummaries.AddRange(await fetchPlatforms(Constants.ElasticBeanstalk.LinuxPlatformType));
             }
-            else if (platformTypes.Contains(BeanstalkPlatformType.Windows))
+            if (platformTypes.Contains(BeanstalkPlatformType.Windows))
             {
-                var windowsPlatforms = await fetchPlatforms("Windows Server");
+                var windowsPlatforms = await fetchPlatforms(Constants.ElasticBeanstalk.WindowsPlatformType);
                 SortElasticBeanstalkWindowsPlatforms(windowsPlatforms);
                 allPlatformSummaries.AddRange(windowsPlatforms);
             }

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
@@ -39,6 +39,12 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
 
             orchestrator._interactiveService.LogSectionStart($"Creating application version", "Uploading deployment bundle to S3 and create an Elastic Beanstalk application version");
 
+            // This step is only required for Elastic Beanstalk Windows deployments since a manifest file needs to be created for that deployment.
+            if (recommendation.Recipe.Id.Equals(Constants.RecipeIdentifier.EXISTING_BEANSTALK_WINDOWS_ENVIRONMENT_RECIPE_ID))
+            {
+                elasticBeanstalkHandler.SetupWindowsDeploymentManifest(recommendation, deploymentPackage);
+            }
+
             var versionLabel = $"v-{DateTime.Now.Ticks}";
             var s3location = await elasticBeanstalkHandler.CreateApplicationStorageLocationAsync(applicationName, versionLabel, deploymentPackage);
             await s3Handler.UploadToS3Async(s3location.S3Bucket, s3location.S3Key, deploymentPackage);

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
@@ -1,0 +1,110 @@
+{
+    "$schema": "./aws-deploy-recipe-schema.json",
+    "Id": "AspNetAppExistingBeanstalkWindowsEnvironment",
+    "Version": "1.0.0",
+    "Name": "ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment",
+    "DisableNewDeployments": true,
+    "DeploymentType": "BeanstalkEnvironment",
+    "DeploymentBundle": "DotnetPublishZipFile",
+    "ShortDescription": "Deploys your application directly to a Windows EC2 instance using AWS Elastic Beanstalk.",
+    "Description": "This ASP.NET Core application will be built and deployed to an existing AWS Elastic Beanstalk Windows environment. Recommended if you want to deploy your application directly to EC2 hosts, not as a container image.",
+    "TargetService": "AWS Elastic Beanstalk",
+    "TargetPlatform": "Windows",
+
+    "RecipePriority": 0,
+    "RecommendationRules": [
+        {
+            "Tests": [
+                {
+                    "Type": "MSProjectSdkAttribute",
+                    "Condition": {
+                        "Value": "Microsoft.NET.Sdk.Web"
+                    }
+                },
+                {
+                    "Type": "MSProperty",
+                    "Condition": {
+                        "PropertyName": "TargetFramework",
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
+                    }
+                }
+            ],
+            "Effect": {
+                "Pass": { "Include": true },
+                "Fail": { "Include": false }
+            }
+        }
+    ],
+    "Categories": [
+        {
+            "Id": "Hosting",
+            "DisplayName": "Hosting",
+            "Order": 20
+        },
+        {
+            "Id": "Health",
+            "DisplayName": "Health & Monitoring",
+            "Order": 30
+        }
+    ],
+    "OptionSettings": [
+        {
+            "Id": "IISWebSite",
+            "Name": "IIS Web Site",
+            "Category": "Hosting",
+            "Description": "The IIS Web Site the application will be installed in.",
+            "Type": "String",
+            "DefaultValue": "Default Web Site",
+            "AdvancedSetting": true,
+            "Updatable": true
+        },
+        {
+            "Id": "IISAppPath",
+            "Name": "IIS Application Path",
+            "Category": "Hosting",
+            "Description": "The IIS application path that will be the root of the application.",
+            "Type": "String",
+            "DefaultValue": "/",
+            "AdvancedSetting": true,
+            "Updatable": true
+        },
+        {
+            "Id": "EnhancedHealthReporting",
+            "Name": "Enhanced Health Reporting",
+            "Category": "Health",
+            "Description": "Enhanced health reporting provides free real-time application and operating system monitoring of the instances and other resources in your environment.",
+            "Type": "String",
+            "DefaultValue": "enhanced",
+            "AllowedValues": [
+                "enhanced",
+                "basic"
+            ],
+            "ValueMapping": {
+                "enhanced": "Enhanced",
+                "basic": "Basic"
+            },
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
+            "Id": "XRayTracingSupportEnabled",
+            "Name": "Enable AWS X-Ray Tracing Support",
+            "Category": "Health",
+            "Description": "AWS X-Ray is a service that collects data about requests that your application serves, and provides tools you can use to view, filter, and gain insights into that data to identify issues and opportunities for optimization. Do you want to enable AWS X-Ray tracing support?",
+            "Type": "Bool",
+            "DefaultValue": false,
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
+            "Id": "HealthCheckURL",
+            "Name": "Health Check URL",
+            "Category": "Health",
+            "Description": "Customize the load balancer health check to ensure that your application, and not just the web server, is in a good state.",
+            "Type": "String",
+            "DefaultValue": "/",
+            "AdvancedSetting": false,
+            "Updatable": true
+        }
+    ]
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/CLITests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/CLITests.cs
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Orchestration.ServiceHandlers;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests.ExistingWindowsEnvironment
+{
+    [Collection(nameof(WindowsTestContextFixture))]
+    public class CLITests
+    {
+        private readonly WindowsTestContextFixture _fixture;
+        private readonly AWSElasticBeanstalkHandler _awsElasticBeanstalkHandler;
+        private readonly Mock<IOptionSettingHandler> _optionSettingHandler;
+        private readonly ProjectDefinitionParser _projectDefinitionParser;
+        private readonly RecipeDefinition _recipeDefinition;
+
+        public CLITests(WindowsTestContextFixture fixture)
+        {
+            _projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            _fixture = fixture;
+            _optionSettingHandler = new Mock<IOptionSettingHandler>();
+            _awsElasticBeanstalkHandler = new AWSElasticBeanstalkHandler(null, null, null, _optionSettingHandler.Object);
+            _recipeDefinition = new Mock<RecipeDefinition>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DeploymentTypes>(),
+                It.IsAny<DeploymentBundleTypes>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()).Object;
+        }
+
+        [Fact]
+        public async Task DeployToExistingBeanstalkEnvironment()
+        {
+            var projectPath = _fixture.TestAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _fixture.EnvironmentName, "--diagnostics", "--silent", "--region", "us-west-2" };
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _fixture.App.Run(deployArgs));
+
+            var environmentDescription = await _fixture.AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(_fixture.EnvironmentName);
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _fixture.HttpHelper.WaitUntilSuccessStatusCode(environmentDescription.CNAME, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            var successMessagePrefix = $"The Elastic Beanstalk Environment {_fixture.EnvironmentName} has been successfully updated";
+            var deployStdOutput = _fixture.InteractiveService.StdOutReader.ReadAllLines();
+            var successMessage = deployStdOutput.First(line => line.Trim().StartsWith(successMessagePrefix));
+            Assert.False(string.IsNullOrEmpty(successMessage));
+
+            var expectedVersionLabel = successMessage.Split(" ").Last();
+            Assert.True(await _fixture.EBHelper.VerifyEnvironmentVersionLabel(_fixture.EnvironmentName, expectedVersionLabel));
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/ServerModeTests.cs
@@ -10,25 +10,24 @@ using System.Threading.Tasks;
 using Amazon.Runtime;
 using AWS.Deploy.CLI.Commands;
 using AWS.Deploy.CLI.IntegrationTests.Utilities;
-using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.ServerMode.Client;
 using Xunit;
 
-namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
+namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests.ExistingWindowsEnvironment
 {
-    [Collection(nameof(TestContextFixture))]
+    [Collection(nameof(WindowsTestContextFixture))]
     public class ServerModeTests
     {
-        private readonly TestContextFixture _fixture;
-        private const string BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkEnvironment";
+        private readonly WindowsTestContextFixture _fixture;
+        private const string BEANSTALK_ENVIRONMENT_RECIPE_ID = "AspNetAppExistingBeanstalkWindowsEnvironment";
 
-        public ServerModeTests(TestContextFixture fixture)
+        public ServerModeTests(WindowsTestContextFixture fixture)
         {
             _fixture = fixture;
         }
 
         [Fact]
-        public async Task DeployToExistingBeanstalkEnvironment()
+        public async Task DeployToExistingWindowsBeanstalkEnvironment()
         {
             var projectPath = _fixture.TestAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
             var portNumber = 4031;

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixtureCollection.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixtureCollection.cs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests.ExistingWindowsEnvironment
+{
+    /// <summary>
+    /// The goal of this class is to create a Collection definition and use <see cref="WindowsTestContextFixture"/> as shared context.
+    /// More info could be found here https://xunit.net/docs/shared-context
+    /// </summary>
+    [CollectionDefinition(nameof(WindowsTestContextFixture))]
+    public class WindowsTestContextFixtureCollection : ICollectionFixture<WindowsTestContextFixture>
+    {
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixtureCollection.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixtureCollection.cs
@@ -5,7 +5,11 @@ using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
 {
-    [CollectionDefinition(nameof(TestContextFixture), DisableParallelization = true)]
+    /// <summary>
+    /// The goal of this class is to create a Collection definition and use <see cref="TestContextFixture"/> as shared context.
+    /// More info could be found here https://xunit.net/docs/shared-context
+    /// </summary>
+    [CollectionDefinition(nameof(TestContextFixture))]
     public class TestContextFixtureCollection : ICollectionFixture<TestContextFixture>
     {
     }

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
             });
         }
 
-        public async Task<bool> CreateEnvironmentAsync(string applicationName, string environmentName, string versionLabel)
+        public async Task<bool> CreateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, BeanstalkPlatformType platformType)
         {
             _interactiveService.WriteLine($"Creating new Elastic Beanstalk environment {environmentName} with versionLabel {versionLabel}");
 
@@ -72,7 +72,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
                 ApplicationName = applicationName,
                 EnvironmentName = environmentName,
                 VersionLabel = versionLabel,
-                PlatformArn = (await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType.Linux)).PlatformArn,
+                PlatformArn = (await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(platformType)).PlatformArn,
                 OptionSettings = new List<ConfigurationOptionSetting>
                 {
                     new ConfigurationOptionSetting("aws:autoscaling:launchconfiguration", "IamInstanceProfile", "aws-elasticbeanstalk-ec2-role"),

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -74,13 +74,14 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var recommendations = await orchestrator.GenerateDeploymentRecommendations();
 
             // ASSERT
-            recommendations.Count.ShouldEqual(6);
+            recommendations.Count.ShouldEqual(7);
             recommendations[0].Name.ShouldEqual("ASP.NET Core App to Amazon ECS using AWS Fargate"); // default recipe
             recommendations[1].Name.ShouldEqual("ASP.NET Core App to AWS App Runner"); // default recipe
             recommendations[2].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Linux"); // default recipe
             recommendations[3].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Windows"); // default recipe
             recommendations[4].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Environment"); // default recipe
-            recommendations[5].Name.ShouldEqual("Container Image to Amazon Elastic Container Registry (ECR)"); // default recipe
+            recommendations[5].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment"); // default recipe
+            recommendations[6].Name.ShouldEqual("Container Image to Amazon Elastic Container Registry (ECR)"); // default recipe
         }
 
         [Fact]
@@ -112,7 +113,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var recommendations = await orchestrator.GenerateDeploymentRecommendations();
 
             // ASSERT - Recipes are ordered by priority
-            recommendations.Count.ShouldEqual(8);
+            recommendations.Count.ShouldEqual(9);
             recommendations[0].Name.ShouldEqual(customEcsRecipeName); // custom recipe
             recommendations[1].Name.ShouldEqual(customEbsRecipeName); // custom recipe
             recommendations[2].Name.ShouldEqual("ASP.NET Core App to Amazon ECS using AWS Fargate"); // default recipe
@@ -120,7 +121,8 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             recommendations[4].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Linux"); // default recipe
             recommendations[5].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Windows"); // default recipe
             recommendations[6].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Environment"); // default recipe
-            recommendations[7].Name.ShouldEqual("Container Image to Amazon Elastic Container Registry (ECR)"); // default recipe
+            recommendations[7].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment"); // default recipe
+            recommendations[8].Name.ShouldEqual("Container Image to Amazon Elastic Container Registry (ECR)"); // default recipe
 
             // ASSERT - Recipe paths
             recommendations[0].Recipe.RecipePath.ShouldEqual(Path.Combine(saveDirectoryPathEcsProject, "ECS-CDK.recipe"));
@@ -163,7 +165,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var recommendations = await orchestrator.GenerateDeploymentRecommendations();
 
             // ASSERT - Recipes are ordered by priority
-            recommendations.Count.ShouldEqual(7);
+            recommendations.Count.ShouldEqual(8);
             recommendations[0].Name.ShouldEqual(customEbsRecipeName);
             recommendations[1].Name.ShouldEqual(customEcsRecipeName);
             recommendations[2].Name.ShouldEqual("ASP.NET Core App to AWS Elastic Beanstalk on Linux");
@@ -171,6 +173,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             recommendations[4].Name.ShouldEqual("ASP.NET Core App to Amazon ECS using AWS Fargate");
             recommendations[5].Name.ShouldEqual("ASP.NET Core App to AWS App Runner");
             recommendations[6].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Environment");
+            recommendations[7].Name.ShouldEqual("ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment");
 
             // ASSERT - Recipe paths
             recommendations[0].Recipe.RecipePath.ShouldEqual(Path.Combine(saveDirectoryPathEbsProject, "EBS-CDK.recipe"));

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
@@ -43,12 +43,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
             _testAppManager = new TestAppManager();
         }
 
-        public Task<AWSCredentials> ResolveCredentials()
-        {
-            var testCredentials = FallbackCredentialsFactory.GetCredentials();
-            return Task.FromResult<AWSCredentials>(testCredentials);
-        }
-
         [Fact]
         public async Task DependentOptionSettingsGetInvalidated()
         {
@@ -56,7 +50,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
             var portNumber = 4022;
-            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ServerModeExtensions.ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
             var cancelSource = new CancellationTokenSource();
@@ -147,7 +141,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
             var portNumber = 4022;
-            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ResolveCredentials);
+            using var httpClient = ServerModeHttpClientFactory.ConstructHttpClient(ServerModeExtensions.ResolveCredentials);
 
             var serverCommand = new ServerModeCommand(_serviceProvider.GetRequiredService<IToolInteractiveService>(), portNumber, null, true);
             var cancelSource = new CancellationTokenSource();


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6274

*Description of changes:*
Currently, we only support redeploying to existing linux beanstalk environments. From a recent statistic that Chris shared, the ratio of windows to linux beanstalk environments is 2:1. We don't support redeploying to windows environments. So the majority of our existing customers cannot deploy to their existing environments on Windows. This PR adds a new recipe that supports existing Windows beanstalk environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
