### PR TITLE
docs: Update credentials documentation to discuss assuming CDK deployment roles, and document the --output parameter on the deployment-project command.

### DIFF
--- a/site/content/docs/commands/project.md
+++ b/site/content/docs/commands/project.md
@@ -1,20 +1,26 @@
 # deployment-project generate command
 
 ### Usage
-    dotnet aws deployment-project - Generates and saves the deployment CDK project in the user provided location.
+
+`dotnet aws deployment-project` - Generates and saves the deployment CDK project in the user provided location.
 
 ### Synopsis
-    dotnet aws deployment-project generate [-d|--diagnostics] [-s|--silent] [--profile <PROFILE>] [--region <REGION>] [--project-path <PROJECT-PATH>] [--project-display-name <DISPLAY-NAME>]
+
+```
+dotnet aws deployment-project generate [-o|--output <OUTPUT-PATH>] [-d|--diagnostics] [--project-path <PROJECT-PATH>] [--project-display-name <DISPLAY-NAME>]
+```
 
 ### Description
-Generates and saves the [deployment CDK project](../deployment-projects/index.md) in a user provided directory path without proceeding with a deployment. Allows user to customize the CDK project before deploying the application.
+Generates and saves the [deployment CDK project](../deployment-projects/index.md) in a user-provided directory without proceeding with a deployment. This allows the user to customize the CDK project before deploying the application.
 
-* The `--output` switch sets the directory where the deployment project will be saved.
-* The `--project-display-name` switch sets the name that will be shown when the .NET project is being deployed.
+* The `--output` switch sets the directory where the CDK deployment project will be saved.
+* The `--project-path` switch sets the path to the project to generate a deployment project for.
+* The `--project-display-name` switch sets the name of the deployment project that will be displayed in the list of available deployment options.
 
 ### Examples
 
-This example creates a deployment project from the .NET project in the current directory. The  deployment project will be saved to a sibling directory called CustomDeploymentProject. The name _"Team custom deployment project"_ will be displayed in the list of the available deployment options.
+This example creates a deployment project from the .NET project in the current directory. The deployment project will be saved to a sibling directory called CustomDeploymentProject. The name _"Team custom deployment project"_ will be displayed in the list of the available deployment options.
 
-    dotnet aws deployment-project generate --output ../CustomDeploymentProject --project-display-name "Team custom deployment project"
-
+```
+dotnet aws deployment-project generate --output ../CustomDeploymentProject --project-display-name "Team custom deployment project"
+```

--- a/site/content/docs/getting-started/setup-creds.md
+++ b/site/content/docs/getting-started/setup-creds.md
@@ -1,10 +1,28 @@
 # Setting up credentials
 
-AWS.Deploy.Tools, internally uses a variety of different tools and services to host your .NET application on AWS. To run the AWS Deploy Tool, you must configure a credential profile that provides access to the AWS account you wish to deploy to. Your credentials must have permissions for certain services, depending on the tasks that you're trying to perform.
+The AWS Deploy Tool for .NET internally uses a variety of different tools and services to host your .NET application on AWS. To run the AWS Deploy Tool, you must configure a credential profile that provides access to the AWS account you wish to deploy to. Your credentials must have permissions for certain services, depending on the tasks that you're trying to perform.
 
 ### Recommended policies
 
-The following are some examples of the typical permissions that are required.
+The AWS Deploy Tool for .NET uses [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/v2/guide/home.html) to create the AWS infrastructure needed to deploy your application. Deploying via AWS CDK will assume roles that were created when [bootstrapping](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html) CDK for the account and region you are deploying into. Ensure that the profile you are deploying with has permission to assume the CDK deployment roles. This can be done with a policy such as:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/cdk-*"
+            ]
+        }
+    ]
+}
+```
+
+In addition to permission to assume the CDK deployment roles, the following are examples of using [AWS managed policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#aws-managed-policies) to provide additional permissions that are required for different commands.
 
   > *Note: Additional permissions might be required, depending on the type of application you're deploying and the services it uses.*
 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6524, DOTNET-6525

*Description of changes:* Updates the documentation site in two places:
1. We were missing the `--output` parameter on the `dotnet aws deployment-project generate` page
     * We also had some parameters that don't exist for that command listed, removed them.
3. When deploying with CDK V2, the deployment process assumes roles that were created by the CDK bootstrap. Our permissions page lists managed policies that help the user get through service calls we make during defaulting, type hints, validation, but didn't mention the need to assume roles during deployment.

     STS doesn't appear to provide managed policies, so I added an example of an inline or custom policy that will accomplish this.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
