### PR TITLE
feat: Add support for deploying .NET 7 applications to Elastic Beanstalk

### DIFF
--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -36,5 +36,7 @@ namespace AWS.Deploy.Constants
         /// Id for the 'dotnet build --self-contained' recipe option
         /// </summary>
         public const string DotnetPublishSelfContainedBuildOptionId = "SelfContainedBuild";
+
+        public const string TARGET_SERVICE_ELASTIC_BEANSTALK = "AWS Elastic Beanstalk";
     }
 }

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -13,6 +13,7 @@ using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Utilities;
+using AWS.Deploy.Constants;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
 
@@ -102,6 +103,13 @@ namespace AWS.Deploy.Orchestration
         {
             _interactiveService.LogInfoMessage(string.Empty);
             _interactiveService.LogInfoMessage("Creating Dotnet Publish Zip file...");
+
+            // Since Beanstalk doesn't currently have .NET 7 preinstalled we need to make sure we are doing a self contained publish when creating the deployment bundle.
+            if (recommendation.Recipe.TargetService == RecipeIdentifier.TARGET_SERVICE_ELASTIC_BEANSTALK && recommendation.ProjectDefinition.TargetFramework == "net7.0")
+            {
+                _interactiveService.LogInfoMessage("Using self contained publish since AWS Elastic Beanstalk does not currently have .NET 7 preinstalled");
+                recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
+            }
 
             var publishDirectoryInfo = _directoryManager.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var additionalArguments = recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments;

--- a/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentCommands/BeanstalkEnvironmentDeploymentCommand.cs
@@ -44,6 +44,10 @@ namespace AWS.Deploy.Orchestration.DeploymentCommands
             {
                 elasticBeanstalkHandler.SetupWindowsDeploymentManifest(recommendation, deploymentPackage);
             }
+            else if (recommendation.Recipe.Id.Equals(Constants.RecipeIdentifier.EXISTING_BEANSTALK_ENVIRONMENT_RECIPE_ID))
+            {
+                elasticBeanstalkHandler.SetupProcfileForSelfContained(deploymentPackage);
+            }
 
             var versionLabel = $"v-{DateTime.Now.Ticks}";
             var s3location = await elasticBeanstalkHandler.CreateApplicationStorageLocationAsync(applicationName, versionLabel, deploymentPackage);

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -25,7 +25,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
@@ -25,7 +25,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
                     }
                 }
             ],

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/CLITests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/CLITests.cs
@@ -40,5 +40,26 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
             var expectedVersionLabel = successMessage.Split(" ").Last();
             Assert.True(await _fixture.EBHelper.VerifyEnvironmentVersionLabel(_fixture.EnvironmentName, expectedVersionLabel));
         }
+
+        [Fact]
+        public async Task DeployToExistingBeanstalkEnvironmentSelfContained()
+        {
+            var projectPath = _fixture.TestAppManager.GetProjectPath(Path.Combine("testapps", "WebAppNoDockerFile", "WebAppNoDockerFile.csproj"));
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _fixture.EnvironmentName, "--diagnostics", "--silent", "--region", "us-west-2", "--apply", "Existing-ElasticBeanStalkConfigFile-Linux-SelfContained.json" };
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _fixture.App.Run(deployArgs));
+
+            var environmentDescription = await _fixture.AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(_fixture.EnvironmentName);
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _fixture.HttpHelper.WaitUntilSuccessStatusCode(environmentDescription.CNAME, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            var successMessagePrefix = $"The Elastic Beanstalk Environment {_fixture.EnvironmentName} has been successfully updated";
+            var deployStdOutput = _fixture.InteractiveService.StdOutReader.ReadAllLines();
+            var successMessage = deployStdOutput.First(line => line.Trim().StartsWith(successMessagePrefix));
+            Assert.False(string.IsNullOrEmpty(successMessage));
+
+            var expectedVersionLabel = successMessage.Split(" ").Last();
+            Assert.True(await _fixture.EBHelper.VerifyEnvironmentVersionLabel(_fixture.EnvironmentName, expectedVersionLabel));
+        }
     }
 }

--- a/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile-Linux-SelfContained.json
+++ b/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile-Linux-SelfContained.json
@@ -1,0 +1,6 @@
+{
+    "RecipeId": "AspNetAppElasticBeanstalkLinux",
+    "Settings": {
+        "SelfContainedBuild": true
+    }
+}

--- a/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile-Linux.json
+++ b/testapps/WebAppNoDockerFile/ElasticBeanStalkConfigFile-Linux.json
@@ -1,0 +1,6 @@
+{
+    "RecipeId": "AspNetAppElasticBeanstalkLinux",
+    "Settings": {
+
+    }
+}

--- a/testapps/WebAppNoDockerFile/Existing-ElasticBeanStalkConfigFile-Linux-SelfContained.json
+++ b/testapps/WebAppNoDockerFile/Existing-ElasticBeanStalkConfigFile-Linux-SelfContained.json
@@ -1,0 +1,6 @@
+{
+    "RecipeId": "AspNetAppExistingBeanstalkEnvironment",
+    "Settings": {
+        "SelfContainedBuild": true
+    }
+}

--- a/testapps/WebAppNoDockerFile/WebAppNoDockerFile.csproj
+++ b/testapps/WebAppNoDockerFile/WebAppNoDockerFile.csproj
@@ -5,6 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Update="Existing-ElasticBeanStalkConfigFile-Linux-SelfContained.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="ElasticBeanStalkConfigFile-Linux.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="ElasticBeanStalkConfigFile-Linux-SelfContained.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Update="ElasticBeanStalkConfigFile.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
*Description of changes:*
Added support for deploying ASP.NET Core applications that target .NET 7 to Elastic Beanstalk. Since Beanstalk doesn't currently have .NET 7 preinstalled the deployment bundle handler checks to see if the target service is beanstalk and if targeting .NET 7. If that is true then override the self contained setting to be true.

While making this change I discovered that self contained publishes were not working to Elastic Beanstalk because we need to generate a [Procfile](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/dotnet-linux-procfile.html) that tells the Beanstalk environment what process to start. The legacy wizard would generate this file. I updated the CDK project for Linux to generate the `Procfile` as well as the deploy to existing environments handler to generate the `Procfile`. Unfortunately the code can not be shared between these 2 parts due new environments being run within the scope of the CDK project and existing environments being run inside this tools orchestrator.

For testing I reworked the Beanstalk integ by replacing the old integ test that relied on manipulating stdin by generalizing the `WindowsEBDefaultConfigurations` integ test into a generic beanstalk integ test that supported both windows and linux config files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
