### PR TITLE
feat: Switch to use the --password-stdin switch when logging into docker

### DIFF
--- a/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
+++ b/src/AWS.Deploy.CLI/Utilities/CommandLineWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -42,6 +43,7 @@ namespace AWS.Deploy.CLI.Utilities
             bool streamOutputToInteractiveService = true,
             Action<TryRunResult>? onComplete = null,
             bool redirectIO = true,
+            string? stdin = null,
             IDictionary<string, string>? environmentVariables = null,
             CancellationToken cancelToken = default,
             bool needAwsCredentials = false)
@@ -58,7 +60,7 @@ namespace AWS.Deploy.CLI.Utilities
                         ? $"/c {command}"
                         : $"-c \"{command}\"",
 
-                RedirectStandardInput = redirectIO,
+                RedirectStandardInput = redirectIO || stdin != null,
                 RedirectStandardOutput = redirectIO,
                 RedirectStandardError = redirectIO,
                 UseShellExecute = false,
@@ -106,6 +108,12 @@ namespace AWS.Deploy.CLI.Utilities
                 };
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
+            }
+
+            if(stdin != null)
+            {
+                process.StandardInput.Write(stdin);
+                process.StandardInput.Close();
             }
 
             // poll for process to prevent blocking the main thread

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -210,8 +210,8 @@ namespace AWS.Deploy.Orchestration
             var authToken = Encoding.UTF8.GetString(authTokenBytes);
             var decodedTokens = authToken.Split(':');
 
-            var dockerLoginCommand = $"docker login --username {decodedTokens[0]} --password {decodedTokens[1]} {authorizationTokens[0].ProxyEndpoint}";
-            var result = await _commandLineWrapper.TryRunWithResult(dockerLoginCommand, streamOutputToInteractiveService: true);
+            var dockerLoginCommand = $"docker login --username {decodedTokens[0]} --password-stdin {authorizationTokens[0].ProxyEndpoint}";
+            var result = await _commandLineWrapper.TryRunWithResult(dockerLoginCommand, streamOutputToInteractiveService: true, stdin: decodedTokens[1]);
 
             if (result.ExitCode != 0)
             {

--- a/src/AWS.Deploy.Orchestration/Utilities/ICommandLineWrapper.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/ICommandLineWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -50,6 +51,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             bool streamOutputToInteractiveService = true,
             Action<TryRunResult>? onComplete = null,
             bool redirectIO = true,
+            string? stdin = null,
             IDictionary<string, string>? environmentVariables = null,
             CancellationToken cancelToken = default,
             bool needAwsCredentials = false);
@@ -86,6 +88,9 @@ namespace AWS.Deploy.Orchestration.Utilities
         /// By default, <see cref="Process.StandardInput"/>, <see cref="Process.StandardOutput"/> and <see cref="Process.StandardError"/> will be redirected.
         /// Set this to false to avoid redirection.
         /// </param>
+        /// <param name="stdin">
+        /// Text to pass into the process through standard input.
+        /// </param>
         /// <param name="environmentVariables">
         /// <see cref="command"/> is executed as a child process of running process which inherits the parent process's environment variables.
         /// <see cref="environmentVariables"/> allows to add (replace if exists) extra environment variables to the child process.
@@ -103,6 +108,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             string workingDirectory = "",
             bool streamOutputToInteractiveService = false,
             bool redirectIO = true,
+            string? stdin = null,
             IDictionary<string, string>? environmentVariables = null,
             CancellationToken cancelToken = default,
             bool needAwsCredentials = false)
@@ -115,6 +121,7 @@ namespace AWS.Deploy.Orchestration.Utilities
                 streamOutputToInteractiveService,
                 onComplete: runResult => result = runResult,
                 redirectIO: redirectIO,
+                stdin: stdin,
                 environmentVariables: environmentVariables,
                 cancelToken: cancelToken,
                 needAwsCredentials: needAwsCredentials);

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolCommandLineWrapper.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolCommandLineWrapper.cs
@@ -41,6 +41,11 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public bool RedirectIO { get; set; }
 
         /// <summary>
+        /// Specifies the input that should be piped into standard input for the process.
+        /// </summary>
+        public string Stdin { get; set; }
+
+        /// <summary>
         /// The cancellation token for the async task.
         /// </summary>
         public CancellationToken CancelToken { get; set; }
@@ -56,6 +61,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             bool streamOutputToInteractiveService = true,
             Action<TryRunResult> onComplete = null,
             bool redirectIO = true,
+            string stdin = null,
             IDictionary<string, string> environmentVariables = null,
             CancellationToken cancelToken = default,
             bool needAwsCredentials = false)
@@ -67,6 +73,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
                 StreamOutputToInteractiveService = streamOutputToInteractiveService,
                 OnCompleteAction = onComplete,
                 RedirectIO = redirectIO,
+                Stdin = stdin,
                 CancelToken = cancelToken
             });
 

--- a/test/AWS.Deploy.Orchestration.UnitTests/TestCommandLineWrapper.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/TestCommandLineWrapper.cs
@@ -22,6 +22,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
             bool streamOutputToInteractiveService = true,
             Action<TryRunResult> onComplete = null,
             bool redirectIO = true,
+            string stdin = null,
             IDictionary<string, string> environmentVariables = null,
             CancellationToken cancelToken = default,
             bool needAwsCredentials = false)


### PR DESCRIPTION
*Description of changes:*
When the deploy tool shells out to the docker CLI use the `--password-stdin` switch instead of `--password`. This removes the following warning messages when pushing container images to ECR.

```
Pushing the docker image to ECR repository...
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
