### PR TITLE
ci: increase CodeBuild job timeout to account for increased integ tests runtime

### DIFF
--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -96,6 +96,7 @@ Resources:
         BuildSpec: buildtools/ci.buildspec.yml
       Artifacts:
         Type: NO_ARTIFACTS
+      TimeoutInMinutes: 120
 
   CodeBuildProjectRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6291

*Description of changes:*
Increase CodeBuild job timeout to 120mins instead of the default 60mins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
