### PR TITLE
feat: add .NET8 support for Beanstalk web apps and ECS Fargate console apps

### DIFF
--- a/src/AWS.Deploy.DockerEngine/Properties/DockerFileConfig.json
+++ b/src/AWS.Deploy.DockerEngine/Properties/DockerFileConfig.json
@@ -3,6 +3,10 @@
         "SdkType": "Microsoft.NET.Sdk.Web",
         "ImageMapping": [
             {
+                "TargetFramework": "net8.0",
+                "BaseImage": "mcr.microsoft.com/dotnet/aspnet:8.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:8.0"
+            },            {
                 "TargetFramework": "net7.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/aspnet:7.0",
                 "BuildImage": "mcr.microsoft.com/dotnet/sdk:7.0"
@@ -27,6 +31,11 @@
     {
         "SdkType": "Microsoft.NET.Sdk",
         "ImageMapping": [
+            {
+                "TargetFramework": "net8.0",
+                "BaseImage": "mcr.microsoft.com/dotnet/runtime:8.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:8.0"
+            },            
             {
                 "TargetFramework": "net7.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/runtime:7.0",

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -105,10 +105,14 @@ namespace AWS.Deploy.Orchestration
             _interactiveService.LogInfoMessage(string.Empty);
             _interactiveService.LogInfoMessage("Creating Dotnet Publish Zip file...");
 
-            // Since Beanstalk doesn't currently have .NET 7 preinstalled we need to make sure we are doing a self contained publish when creating the deployment bundle.
-            if (recommendation.Recipe.TargetService == RecipeIdentifier.TARGET_SERVICE_ELASTIC_BEANSTALK && recommendation.ProjectDefinition.TargetFramework == "net7.0")
+            // Since Beanstalk doesn't currently have .NET 7 and .NET 8 preinstalled we need to make sure we are doing a self-contained publish when creating the deployment bundle.
+            var targetFramework = recommendation.ProjectDefinition.TargetFramework ?? string.Empty;
+            var unavailableFramework = new List<string> { "net7.0", "net8.0" };
+            var frameworkNames = new Dictionary<string, string> { { "net7.0", ".NET 7" }, { "net8.0", ".NET 8" } };
+            if (recommendation.Recipe.TargetService == RecipeIdentifier.TARGET_SERVICE_ELASTIC_BEANSTALK &&
+                unavailableFramework.Contains(targetFramework))
             {
-                _interactiveService.LogInfoMessage("Using self contained publish since AWS Elastic Beanstalk does not currently have .NET 7 preinstalled");
+                _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have {frameworkNames[targetFramework]} preinstalled");
                 recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
             }
 

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -25,7 +25,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
@@ -25,7 +25,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -41,7 +41,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 },
                 {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -36,7 +36,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ],

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -26,6 +26,7 @@ namespace AWS.Deploy.CLI.UnitTests
         [InlineData("ConsoleSdkType", "")]
         [InlineData("WorkerServiceExample", "")]
         [InlineData("WebAppNet7", "")]
+        [InlineData("WebAppNet8", "")]
         public async Task DockerGenerate(string topLevelFolder, string projectName)
         {
             await DockerGenerateTestHelper(topLevelFolder, projectName);

--- a/testapps/docker/WebAppNet8/Dockerfile
+++ b/testapps/docker/WebAppNet8/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["WebAppNet8.csproj", ""]
+RUN dotnet restore "WebAppNet8.csproj"
+COPY . .
+WORKDIR "/src/"
+RUN dotnet build "WebAppNet8.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN apt-get update -yq \
+    && apt-get install -yq ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update -yq \
+    && apt-get install nodejs -yq
+RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WebAppNet8.dll"]

--- a/testapps/docker/WebAppNet8/Program.cs
+++ b/testapps/docker/WebAppNet8/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Test .NET 8");
+app.Run();

--- a/testapps/docker/WebAppNet8/ReferenceDockerfile
+++ b/testapps/docker/WebAppNet8/ReferenceDockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["WebAppNet8.csproj", ""]
+RUN dotnet restore "WebAppNet8.csproj"
+COPY . .
+WORKDIR "/src/"
+RUN dotnet build "WebAppNet8.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN apt-get update -yq \
+    && apt-get install -yq ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update -yq \
+    && apt-get install nodejs -yq
+RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "WebAppNet8.dll"]

--- a/testapps/docker/WebAppNet8/WebAppNet8.csproj
+++ b/testapps/docker/WebAppNet8/WebAppNet8.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/testapps/docker/WebAppNet8/appsettings.Development.json
+++ b/testapps/docker/WebAppNet8/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/testapps/docker/WebAppNet8/appsettings.json
+++ b/testapps/docker/WebAppNet8/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7160
DOTNET-7159

*Description of changes:*
* Add .NET8 support for all recipes except for Web Apps on Fargate and App Runner
* Web Apps on Fargate and App Runner will be updated as a quick follow up after ironing out the changes Microsoft made to the base .NET8 docker images

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
