### PR TITLE
 Enable toggling "Internet-Facing" for the ECS Fargate Load Balancer

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Configurations/LoadBalancerConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Configurations/LoadBalancerConfiguration.cs
@@ -68,6 +68,10 @@ namespace AspNetAppEcsFargate.Configurations
         /// </summary>
         public double ListenerConditionPriority { get; set; } = 100;
 
+        /// <summary>
+        /// Whether the load balancer has an internet-routable address.
+        /// </summary>
+        public bool InternetFacing { get; set; } = true;
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
@@ -206,7 +206,7 @@ namespace AspNetAppEcsFargate
                 ServiceLoadBalancer = new ApplicationLoadBalancer(this, nameof(ServiceLoadBalancer), InvokeCustomizeCDKPropsEvent(nameof(ServiceLoadBalancer), this, new ApplicationLoadBalancerProps
                 {
                     Vpc = AppVpc,
-                    InternetFacing = true
+                    InternetFacing = settings.LoadBalancer.InternetFacing
                 }));
 
                 LoadBalancerListener = ServiceLoadBalancer.AddListener(nameof(LoadBalancerListener), InvokeCustomizeCDKPropsEvent(nameof(LoadBalancerListener), this, new ApplicationListenerProps

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppEcsFargate",
-    "Version": "1.0.1",
+    "Version": "1.1.0",
     "Name": "ASP.NET Core App to Amazon ECS using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -702,6 +702,15 @@
                             "Value": "Path"
                         }
                     ]
+                },
+                {
+                    "Id": "InternetFacing",
+                    "Name": "Internet-Facing",
+                    "Description": "Should the load balancer have an internet-routable address? Internet-facing load balancers can route requests from clients over the internet. Internal load balancers can route requests only from clients with access to the VPC.",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
                 }
             ]
         },


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6294 and #679 

*Description of changes:* Adds a new option setting to the ASP.NET ECS Fargate recipe to expose the [internetFacing?](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancing.LoadBalancerProps.html#internetfacing) property in the underlying CDK recipe.
* The GitHub issue suggested exposing `Load Balancer Schema: internet-facing`, but this appears to be mapped to a boolean in CDK.
* I was not able to mark this updatable because the redeployment fails due to https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/780
* Added automated tests that examine the generated CloudFormation template. Did manual testing with both settings, verified that my resulting application was accessible from an instance running in the same VPC but not my laptop.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
