### PR TITLE
ci: enable CodeBuild PR checks to run on multiple AWS accounts

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -16,14 +16,31 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Setup .NET Core 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Invoke Load Balancer Lambda
+        id: lambda
+        shell: pwsh
+        run: |
+          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{\"Roles\": \"${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}\", \"ProjectName\": \"${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}\", \"Branch\": \"${{ github.sha }}\"}'
+          $roleArn=$(cat ./response.json)
+          "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
+      - name: Configure Test Runner Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200
           aws-region: us-west-2
       - name: Run CodeBuild
         id: codebuild
         uses: aws-actions/aws-codebuild-run-build@v1.0.3
         with:
-          project-name: ${{ secrets.CI_AWS_CODE_BUILD_PROJECT_NAME }}
+          project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
       - name: CodeBuild Link
         shell: pwsh
         run: |

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI.sln
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.Tools.CI", "AWS.Deploy.Tools.CI\AWS.Deploy.Tools.CI.csproj", "{81F4E63D-681F-4796-8CDC-809CA16303A7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{81F4E63D-681F-4796-8CDC-809CA16303A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81F4E63D-681F-4796-8CDC-809CA16303A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81F4E63D-681F-4796-8CDC-809CA16303A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81F4E63D-681F-4796-8CDC-809CA16303A7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4B5BB5B3-122F-48AE-BE94-24B95898AC99}
+	EndGlobalSection
+EndGlobal

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI.csproj
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improvement cold starts. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="0.10.0-preview" />
+    <PackageReference Include="AWSSDK.CodeBuild" Version="3.7.100.48" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.48" />
+  </ItemGroup>
+</Project>

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/CodeBuildFunctions.cs
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/CodeBuildFunctions.cs
@@ -1,0 +1,130 @@
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Amazon.CodeBuild;
+using Amazon.CodeBuild.Model;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.Annotations;
+using Amazon.Lambda.Annotations.APIGateway;
+using AWS.Deploy.Tools.CI.Models;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace AWS.Deploy.Tools.CI;
+
+/// <summary>
+/// Lambda functions that will interact with CodeBuild as part of the AWS.Deploy.Tools CI/CD pipeline.
+/// </summary>
+public class CodeBuildFunctions
+{
+    private readonly IAmazonSecurityTokenService _githubSTSClient;
+
+    public CodeBuildFunctions(IAmazonSecurityTokenService githubSTSClient)
+    {
+        _githubSTSClient = githubSTSClient;
+    }
+
+    /// <summary>
+    /// The <see cref="GetAvailableTestRunner"/> function is responsible for checking available test runner accounts to run the AWS.Deploy.Tools CodeBuild PR check.
+    /// A list of IAM roles, representing the test runner accounts, is passed to the function. 
+    /// These roles are assumed and used to check if the CodeBuild CI project in the test runner account is currently running any jobs.
+    /// </summary>
+    /// <returns>The function will return the IAM role of the account that is not running any CodeBuild CI jobs.</returns>
+    /// <exception cref="ArgumentNullException">If the input passed to the function is invalid.</exception>
+    /// <exception cref="Exception">If no test runner account is available.</exception>
+    /// <exception cref="Exception">If a CodeBuild CI project is not found in the test runner account.</exception>
+    [LambdaFunction(Name = "GetAvailableTestRunner", Policies = "@AWSDeployToolsCIGetAvailableTestRunnerLambdaAssumeRolePolicy")]
+    public async Task<string> GetAvailableTestRunner(GetAvailableTestRunnerInput input)
+    {
+        if (string.IsNullOrEmpty(input.Roles))
+        {
+            throw new ArgumentNullException(nameof(input.Roles));
+        }
+        if (string.IsNullOrEmpty(input.ProjectName))
+        {
+            throw new ArgumentNullException(nameof(input.ProjectName));
+        }
+        if (string.IsNullOrEmpty(input.Branch))
+        {
+            throw new ArgumentNullException(nameof(input.Branch));
+        }
+
+        var roles = input.Roles.Split(",").Select(x => x.Trim()).ToList();
+
+        if (!roles.Any())
+        {
+            throw new ArgumentNullException(nameof(input.Roles));
+        }
+
+        foreach (var role in roles)
+        {
+            var assumeRoleResponse =
+                await _githubSTSClient.AssumeRoleAsync(
+                    new AssumeRoleRequest
+                    {
+                        RoleArn = role,
+                        RoleSessionName = "DeployToolTestRunner"
+                    }
+                );
+
+            using var testRunnerSTSClient = new AmazonSecurityTokenServiceClient(assumeRoleResponse.Credentials);
+            var callerIdentity = await testRunnerSTSClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
+
+            using var codeBuildClient = new AmazonCodeBuildClient(assumeRoleResponse.Credentials);
+
+            var batchGetProjectsResponse =
+                await codeBuildClient.BatchGetProjectsAsync(
+                    new BatchGetProjectsRequest
+                    {
+                        Names = new List<string> { input.ProjectName }
+                    }
+                );
+
+            if (!batchGetProjectsResponse.Projects.Any())
+            {
+                throw new Exception($"Could not find any project with the name '{input.ProjectName}' in account '{callerIdentity.Account}'.");
+            }
+
+            var project = batchGetProjectsResponse.Projects.First();
+
+            var listBuildsForProjectResponse =
+                await codeBuildClient.ListBuildsForProjectAsync(
+                    new ListBuildsForProjectRequest
+                    {
+                        ProjectName = project.Name
+                    }
+                );
+
+            var runningBuilds = 0;
+            if (listBuildsForProjectResponse.Ids.Any())
+            {
+                var latestBuilds = listBuildsForProjectResponse.Ids.Take(20).ToList();
+                var detailedBuilds =
+                    await codeBuildClient.BatchGetBuildsAsync(
+                        new BatchGetBuildsRequest
+                        {
+                            Ids = latestBuilds
+                        }
+                    );
+
+                foreach (var detailedBuild in detailedBuilds.Builds)
+                {
+                    if (detailedBuild.BuildComplete == false)
+                    {
+                        runningBuilds++;
+                    }
+                }
+            }
+
+            if (runningBuilds < project.ConcurrentBuildLimit)
+            {
+                return role;
+            }
+            else
+            {
+                continue;
+            }
+        }
+
+        throw new Exception("There are no available Test Runner accounts.");
+    }
+}

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/Models/GetAvailableTestRunnerInput.cs
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/Models/GetAvailableTestRunnerInput.cs
@@ -1,0 +1,31 @@
+﻿namespace AWS.Deploy.Tools.CI.Models;
+
+/// <summary>
+/// Input to the Lambda function <see cref="CodeBuildFunctions.GetAvailableTestRunner"/>
+/// </summary>
+public class GetAvailableTestRunnerInput
+{
+    /// <summary>
+    /// Comma-separated list of IAM roles in the test runner accounts that have a trust relationship 
+    /// with the AWS account that will be hosting the Lambda function <see cref="CodeBuildFunctions.GetAvailableTestRunner"/>
+    /// These roles will be used to invoke a CodeBuild job hosted in the test runner accounts.
+    /// </summary>
+    public string Roles { get; set; }
+    
+    /// <summary>
+    /// The CodeBuild project name that will be invoked in the test runner account.
+    /// </summary>
+    public string ProjectName { get; set; }
+
+    /// <summary>
+    /// The GitHub branch/commit-id that will be passed to the CodeBuild project.
+    /// </summary>
+    public string Branch { get; set; }
+
+    public GetAvailableTestRunnerInput(string roles, string projectName, string branch)
+    {
+        Roles = roles;
+        ProjectName = projectName;
+        Branch = branch;
+    }
+}

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/Startup.cs
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/Startup.cs
@@ -1,0 +1,23 @@
+using Amazon.Lambda.Annotations;
+using Amazon.SecurityToken;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AWS.Deploy.Tools.CI
+{
+    [LambdaStartup]
+    public class Startup
+    {
+        /// <summary>
+        /// Services for Lambda functions can be registered in the services dependency injection container in this method. 
+        ///
+        /// The services can be injected into the Lambda function through the containing type's constructor or as a
+        /// parameter in the Lambda function using the FromService attribute. Services injected for the constructor have
+        /// the lifetime of the Lambda compute container. Services injected as parameters are created within the scope
+        /// of the function invocation.
+        /// </summary>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddAWSService<IAmazonSecurityTokenService>();
+        }
+    }
+}

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/aws-lambda-tools-defaults.json
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/aws-lambda-tools-defaults.json
@@ -1,0 +1,5 @@
+{
+    "template" : "serverless.template",
+    "stack-name" : "AWS-Deploy-Tools-CI",
+    "template-parameters" : "\"GitHubOrg\"=\"aws\";\"GitHubRepositoryName\"=\"aws-dotnet-deploy\""
+}

--- a/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/serverless.template
+++ b/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/serverless.template
@@ -1,0 +1,117 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.10.0.0).",
+  "Parameters": {
+    "GitHubOrg": {
+      "Type": "String",
+      "Default": "aws",
+      "Description": "The GitHub organization to use for the repository."
+    },
+    "GitHubRepositoryName": {
+      "Type": "String",
+      "Default": "aws-dotnet-deploy",
+      "Description": "The name of the GitHub repository to create the role template in and to use for the CodeBuild."
+    }
+  },
+  "Resources": {
+    "AWSDeployToolsCIGitHubTrustRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": "AWSDeployToolsCIGitHubTrustRole",
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": {
+                  "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
+                }
+              },
+              "Condition": {
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": {
+                    "Fn::Sub": "repo:${GitHubOrg}/${GitHubRepositoryName}:*"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "AWSDeployToolsCIGitHubTrustRolePolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "GetAvailableTestRunner",
+                        "Arn"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Action": [
+                    "sts:AssumeRole"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "MaxSessionDuration": "7200"
+      }
+    },
+    "AWSDeployToolsCIGetAvailableTestRunnerLambdaAssumeRolePolicy": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "Description": "Policy created by AWS.Deploy.Tools.CI for Lambda Function",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "GetAvailableTestRunner": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "Tool": "Amazon.Lambda.Annotations"
+      },
+      "Properties": {
+        "Runtime": "dotnet6",
+        "CodeUri": ".",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          {
+            "Ref": "AWSDeployToolsCIGetAvailableTestRunnerLambdaAssumeRolePolicy"
+          }
+        ],
+        "PackageType": "Zip",
+        "Handler": "AWS.Deploy.Tools.CI::AWS.Deploy.Tools.CI.CodeBuildFunctions_GetAvailableTestRunner_Generated::GetAvailableTestRunner"
+      }
+    }
+  }
+}

