### PR TITLE
fix: incorrect message when deployment settings file doesn't exist

### DIFF
--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -126,7 +126,8 @@ namespace AWS.Deploy.Common
         FailedToReadCdkBootstrapVersion = 10010400,
         UnsupportedOptionSettingType = 10010500,
         FailedToSaveDeploymentSettings = 10010600,
-        InvalidWindowsManifestFile = 10010700
+        InvalidWindowsManifestFile = 10010700,
+        DeploymentConfigurationNotFound = 10010800,
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -127,7 +127,7 @@ namespace AWS.Deploy.Common
         UnsupportedOptionSettingType = 10010500,
         FailedToSaveDeploymentSettings = 10010600,
         InvalidWindowsManifestFile = 10010700,
-        DeploymentConfigurationNotFound = 10010800,
+        UserDeploymentFileNotFound = 10010800,
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
@@ -60,11 +60,11 @@ namespace AWS.Deploy.Orchestration
             }
             catch (IOException ex)
             {
-                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNotFound, $"An error occured while trying to read the deployment settings file located at {filePath}. Make sure the file exists and is readable.", ex);
+                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNotFound, $"An error occurred while trying to read the deployment settings file located at {filePath}. Make sure the file exists and is readable.", ex);
             }
             catch (Exception ex)
             {
-                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, $"An error occured while trying to deserialize the deployment settings file located at {filePath}.\n  {ex.Message}", ex);
+                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, $"An error occurred while trying to deserialize the deployment settings file located at {filePath}.\n  {ex.Message}", ex);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
@@ -60,7 +60,7 @@ namespace AWS.Deploy.Orchestration
             }
             catch (IOException ex)
             {
-                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNotFound, $"An error occurred while trying to read the deployment settings file located at {filePath}. Make sure the file exists and is readable.", ex);
+                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNotFound, $"An error occurred while trying to read the deployment settings file located at {filePath}. Make sure the path you provided exists on your file system, and is readable.", ex);
             }
             catch (Exception ex)
             {

--- a/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
@@ -58,9 +58,13 @@ namespace AWS.Deploy.Orchestration
                 var userDeploymentSettings = JsonConvert.DeserializeObject<DeploymentSettings>(contents);
                 return userDeploymentSettings;
             }
+            catch (IOException ex)
+            {
+                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNotFound, $"An error occured while trying to read the deployment settings file located at {filePath}. Make sure the file exists and is readable.", ex);
+            }
             catch (Exception ex)
             {
-                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, $"An error occured while trying to deserialize the deployment settings file located at {filePath}", ex);
+                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, $"An error occured while trying to deserialize the deployment settings file located at {filePath}.\n  {ex.Message}", ex);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentSettingsHandler.cs
@@ -52,19 +52,22 @@ namespace AWS.Deploy.Orchestration
 
         public async Task<DeploymentSettings?> ReadSettings(string filePath)
         {
-            try
+            if (_fileManager.Exists(filePath))
             {
-                var contents = await _fileManager.ReadAllTextAsync(filePath);
-                var userDeploymentSettings = JsonConvert.DeserializeObject<DeploymentSettings>(contents);
-                return userDeploymentSettings;
+                try
+                {
+                    var contents = await _fileManager.ReadAllTextAsync(filePath);
+                    var userDeploymentSettings = JsonConvert.DeserializeObject<DeploymentSettings>(contents);
+                    return userDeploymentSettings;
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, $"An error occurred while trying to deserialize the deployment settings file located at {filePath}.\n  {ex.Message}", ex);
+                }
             }
-            catch (IOException ex)
+            else
             {
-                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.DeploymentConfigurationNotFound, $"An error occurred while trying to read the deployment settings file located at {filePath}. Make sure the path you provided exists on your file system, and is readable.", ex);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, $"An error occurred while trying to deserialize the deployment settings file located at {filePath}.\n  {ex.Message}", ex);
+                throw new InvalidDeploymentSettingsException(DeployToolErrorCode.UserDeploymentFileNotFound, $"The deployment settings file located at {filePath} doesn't exist.");
             }
         }
 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -259,7 +259,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
 
             // ASSERT
             var ex = await Assert.ThrowsAsync<InvalidDeploymentSettingsException>(readAction);
