### PR TITLE
chore: Update ci.template.yml with new OIDC Thumbprint

### DIFF
--- a/buildtools/ci.template.yml
+++ b/buildtools/ci.template.yml
@@ -85,7 +85,7 @@ Resources:
         - sts.amazonaws.com
       ThumbprintList:
         - 6938fd4d98bab03faadb97b34396831e3780aea1
-
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
See https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/

This should hopefully fix the CI failures related to the OIDC thumbprint. We made a similar change for the PowerShell repo recently: https://github.com/aws/aws-tools-for-powershell/commit/05fb600f8bfe76e19758525750b654aa8e0c42e9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
