### PR TITLE
ci: increase codebuild ci role assume duration

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          role-duration-seconds: 7200
           aws-region: us-west-2
       - name: Run CodeBuild
         id: codebuild


### PR DESCRIPTION
*Description of changes:*
The CodeBuild PR check is failing when it hits the 1 hour mark. I have increased the maximum duration of the IAM roles we are assuming to allow for longer builds. This PR increases the duration in seconds for the assume role to allow builds to run longer than the default 60 seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
