### PR TITLE
Address semgrep issues around Path.Combine and build warnings

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,1 +1,2 @@
 testapps/
+test/

--- a/src/AWS.Deploy.DockerEngine/DockerFile.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerFile.cs
@@ -79,6 +79,9 @@ namespace AWS.Deploy.DockerEngine
                 .Replace("{project-name}", _projectName)
                 .Replace("{assembly-name}", _assemblyName);
 
+            // ProjectDefinitionParser will have transformed projectDirectory to an absolute path, 
+            // and DockerFileName is static so traversal should not be possible here.
+            // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
             File.WriteAllText(Path.Combine(projectDirectory, DockerFileName), dockerFile);
         }
     }

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -449,6 +449,8 @@ namespace AWS.Deploy.Orchestration.Data
             var response = await HandleException(async () => await ec2Client.CreateKeyPairAsync(request),
             "Error attempting to create EC2 key pair");
 
+            // We're creating the key pair at a user-defined location, and want to support relative paths
+            // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
             await File.WriteAllTextAsync(Path.Combine(saveLocation, $"{keyName}.pem"), response.KeyPair.KeyMaterial);
 
             return response.KeyPair.KeyName;

--- a/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -33,8 +33,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Should-DotNetStandard" Version="1.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/MockPaginatedEnumerable.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/MockPaginatedEnumerable.cs
@@ -20,10 +20,10 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
-            return new MockAsyncEnumerator<T>(_data);
+            return new MockAsyncEnumerator(_data);
         }
 
-        class MockAsyncEnumerator<T> : IAsyncEnumerator<T>
+        class MockAsyncEnumerator : IAsyncEnumerator<T>
         {
             readonly T[] _data;
             int _position;


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6361

*Description of changes:* Addresses warnings from both semgrep and the .NET build.
* For the `Path.Combine` - they were either cases where we want to support relative paths, or else after reviewing code appear to be a false-positive.
* Commit message is intentionally not following conventional commits to avoid a changelog entry as there are no user-facing changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
