### PR TITLE
feat: Add HTTP3 support for BlazorWasm deployments

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -17,7 +17,7 @@
 ** AWSSDK.IdentityManagement; version 3.7.2.25 -- https://www.nuget.org/packages/AWSSDK.IdentityManagement
 ** AWSSDK.SecurityToken; version 3.7.1.35 -- https://www.nuget.org/packages/AWSSDK.SecurityToken
 ** Constructs; version 10.0.0 -- https://www.nuget.org/packages/Constructs
-** Amazon.CDK.Lib; version 2.13.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
+** Amazon.CDK.Lib; version 2.43.1 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
 ** Amazon.JSII.Runtime; version 1.54.0 -- https://www.nuget.org/packages/Amazon.JSII.Runtime
 ** AWSSDK.CloudControlApi; version 3.7.2 -- https://www.nuget.org/packages/AWSSDK.CloudControlApi/
 ** AWSSDK.SimpleSystemsManagement; version 3.7.16 -- https://www.nuget.org/packages/AWSSDK.SimpleSystemsManagement/

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.61" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.61" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.13.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
@@ -330,9 +330,11 @@
             "Category": "Networking",
             "Description": "The maximum http version that users can use to communicate with the CloudFront distribution",
             "Type": "String",
-            "DefaultValue": "HTTP2",
-            "AllowedValues": [ "HTTP2", "HTTP1_1" ],
+            "DefaultValue": "HTTP2_AND_3",
+            "AllowedValues": [ "HTTP2_AND_3", "HTTP3","HTTP2", "HTTP1_1" ],
             "ValueMapping": {
+                "HTTP2_AND_3": "HTTP 2 and 3",
+                "HTTP3": "HTTP 3",
                 "HTTP2": "HTTP 2",
                 "HTTP1_1": "HTTP 1.1"
             },


### PR DESCRIPTION
*Description of changes:*
CloudFront added support for HTTP 3 [last month](https://aws.amazon.com/blogs/aws/new-http-3-support-for-amazon-cloudfront/). This PR adds the enums to the recipe for selecting HTTP 3.

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/1653751/192080393-f6e4d1a7-170c-45af-8b22-40793378c943.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
