### PR TITLE
feat: Allow changing Elastic Beanstalk's platform version for environments

### DIFF
--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -434,7 +434,7 @@
             "TypeHint": "DotnetBeanstalkPlatformArn",
             "DefaultValue": "{LatestDotnetBeanstalkPlatformArn}",
             "AdvancedSetting": true,
-            "Updatable": false,
+            "Updatable": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -423,7 +423,7 @@
             "TypeHint": "DotnetWindowsBeanstalkPlatformArn",
             "DefaultValue": "{LatestDotnetWindowsBeanstalkPlatformArn}",
             "AdvancedSetting": true,
-            "Updatable": false,
+            "Updatable": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",


### PR DESCRIPTION
*Description of changes:*
To allow users to migrate to newer Beanstalk platform versions the setting has been changed to be updatable for redeployments. I have confirm CloudFormation supports changing platform version via this change through the tooling for both single and load balanced environments. It will trigger a replacement of the EC2 instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
