### PR TITLE
chore: remove dependency on existing IAM role for integ tests

### DIFF
--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixture.cs
@@ -122,7 +122,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests.E
 
             await EBHelper.CreateApplicationAsync(ApplicationName);
             await EBHelper.CreateApplicationVersionAsync(ApplicationName, VersionLabel, zipFilePath);
-            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, VersionLabel, BeanstalkPlatformType.Windows);
+            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, VersionLabel, BeanstalkPlatformType.Windows, RoleName);
             Assert.True(success);
 
             var environmentDescription = await AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
@@ -114,7 +114,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
 
             await EBHelper.CreateApplicationAsync(ApplicationName);
             await EBHelper.CreateApplicationVersionAsync(ApplicationName, VersionLabel, zipFilePath);
-            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, VersionLabel, BeanstalkPlatformType.Linux);
+            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, VersionLabel, BeanstalkPlatformType.Linux, RoleName);
             Assert.True(success);
 
             var environmentDescription = await AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
             });
         }
 
-        public async Task<bool> CreateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, BeanstalkPlatformType platformType)
+        public async Task<bool> CreateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, BeanstalkPlatformType platformType, string ec2Role)
         {
             _interactiveService.WriteLine($"Creating new Elastic Beanstalk environment {environmentName} with versionLabel {versionLabel}");
 
@@ -75,7 +75,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
                 PlatformArn = (await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(platformType)).PlatformArn,
                 OptionSettings = new List<ConfigurationOptionSetting>
                 {
-                    new ConfigurationOptionSetting("aws:autoscaling:launchconfiguration", "IamInstanceProfile", "aws-elasticbeanstalk-ec2-role"),
+                    new ConfigurationOptionSetting("aws:autoscaling:launchconfiguration", "IamInstanceProfile", ec2Role),
                     new ConfigurationOptionSetting("aws:elasticbeanstalk:healthreporting:system", "SystemType", "basic")
                 }
             });


### PR DESCRIPTION
*Description of changes:*
Integration tests fail when run on a new environment. This is because some tests having a dependency on a hard-coded IAM role which must be present in the environment. This PR removes that dependency and uses a new role that is created for every test run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
