### PR TITLE
fix: Set container memory limit to the same as the task to ensure the…

### DIFF
--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
@@ -151,7 +151,8 @@ namespace AspNetAppEcsFargate
             {
                 Image = ContainerImage.FromEcrRepository(EcrRepository, recipeConfiguration.ECRImageTag),
                 Logging = AppLogging,
-                Environment = settings.ECSEnvironmentVariables
+                Environment = settings.ECSEnvironmentVariables,
+                MemoryLimitMiB = settings.TaskMemory
             }));
 
             AppContainerDefinition.AddPortMappings(new PortMapping

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/Generated/Recipe.cs
@@ -126,7 +126,8 @@ namespace ConsoleAppECSFargateScheduleTask
             {
                 Image = ContainerImage.FromEcrRepository(ecrRepository, props.ECRImageTag),
                 Logging = AppLogging,
-                Environment = settings.ECSEnvironmentVariables
+                Environment = settings.ECSEnvironmentVariables,
+                MemoryLimitMiB = settings.TaskMemory
             };
 
             AppTaskDefinition.AddContainer(nameof(AppContainerDefinition), InvokeCustomizeCDKPropsEvent(nameof(AppContainerDefinition), this, AppContainerDefinition));

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Recipe.cs
@@ -133,7 +133,8 @@ namespace ConsoleAppEcsFargateService
             {
                 Image = ContainerImage.FromEcrRepository(ecrRepository, props.ECRImageTag),
                 Logging = AppLogging,
-                Environment = settings.ECSEnvironmentVariables
+                Environment = settings.ECSEnvironmentVariables,
+                MemoryLimitMiB = settings.TaskMemory
             };
 
             AppTaskDefinition.AddContainer(nameof(AppContainerDefinition), InvokeCustomizeCDKPropsEvent(nameof(AppContainerDefinition), this, AppContainerDefinition));

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.101.7" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.7.100.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
*Description of changes:*
As part of investigating [this memory](https://github.com/dotnet/runtime/issues/82815) issue with AWS Fargate it was discovered that .NET has incorrect understanding of the amount of heap space when only setting the task memory size. .NET looks at the containers hard memory limit which is not the same as the task memory.

The change is set our configured memory for both the task and container. We can do that in this tooling because we are only deploying a single container as part of the task definition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.