### PR TITLE
Validate security groups belong to the selected VPC for the ECS Fargate recipes

### DIFF
--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/SecurityGroupsInVpcValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/SecurityGroupsInVpcValidator.cs
@@ -16,7 +16,17 @@ namespace AWS.Deploy.Common.Recipes.Validation
     public class SecurityGroupsInVpcValidator : IOptionSettingItemValidator
     {
         private static readonly string defaultValidationFailedMessage = "The selected security groups are not part of the selected VPC.";
+
+        /// <summary>
+        /// Path to the OptionSetting that stores a selected Vpc Id
+        /// </summary>
         public string VpcId { get; set; } = "";
+
+        /// <summary>
+        /// Path to the OptionSetting that determines if the default VPC should be used
+        /// </summary>
+        public string IsDefaultVpcOptionSettingId { get; set; } = "";
+
         public string ValidationFailedMessage { get; set; } = defaultValidationFailedMessage;
 
         private readonly IAWSResourceQueryer _awsResourceQueryer;
@@ -32,18 +42,77 @@ namespace AWS.Deploy.Common.Recipes.Validation
         {
             if (string.IsNullOrEmpty(VpcId))
                 return ValidationResult.Failed($"The '{nameof(SecurityGroupsInVpcValidator)}' validator is missing the '{nameof(VpcId)}' configuration.");
-            var vpcIdSetting = _optionSettingHandler.GetOptionSetting(recommendation, VpcId);
-            var vpcId = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, vpcIdSetting);
+
+            var vpcId = "";
+
+            // The ECS Fargate recipes expose a separate radio button to select the default VPC which is mutually exclusive
+            // with specifying an explicit VPC Id. Because we give preference to "UseDefault" in the CDK project,
+            // we should do so here as well and validate the security groups against the default VPC if it's selected.
+            if (!string.IsNullOrEmpty(IsDefaultVpcOptionSettingId))
+            {
+                var isDefaultVpcOptionSetting = _optionSettingHandler.GetOptionSetting(recommendation, IsDefaultVpcOptionSettingId);
+                var shouldUseDefaultVpc = _optionSettingHandler.GetOptionSettingValue<bool>(recommendation, isDefaultVpcOptionSetting);
+
+                if (shouldUseDefaultVpc)
+                {
+                    vpcId = (await _awsResourceQueryer.GetDefaultVpc()).VpcId;
+                }
+            }
+
+            // If the "Use default?" option doesn't exist in the recipe, or it does and was false, or
+            // we failed to look up the default VPC, then use the explicity VPC Id
+            if (string.IsNullOrEmpty(vpcId))
+            {
+                var vpcIdSetting = _optionSettingHandler.GetOptionSetting(recommendation, VpcId);
+                vpcId = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, vpcIdSetting);
+            }
+
             if (string.IsNullOrEmpty(vpcId))
                 return ValidationResult.Failed("The VpcId setting is not set or is empty. Make sure to set the VPC Id first.");
 
             var securityGroupIds = (await _awsResourceQueryer.DescribeSecurityGroups(vpcId)).Select(x => x.GroupId);
+
+            // The ASP.NET Fargate recipe uses a list of security groups
             if (input?.TryDeserialize<SortedSet<string>>(out var inputList) ?? false)
             {
+                var invalidSecurityGroups = new List<string>();
                 foreach (var securityGroup in inputList!)
                 {
                     if (!securityGroupIds.Contains(securityGroup))
-                        return ValidationResult.Failed("The selected security group(s) are invalid since they do not belong to the currently selected VPC.");
+                        invalidSecurityGroups.Add(securityGroup);
+                }
+
+                if (invalidSecurityGroups.Any())
+                {
+                    return ValidationResult.Failed($"The selected security group(s) ({string.Join(", ", invalidSecurityGroups)}) " +
+                        $"are invalid since they do not belong to the currently selected VPC {vpcId}.");
+                }
+
+                return ValidationResult.Valid();
+            }
+
+            // The Console ECS Fargate Service recipe uses a comma-separated string, which will fall through the TryDeserialize above
+            if (input is string)
+            {
+                // Security groups aren't required
+                if (string.IsNullOrEmpty(input.ToString()))
+                {
+                    return ValidationResult.Valid();
+                }
+
+                var securityGroupList = input.ToString()?.Split(',') ?? new string[0];
+                var invalidSecurityGroups = new List<string>();
+
+                foreach (var securityGroup in securityGroupList)
+                {
+                    if (!securityGroupIds.Contains(securityGroup))
+                        invalidSecurityGroups.Add(securityGroup);
+                }
+
+                if (invalidSecurityGroups.Any())
+                {
+                    return ValidationResult.Failed($"The selected security group(s) ({string.Join(", ", invalidSecurityGroups)}) " +
+                        $"are invalid since they do not belong to the currently selected VPC {vpcId}.");
                 }
 
                 return ValidationResult.Valid();

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -382,6 +382,13 @@
                         "AllowEmptyString": true,
                         "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
                     }
+                },
+                {
+                    "ValidatorType": "SecurityGroupsInVpc",
+                    "Configuration": {
+                        "VpcId": "Vpc.VpcId",
+                        "IsDefaultVpcOptionSettingId": "Vpc.IsDefault"
+                    }
                 }
             ]
         },

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -422,7 +422,16 @@
             "Type": "String",
             "DefaultValue": "",
             "AdvancedSetting": true,
-            "Updatable": true
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "SecurityGroupsInVpc",
+                    "Configuration": {
+                        "VpcId": "Vpc.VpcId",
+                        "IsDefaultVpcOptionSettingId": "Vpc.IsDefault"
+                    }
+                }
+            ]
         },
         {
             "Id": "TaskCpu",


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6329

*Description of changes:* This applies the existing `SecurityGroupsInVpcValidator` validator to the security groups option in the ASP.NET and console service ECS Fargate recipes. 

Previously it was possible to select security groups that don't match the selected VPC, then the CloudFormation deployment would fail.
```
Stack Deployments Failed: Error: The stack named FargateExtraSecurityGroups failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: Resource handler returned message: "Invalid request provided: CreateService error: Security group sg-<redacted> does not appear to belong to the same VPC as the input subnets.
```

Caveats:
* We don't have a security groups option in the ECS Fargate scheduled task recipe currently
* Because the console service recipe is still collecting security groups as a comma-separated string instead of a `List`, I expanded the validator to handle that input as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
