### PR TITLE
fix: json comments in beanstalk windows manifest caused exception

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -125,7 +125,8 @@ namespace AWS.Deploy.Common
         ECRRepositoryNameIsNull = 10010300,
         FailedToReadCdkBootstrapVersion = 10010400,
         UnsupportedOptionSettingType = 10010500,
-        FailedToSaveDeploymentSettings = 10010600
+        FailedToSaveDeploymentSettings = 10010600,
+        InvalidWindowsManifestFile = 10010700
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -260,4 +260,12 @@ namespace AWS.Deploy.Orchestration
     {
         public InvalidDeployToolWorkspaceException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
+
+    /// <summary>
+    /// Throw if the deploy tool detects an invalid windows elastic beanstalk manifest file.
+    /// </summary>
+    public class InvalidWindowsManifestFileException : DeployToolException
+    {
+        public InvalidWindowsManifestFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
 }

--- a/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
+++ b/src/AWS.Deploy.Orchestration/ServiceHandlers/AWSElasticBeanstalkHandler.cs
@@ -93,7 +93,7 @@ namespace AWS.Deploy.Orchestration.ServiceHandlers
         {
             try
             {
-                return JsonSerializer.Deserialize<T>(json?.ToString() ?? string.Empty);
+                return JsonSerializer.Deserialize<T>(json?.ToString() ?? string.Empty, new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
             }
             catch
             {

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
@@ -471,8 +471,38 @@ namespace AWS.Deploy.Orchestration.UnitTests
             Assert.Equal("false", optionSettings[Constants.ElasticBeanstalk.XRayTracingOptionId]);
         }
 
-        [Fact]
-        public async Task GetPreviousSettings_BeanstalkWindowsEnvironment()
+        [Theory]
+
+        [InlineData(@"{
+              ""manifestVersion"": 1,
+              ""deployments"": {
+                ""aspNetCoreWeb"": [
+                  {
+                    ""name"": ""app"",
+                    ""parameters"": {
+                      ""iisPath"": ""/path"",
+                      ""iisWebSite"": ""Default Web Site Custom""
+                    }
+                  }
+                ]
+              }
+            }")]
+        [InlineData(@"{
+              ""manifestVersion"": 1,
+              // comments
+              ""deployments"": {
+                ""aspNetCoreWeb"": [
+                  {
+                    ""name"": ""app"",
+                    ""parameters"": {
+                      ""iisPath"": ""/path"",
+                      ""iisWebSite"": ""Default Web Site Custom""
+                    }
+                  }
+                ]
+              }
+            }")]
+        public async Task GetPreviousSettings_BeanstalkWindowsEnvironment(string manifestJson)
         {
             var application = new CloudApplication("name", "Id", CloudApplicationResourceType.BeanstalkEnvironment, "recipe");
             var configurationSettings = new List<ConfigurationOptionSetting>
@@ -507,20 +537,6 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 _mockOrchestratorInteractiveService.Object,
                 _fileManager);
 
-            var manifestJson = @"{
-              ""manifestVersion"": 1,
-              ""deployments"": {
-                ""aspNetCoreWeb"": [
-                  {
-                    ""name"": ""app"",
-                    ""parameters"": {
-                      ""iisPath"": ""/path"",
-                      ""iisWebSite"": ""Default Web Site Custom""
-                    }
-                  }
-                ]
-              }
-            }";
             _fileManager.InMemoryStore.Add(Path.Combine("testPath", "aws-windows-deployment-manifest.json"), manifestJson);
             var projectDefinition = new ProjectDefinition(null, Path.Combine("testPath", "project.csproj"), "", "net6.0");
             var recipeDefinitiion = new RecipeDefinition("AspNetAppExistingBeanstalkWindowsEnvironment", "", "", DeploymentTypes.BeanstalkEnvironment, DeploymentBundleTypes.DotnetPublishZipFile, "", "", "", "", "");


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6340

*Description of changes:*
* Added JSON Options to the System.Text.Json deserializer to skip reading comments instead of failing serialization.
* Added exception handling over the deseerialization block to provide user friendly error messages if serialization exceptions happen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
