### PR TITLE
chore: Truncate long error messages

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -615,13 +615,14 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                 if (state.DeploymentTask.Exception != null)
                 {
                     var innerException = state.DeploymentTask.Exception.InnerException;
+                    var message = innerException.GetTruncatedErrorMessage();
                     if (innerException is DeployToolException deployToolException)
                     {
-                        output.Exception = new DeployToolExceptionSummary(deployToolException.ErrorCode.ToString(), deployToolException.Message, deployToolException.ProcessExitCode);
+                        output.Exception = new DeployToolExceptionSummary(deployToolException.ErrorCode.ToString(), message, deployToolException.ProcessExitCode);
                     }
                     else
                     {
-                        output.Exception = new DeployToolExceptionSummary(DeployToolErrorCode.UnexpectedError.ToString(), innerException?.Message ?? string.Empty);
+                        output.Exception = new DeployToolExceptionSummary(DeployToolErrorCode.UnexpectedError.ToString(), message);
                     }
                 }
             }

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -318,5 +318,27 @@ namespace AWS.Deploy.Common
 
             return $"{Environment.NewLine}{e.Message}{Environment.NewLine}{e.StackTrace}{PrettyPrint(e.InnerException)}";
         }
+
+        /// <summary>
+        /// Returns the truncated error message by only preserving the leading and trailing k characters.
+        /// The message will only be truncated if its length is greater than 2*k.
+        /// </summary>
+        /// <param name="numChars">Species the number of leading and trailing characters to preserve.</param>
+        /// <returns>The truncated error message or <see cref="string.Empty"/> if the error message is null or empty.</returns>
+        public static string GetTruncatedErrorMessage(this Exception? e, int numChars = 500)
+        {
+            var message = e?.Message;
+
+            if (string.IsNullOrEmpty(message))
+                return string.Empty;
+
+            if (message.Length <= 2*numChars)
+                return message;
+
+            var firstKChars = message.Substring(0, numChars);
+            var lastkChars = message.Substring(message.Length - numChars);
+            var seperator = $"{Environment.NewLine}...{Environment.NewLine}Error truncated to the first and last {numChars} characters{Environment.NewLine}...{Environment.NewLine}";
+            return $"{firstKChars}{seperator}{lastkChars}";
+        }
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/ExceptionExtensionsTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ExceptionExtensionsTests.cs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using AWS.Deploy.Common;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class ExceptionExtensionsTests
+    {
+        [Fact]
+        public void GetTruncatedErrorMessage_EmptyMessage()
+        {
+            // ARRANGE
+            var ex = new Exception(string.Empty);
+
+            // ACT and ASSERT
+            Assert.Equal(string.Empty, ex.GetTruncatedErrorMessage());
+        }
+
+        [Fact]
+        public void GetTruncatedErrorMessage_NoTruncation()
+        {
+            // ARRANGE
+            var message = "This is an AWSDeployToolException";
+            var ex = new Exception(message);
+
+            // ACT and ASSERT
+            // No truncation is performed because the message length < 2 * k
+            Assert.Equal(message, ex.GetTruncatedErrorMessage(numChars: 50));
+        }
+
+        [Fact]
+        public void GetTruncatedErrorMessage()
+        {
+            // ARRANGE
+            var message =
+                "error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. " +
+                "error text. error text. error text. error text. error text. error text. error text.";
+
+
+            var ex = new Exception(message);
+
+            // ACT
+            var truncatedErrorMessage = ex.GetTruncatedErrorMessage(numChars: 50);
+
+            // ACT and ASSERT
+            var expectedMessage =
+                @"error text. error text. error text. error text. er
+...
+Error truncated to the first and last 50 characters
+...
+t. error text. error text. error text. error text.";
+
+            Assert.Equal(expectedMessage, truncatedErrorMessage);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6257

*Description of changes:*
This PR truncates long error messages so that external telemetery systems that are hooked to the deploy tool via server mode are not overloaded.

Currently, the truncation is only performed in the `GetDeploymentStatus` API call. However, I am unsure if this is the only place from where the data is fed into external telemetry systems. The same concern has also been brought up via internal communication.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
