### PR TITLE
ci: doc generator step was failing to push if there are no changes

### DIFF
--- a/.github/workflows/doc-builder.yml
+++ b/.github/workflows/doc-builder.yml
@@ -40,7 +40,16 @@ jobs:
         run: |
           cd ./src/AWS.Deploy.DocGenerator
           dotnet run --project ./AWS.Deploy.DocGenerator.csproj
+      - name: Check For Git Untracked Changes
+        id: gitcheck
+        shell: pwsh
+        run: |
+          $newFiles=$(git ls-files --others --exclude-standard | wc -l)
+          $modifiedFiles=$(git diff --name-only | wc -l)
+          "newFiles=$newFiles" >> $env:GITHUB_OUTPUT
+          "modifiedFiles=$modifiedFiles" >> $env:GITHUB_OUTPUT
       - name: Commit and Push next version
+        if: steps.gitcheck.outputs.newFiles != 0 || steps.gitcheck.outputs.modifiedFiles != 0
         id: commit-push
         run: |
           git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"


### PR DESCRIPTION
*Description of changes:*
ci: doc generator step was failing to push if there are no changes
The Doc generator GitHub workflow failed if there are no doc changes in the release. This changes makes it so that the Workflow checks for changes first before proceeding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
