### PR TITLE
chore: Enable code coverage on the repository

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -1,6 +1,11 @@
 name: AWS CodeBuild CI
 
 on:
+  # Manually trigger on specific branches
+  workflow_dispatch: 
+  push:
+    branches:
+      - dev
   pull_request:
     branches:
       - main
@@ -19,10 +24,12 @@ jobs:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
           role-duration-seconds: 7200
           aws-region: us-west-2
+
       - name: Setup .NET Core 6.0
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
+
       - name: Invoke Load Balancer Lambda
         id: lambda
         shell: pwsh
@@ -30,17 +37,23 @@ jobs:
           aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{\"Roles\": \"${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}\", \"ProjectName\": \"${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}\", \"Branch\": \"${{ github.sha }}\"}'
           $roleArn=$(cat ./response.json)
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
+
       - name: Configure Test Runner Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200
           aws-region: us-west-2
+
       - name: Run CodeBuild
         id: codebuild
         uses: aws-actions/aws-codebuild-run-build@v1.0.3
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+          env-vars-for-codebuild: CODECOV_TOKEN
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: CodeBuild Link
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# AWS .NET deployment tool [![nuget](https://img.shields.io/nuget/v/AWS.Deploy.Tools.svg) ![downloads](https://img.shields.io/nuget/dt/AWS.Deploy.Tools.svg)](https://www.nuget.org/packages/AWS.Deploy.Tools/)
+# AWS .NET deployment tool 
+[![nuget](https://img.shields.io/nuget/v/AWS.Deploy.Tools.svg) ![downloads](https://img.shields.io/nuget/dt/AWS.Deploy.Tools.svg)](https://www.nuget.org/packages/AWS.Deploy.Tools/)
+[![build status](https://img.shields.io/github/actions/workflow/status/aws/aws-dotnet-deploy/codebuild-ci.yml?branch=dev)](https://github.com/aws/aws-dotnet-deploy/actions/workflows/codebuild-ci.yml)
+[![code coverage](https://img.shields.io/codecov/c/github/aws/aws-dotnet-deploy/dev.svg)](https://codecov.io/gh/aws/aws-dotnet-deploy)
 
 ## Overview
 This repository contains the AWS Deploy Tool for .NET CLI - the opinionated tooling that simplifies deployment of .NET applications. The tool suggests the right AWS compute service to deploy your application to.  It then builds and packages your application as required by the chosen compute service, generates the deployment infrastructure, deploys your application by using the appropriate deployment engine (Cloud Development Kit (CDK) or native service APIs), and displays the endpoint.

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -20,7 +20,7 @@ phases:
   post_build:
     steps:
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d #v3
         
 reports:
     aws-dotnet-deploy-tests:

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -15,7 +15,13 @@ phases:
   build:
     commands:
       - dotnet build AWS.Deploy.sln -c Release
-      - dotnet test AWS.Deploy.sln -c Release --no-build --logger trx --results-directory ./testresults
+      - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover AWS.Deploy.sln -c Release --no-build --logger trx --results-directory ./testresults
+
+  post_build:
+    steps:
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        
 reports:
     aws-dotnet-deploy-tests:
         file-format: VisualStudioTrx

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: dev # set the default branch to 'dev'. This branch provides the coverage baselines during pull requests.

--- a/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -20,6 +20,16 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -12,7 +12,16 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
@@ -24,7 +24,17 @@
     <PackageReference Include="Should-DotNetStandard" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    
   </ItemGroup>
 
     <ItemGroup>

--- a/test/AWS.Deploy.DocGenerator.UnitTests/AWS.Deploy.DocGenerator.UnitTests.csproj
+++ b/test/AWS.Deploy.DocGenerator.UnitTests/AWS.Deploy.DocGenerator.UnitTests.csproj
@@ -26,10 +26,17 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
@@ -13,6 +13,16 @@
       <PackageReference Include="xunit" Version="2.4.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
       <PackageReference Include="Moq" Version="4.16.1" />
+
+      <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+
+      <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
@@ -12,7 +12,16 @@
     <PackageReference Include="Should-DotNetStandard" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6101

*Description of changes:*
This PR enables code coverage on the repository by making the following changes:

1. Adds a package reference to _coverlet.collector_ and _coverlet.msbuild_ in all `*Tests.csproj`. These packages are used to generate coverage reports during test execution.
2. Modifes `buildtools/ci.buildspec.yml` to include test coverge directives with `dotnet test` command and also adds a _post_build_ step to upload coverage reports to Codecov.
3. Modifies the _AWS CodeBuild CI_ GitHub action to read the `CODECOV_TOKEN` from the repository secret and pass it on to the CI CodeBuild job as an environment variable. This is required for uploading reports to Codecov.
5. Added `codecov.yml` config file to customize the behavior of Codecov. It currently sets the default branch to `dev` as the coverage baselines will be fetched from `dev` during pull requests.
6.  Adds a trigger on the  _AWS CodeBuild CI_ GitHub action so that it is also invoked during push to `dev` and coverage reports can be continually updated.
7. Added REAMDE badges to provide easy access to the the CI job status and Codecov dashboards for the repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