--- a/buildtools/README.md
+++ b/buildtools/README.md
@@ -1,11 +1,52 @@
-# Setup
+# AWS.Deploy.Tools.CI
 
-1. Create CF template using `buildtools/ci.template`
-2. Copy output `CodeBuildProjectName` & `OidcRole` output variables.
-3. Create `CI_AWS_ROLE_ARN` repository secret with `OidcRole` value and
-   `CI_AWS_CODE_BUILD_PROJECT_NAME` repository secret with `CodeBuildProjectName`
-   value.
-4. Voila!
+The `AWS.Deploy.Tools.CI` project is used to setup the CI/CD PR check between the [AWS.Deploy.Tools](https://github.com/aws/aws-dotnet-deploy) GitHub Repo and the AWS CodeBuild project that will be executed by the GitHub workflow `AWS CodeBuild CI (codebuild-ci.yml)`.
+
+The workflow will be executed starting from `AWS CodeBuild CI (codebuild-ci.yml)` PR check, which will call a Lambda function in an `AWS Account` (which will act as a load balancer) which will ping 1 or many `Test Runner` accounts to check for availability.
+
+## Main Account (Load Balancer)
+
+We will start by deploying the `Lambda function` to the main testing account. Make sure you have AWS credentials with `Admin` access for the main testing account stored in your `credentials` file locally. 
+
+From the [_**AWS.Deploy.Tools.CI Project Directory**_](/buildtools/AWS.Deploy.Tools.CI/AWS.Deploy.Tools.CI/), run the following commands:
+```
+dotnet tool update -g Amazon.Lambda.Tools
+dotnet lambda deploy-serverless --profile <main-testing-account-admin-profile> --region <main-testing-account-region> --config-file aws-lambda-tools-defaults.json  --resolve-s3 true
+```
+
+The `Lambda Function` should now be deployed in the main testing account. Log into the account and take note of the `Lambda Function` name as it will be needed in a later step. Also, check the Resources tab of the created stack an take note of the IAM role `AWSDeployToolsCIGitHubTrustRole` ARN.
+
+## Test Runner Accounts
+
+You can setup 1 or multiple test runner accounts. These are new AWS Accounts other than the main account that containes the Lambda function. These accounts will run the `AWS CodeBuild Project` defined in [ci.template.yml](./ci.template.yml)
+
+The setup needs an OIDC Identity provider to be defined for the Test Runner account. If one exists, take note of the ARN. If not, go to [Identity providers](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-west-2#/identity_providers) and create one.
+Use the following config:
+* Provider: `token.actions.githubusercontent.com`
+* Audiences: `sts.amazonaws.com`
+* Generate Thumbprint
+
+To create the `AWS CodeBuild Project` in a test runner account
+1. Go to CloudFormation, create a Stack using [buildtools/ci.template](ci.template.yml)
+2. Use the following variables:
+    * Stack name: `aws-dotnet-deploy-ci`
+    * CodeBuildProjectName: `aws-dotnet-deploy-ci`
+    * GitHubOrg: `aws`
+    * GitHubRepositoryName: `aws-dotnet-deploy`
+    * MainAWSAccountId : *Main AWS Account ID that you deployed the Lambda function to*
+    * OIDCProviderArn: *ARN of the OIDC Identity Provider for the Test Runner account*
+    * TestRunnerTrustRoleName: `aws-dotnet-deploy-ci-role`
+2. Once the Stack is created, take note of CodeBuild Project name `aws-dotnet-deploy-ci` and the new `TestRunnerTrustRole` ARN that you can find in the Resources tab of the created stack.
+
+Repeat the above steps for every account that you want to use as a Test Runner.
+
+## GitHub Workflow
+
+In order for the GitHub workflow `AWS CodeBuild CI (codebuild-ci.yml)` to work properly, we need to set some GitHub secrets on the repo. Based on the names/ARNs you noted from previous steps, add the following secrets:
+* CI_TESTING_LOAD_BALANCER_LAMBDA_NAME: *From Main Account step, this is the name of the Lambda function*
+* CI_MAIN_TESTING_ACCOUNT_ROLE_ARN: *From Main Account step, this is the IAM role AWSDeployToolsCIGitHubTrustRole ARN*
+* CI_TESTING_CODE_BUILD_PROJECT_NAME: *From Test Runner Accounts step, this is `aws-dotnet-deploy-ci`*
+* CI_TEST_RUNNER_ACCOUNT_ROLES: This is a comma-delimited string of `TestRunnerTrustRole` ARNs from the Test Runner Accounts step
 
 # Troubleshooting
 

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -10,24 +10,12 @@ phases:
       - export PATH="$PATH:$HOME/.dotnet"
   pre_build:
     commands:
-      - export ORIGINAL_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-      - export ORIGINAL_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-      - export ORIGINAL_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
       - export DOTNET_CLI_TELEMETRY_OPTOUT=1
-      - eval $(aws sts assume-role --role-arn arn:aws:iam::610240510716:role/aws-dotnet-deploy-ci-test-runner --role-session-name test | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
 
   build:
     commands:
       - dotnet build AWS.Deploy.sln -c Release
       - dotnet test AWS.Deploy.sln -c Release --no-build --logger trx --results-directory ./testresults
-  post_build:
-    commands:
-      - export AWS_ACCESS_KEY_ID=${ORIGINAL_AWS_ACCESS_KEY_ID}
-      - export AWS_SECRET_ACCESS_KEY=${ORIGINAL_AWS_SECRET_ACCESS_KEY}
-      - export AWS_SESSION_TOKEN=${ORIGINAL_AWS_SESSION_TOKEN}
-      - unset ORIGINAL_AWS_ACCESS_KEY_ID
-      - unset ORIGINAL_AWS_SECRET_ACCESS_KEY
-      - unset ORIGINAL_AWS_SESSION_TOKEN
 reports:
     aws-dotnet-deploy-tests:
         file-format: VisualStudioTrx

--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -1,4 +1,8 @@
 Parameters:
+  MainAWSAccountId:
+    Type: String
+    Default: ""
+    Description: The Account ID of the Main account containing the Lambda function that will trigger the CI CodeBuild project.
   GitHubOrg:
     Type: String
     Default: "aws"
@@ -15,12 +19,8 @@ Parameters:
     Description: Name of the CodeBuild project.
     Default: "aws-dotnet-deploy-ci"
     Type: String
-  TestRunnerRoleArn:
-    Description: Role to assume when running tests.  This role must already exsit.  Role can be a different account.  Example arn:aws:iam:112233445566::role/awsdotnet-deploy-ci-test-runner
-    Default: ""
-    Type: String
-  OidcRoleRoleName:
-    Description: Name of the role to use for the OIDC provider.
+  TestRunnerTrustRoleName:
+    Description: Name of the role to allow GitHub to execute CodeBuild jobs.
     Default: "aws-dotnet-deploy-ci-role"
     Type: String
 
@@ -31,12 +31,17 @@ Conditions:
     - ""
 
 Resources:
-  OidcRole:
+  TestRunnerTrustRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Ref OidcRoleRoleName
+      RoleName: !Ref TestRunnerTrustRoleName
+      MaxSessionDuration: 7200
       AssumeRolePolicyDocument:
         Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${MainAWSAccountId}:root
+            Action: sts:AssumeRole
           - Effect: Allow
             Action: sts:AssumeRoleWithWebIdentity
             Principal:
@@ -56,6 +61,8 @@ Resources:
                 Action:
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
+                  - codebuild:BatchGetProjects
+                  - codebuild:ListBuildsForProject
                 Resource:
                   - !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildProjectName}
               - Effect: Allow
@@ -63,6 +70,11 @@ Resources:
                   - logs:GetLogEvents
                 Resource:
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}:*
+              - Effect: Allow
+                Action:
+                  - sts:GetCallerIdentity
+                Resource: 
+                  - '*'
 
   GithubOidc:
     Type: AWS::IAM::OIDCProvider
@@ -86,10 +98,6 @@ Resources:
         Type: LINUX_CONTAINER
         ImagePullCredentialsType: CODEBUILD
         Image: aws/codebuild/standard:5.0
-        EnvironmentVariables:
-        - Name: TEST_RUNNER_ROLE_ARN
-          Type: PLAINTEXT
-          Value: !Ref TestRunnerRoleArn
       Source:
         Type: GITHUB
         Location: !Sub https://github.com/${GitHubOrg}/${GitHubRepositoryName}
@@ -102,6 +110,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub ${CodeBuildProjectName}-codebuild-service-role
+      MaxSessionDuration: 7200
       AssumeRolePolicyDocument:
         Statement:
         - Action: ['sts:AssumeRole']
@@ -116,30 +125,13 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Action:
-                - 'logs:CreateLogGroup'
-                - 'logs:PutLogEvents'
-                - 'logs:CreateLogStream'
+                - '*'
                 Effect: Allow
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}"
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${CodeBuildProjectName}:*"
-              - Action:
-                - 'sts:AssumeRole'
-                Effect: Allow
-                Resource:
-                  - !Ref TestRunnerRoleArn
-              - Action:
-                - codebuild:BatchPutTestCases
-                - codebuild:CreateReport
-                - codebuild:CreateReportGroup
-                - codebuild:UpdateReport
-                - codebuild:UpdateReportGroup
-                Effect: Allow
-                Resource:
-                  - !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/*
+                  - '*'
 
 Outputs:
-  OidcRole:
-    Value: !GetAtt OidcRole.Arn
+  TestRunnerTrustRole:
+    Value: !GetAtt TestRunnerTrustRole.Arn
   CodeBuildProjectName:
     Value: !Sub ${CodeBuildProjectName}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6292

*Description of changes:*
* Created new project `AWS.Deploy.Tools.CI` which will deploy a Lambda function to our main testing account. This Lambda function will ping multiple test runner accounts (which we will define) to check for availability to run the CodeBuild testing project.
* Updated the CloudFormation template `ci.template.yml` to create needed roles without needing anything to be manually defined.
* Added step in GitHub workflow `codebuild-ci.yml` to call the Lambda function to retrieve the appropriate IAM Role to assume before kicking off the CodeBuild project from GitHub.

**Note**: The `AWS CodeBuild CI` PR check is expected to fail for this PR as I am modifying the workflow file to use a different infrastructure which does not yet exist. We need to release this change first for the GitHub workflow to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
