### PR TITLE
docs: Clarify the exception that is thrown when missing permissions for ListPlatformVersions during Elastic Beanstalk deployments

### DIFF
--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -587,7 +587,10 @@ namespace AWS.Deploy.Orchestration.Data
 
             if (!platforms.Any())
             {
-                throw new FailedToFindElasticBeanstalkSolutionStackException(DeployToolErrorCode.FailedToFindElasticBeanstalkSolutionStack, "Cannot use Elastic Beanstalk deployments because we cannot find a .NET Core Solution Stack to use. One possible reason could be that Elastic Beanstalk is not enabled in your region if you are using a non-default region.");
+                throw new FailedToFindElasticBeanstalkSolutionStackException(DeployToolErrorCode.FailedToFindElasticBeanstalkSolutionStack,
+                    "Cannot use Elastic Beanstalk deployments because we cannot find a .NET Core Solution Stack to use. " +
+                    "Possible reasons could be that Elastic Beanstalk is not enabled in your region if you are using a non-default region, " +
+                    "or that the configured credentials lack permission to call ListPlatformVersions.");
             }
 
             return platforms.First();


### PR DESCRIPTION
*Issue #, if available:* V855437126

*Description of changes:* Amends the exception message thrown when `GetLatestElasticBeanstalkPlatformArn` fails to include inadequate IAM permissions.

An internal user encountered this testing Code Catalyst.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