-            Assert.Contains("An error occured while trying to deserialize the deployment settings file", ex.Message);
+            Assert.Contains("An error occurred while trying to deserialize the deployment settings file", ex.Message);
         }
 
         [Fact]
@@ -275,7 +275,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
 
             // ASSERT
             var ex = await Assert.ThrowsAsync<InvalidDeploymentSettingsException>(readAction);
-            Assert.Contains("An error occured while trying to read the deployment settings file", ex.Message);
+            Assert.Contains("An error occurred while trying to read the deployment settings file", ex.Message);
         }
 
         private object GetOptionSettingValue(Recommendation recommendation, string fullyQualifiedId)

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -259,7 +259,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
 
             // ASSERT
             var ex = await Assert.ThrowsAsync<InvalidDeploymentSettingsException>(readAction);
-            Assert.Contains("An error occurred while trying to deserialize the deployment settings file", ex.Message);
+            Assert.Equal(DeployToolErrorCode.FailedToDeserializeUserDeploymentFile, ex.ErrorCode);
         }
 
         [Fact]
@@ -275,7 +275,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
 
             // ASSERT
             var ex = await Assert.ThrowsAsync<InvalidDeploymentSettingsException>(readAction);
-            Assert.Contains("An error occurred while trying to read the deployment settings file", ex.Message);
+            Assert.Equal(DeployToolErrorCode.UserDeploymentFileNotFound, ex.ErrorCode);
         }
 
         private object GetOptionSettingValue(Recommendation recommendation, string fullyQualifiedId)

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -246,6 +246,38 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             Assert.Equal(expectedSnapshot, actualSnapshot);
         }
 
+        [Fact]
+        public async Task ReadSettings_InvalidJson()
+        {
+            // ARRANGE
+            var recommendations = await _recommendationEngine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, "AspNetAppAppRunner"));
+            var filePath = Path.Combine("ConfigFileDeployment", "TestFiles", "InvalidConfigFile.json");
+
+            // ACT
+            var readAction = async () => await _deploymentSettingsHandler.ReadSettings(filePath);
+
+            // ASSERT
+            var ex = await Assert.ThrowsAsync<InvalidDeploymentSettingsException>(readAction);
+            Assert.Contains("An error occured while trying to deserialize the deployment settings file", ex.Message);
+        }
+
+        [Fact]
+        public async Task ReadSettings_FileNotFound()
+        {
+            // ARRANGE
+            var recommendations = await _recommendationEngine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.FirstOrDefault(x => string.Equals(x.Recipe.Id, "AspNetAppAppRunner"));
+            var filePath = Path.Combine("ConfigFileDeployment", "TestFiles", "AppRunnerConfigFile");
+
+            // ACT
+            var readAction = async () => await _deploymentSettingsHandler.ReadSettings(filePath);
+
+            // ASSERT
+            var ex = await Assert.ThrowsAsync<InvalidDeploymentSettingsException>(readAction);
+            Assert.Contains("An error occured while trying to read the deployment settings file", ex.Message);
+        }
+
         private object GetOptionSettingValue(Recommendation recommendation, string fullyQualifiedId)
         {
             var optionSetting = _optionSettingHandler.GetOptionSetting(recommendation, fullyQualifiedId);

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/InvalidConfigFile.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/InvalidConfigFile.json
@@ -1,0 +1,12 @@
+{
+  "AWSProfile": "default",
+  "AWSRegion": "us-west-2",
+  "RecipeId": "PushContainerImageEcr"
+  "Settings": {
+    "ImageTag": 123456789,
+    "DockerBuildArgs": "",
+    "DockerfilePath": "DockerAssets/Dockerfile",
+    "DockerExecutionDirectory": "DockerAssets",
+    "ECRRepositoryName": "my-ecr-repository"
+  }
+}


### PR DESCRIPTION
*Description of changes:*
While running some test scenarios in CodeCatalyst using different deployment settings files I kept the error message `An error occured while trying to deserialize the deployment settings file located at ...`. I was sure the file schema was correct, but was not sure what was the error. I cloned the repo and debugged the CLI. I identified that the same error message is shown to the user whether there was an error deserializing the deployment settings file, of if the file cannot be found.

This fix adds a specific error message telling users to check the path they provided exist to avoid this confusion. For scenarios when the file exists but there is a problem deserializing the JSON, the error message now also shows the specifics of what is wrong with the file. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.