### PR TITLE
feat: add support for .NET8 container-based web apps

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - dev
+      - 'feature/**'
 
 permissions:
   id-token: write

--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -211,6 +211,7 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{3aac19a6-02e8-45d0-bdd0-cad0fbe15f64}*SharedItemsImports = 5
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{3f7a5ca6-7178-4dbf-8dad-6a63684c7a8e}*SharedItemsImports = 5
+		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{4c4f07ce-4c88-44c6-864f-c5e563712ee2}*SharedItemsImports = 5
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{5f8ec972-781d-4a82-a73f-36a97281b0d5}*SharedItemsImports = 5
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{8a351cc0-70c0-4412-b45e-358606251512}*SharedItemsImports = 5
 		src\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems*{f2266c44-c8c5-45ad-aa9b-44f8825bdf63}*SharedItemsImports = 13

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 16
+      nodejs: 18
     commands:
       # install .NET SDK
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS App Runner.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS App Runner.md
@@ -8,7 +8,7 @@
     * ID: ServiceName
     * Description: The name of the AWS App Runner service.
     * Type: String
-* **Port**
+* **Container Port**
     * ID: Port
     * Description: The port the container is listening for requests on.
     * Type: Int

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon ECS using AWS Fargate.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon ECS using AWS Fargate.md
@@ -29,6 +29,10 @@
     * ID: DesiredCount
     * Description: The desired number of ECS tasks to run for the service.
     * Type: Int
+* **Container Port**
+    * ID: Port
+    * Description: The port the container is listening for requests on.
+    * Type: Int
 * **Application IAM Role**
     * ID: ApplicationIAMRole
     * Description: The Identity and Access Management (IAM) role that provides AWS credentials to the application to access AWS services.

--- a/site/content/docs/deployment-projects/recipe-file.md
+++ b/site/content/docs/deployment-projects/recipe-file.md
@@ -318,7 +318,7 @@ Here is an example of a validator for a port setting that ensures the value is w
 ...
 {
     "Id": "Port",
-    "Name": "Port",
+    "Name": "Container Port",
     "Category": "General",
     "Description": "The port the container is listening for requests on.",
     "Type": "Int",

--- a/site/content/troubleshooting-guide/docker-issues.md
+++ b/site/content/troubleshooting-guide/docker-issues.md
@@ -84,3 +84,12 @@ Failed to push Docker Image
 **Why is this happening** You may see this if your project has project references (.csproj, .vbproj) that are located in a higher folder than the solution file (.sln) that AWS.Deploy.Tools is using to generate a Dockerfile. In this case AWS.Deploy.Tools will not generate a Dockerfile to avoid a large build context that can result in long builds.
 
 **Resolution**: If you would still like to deploy to an [AWS service that requires Docker](../docs/support.md), you must create your own Dockerfile and set an appropriate "Docker Execution Directory" in the deployment options. Alternatively you may choose another deployment target that does not require Docker, such as AWS Elastic Beanstalk.
+
+
+## Application deployment stuck or fails because of health check
+
+Microsoft has made changes to the base images used in .NET 8 which now expose 8080 as the default HTTP port instead of the port 80 which was used in previous versions. In addition to that, Microsoft now uses a non-root user by default.
+
+As we added support for deploying .NET 8 container-based applications, the container port setting in the recipes that support it now defaults to 8080 for .NET 8 and 80 in previous versions. For applications that do not have a `dockerfile`, we generate one accordingly. However, for applications that have their own `dockerfile`, the user is responsible for setting and exposing the proper port. If the container port is different from the port exposed in the container, the deployment might keep going until it reaches a timeout from the underlying services, or you might receive an error related to the health check.
+
+In the tool, we have added a warning message if we detect that the container port setting is different from the one exposed in the container.

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DockerHttpPortCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DockerHttpPortCommand.cs
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.TypeHintData;
+using System.Threading.Tasks;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class DockerHttpPortCommand : ITypeHintCommand
+    {
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public DockerHttpPortCommand(IConsoleUtilities consoleUtilities, IOptionSettingHandler optionSettingHandler)
+        {
+            _consoleUtilities = consoleUtilities;
+            _optionSettingHandler = optionSettingHandler;
+        }
+
+        public Task<TypeHintResourceTable> GetResources(Recommendation recommendation, OptionSettingItem optionSetting) => Task.FromResult(new TypeHintResourceTable());
+
+        public Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var settingValue = _consoleUtilities
+                .AskUserForValue(
+                    string.Empty,
+                    _optionSettingHandler.GetOptionSettingValue<string>(recommendation, optionSetting) ?? string.Empty,
+                    allowEmpty: false,
+                    resetValue: _optionSettingHandler.GetOptionSettingDefaultValue<string>(recommendation, optionSetting) ?? string.Empty,
+                    validators: async httpPort => await ValidateHttpPort(httpPort, recommendation, optionSetting));
+
+            var settingValueInt = int.Parse(settingValue);
+            recommendation.DeploymentBundle.DockerfileHttpPort = settingValueInt;
+            return Task.FromResult<object>(settingValueInt);
+        }
+
+        private async Task<string> ValidateHttpPort(string httpPort, Recommendation recommendation, OptionSettingItem optionSettingItem)
+        {
+            var validationResult = await new RangeValidator() { Min = 0, Max = 65535 }.Validate(httpPort, recommendation, optionSettingItem);
+
+            if (validationResult.IsValid)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return validationResult.ValidationFailedMessage ?? "Invalid value for Docker HTTP Port.";
+            }
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -72,6 +72,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.VPCConnector, ActivatorUtilities.CreateInstance<VPCConnectorCommand>(serviceProvider) },
                 { OptionSettingTypeHint.FilePath, ActivatorUtilities.CreateInstance<FilePathCommand>(serviceProvider) },
                 { OptionSettingTypeHint.ElasticBeanstalkVpc, ActivatorUtilities.CreateInstance<ElasticBeanstalkVpcCommand>(serviceProvider) },
+                { OptionSettingTypeHint.DockerHttpPort, ActivatorUtilities.CreateInstance<DockerHttpPortCommand>(serviceProvider) },
             };
         }
 

--- a/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
+++ b/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.IO;
-
 namespace AWS.Deploy.Common
 {
     /// <summary>
@@ -24,6 +22,11 @@ namespace AWS.Deploy.Common
         /// The path to the Dockerfile. This can either be an absolute path or relative to the project directory.
         /// </summary>
         public string DockerfilePath { get; set; } = "";
+
+        /// <summary>
+        /// The HTTP port to expose in the container.
+        /// </summary>
+        public int DockerfileHttpPort { get; set; } = 8080;
 
         /// <summary>
         /// The ECR Repository Name where the docker image will be pushed to.

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -128,6 +128,7 @@ namespace AWS.Deploy.Common
         FailedToSaveDeploymentSettings = 10010600,
         InvalidWindowsManifestFile = 10010700,
         UserDeploymentFileNotFound = 10010800,
+        DockerInspectFailed = 10004200,
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -39,6 +39,7 @@ namespace AWS.Deploy.Common.Recipes
         ExistingSecurityGroups,
         VPCConnector,
         FilePath,
-        ElasticBeanstalkVpc
+        ElasticBeanstalkVpc,
+        DockerHttpPort
     };
 }

--- a/src/AWS.Deploy.Constants/Docker.cs
+++ b/src/AWS.Deploy.Constants/Docker.cs
@@ -26,6 +26,11 @@ namespace AWS.Deploy.Constants
         public const string DockerBuildArgsOptionId = "DockerBuildArgs";
 
         /// <summary>
+        /// Id for the Docker HTTP Port recipe option
+        /// </summary>
+        public const string DockerHttpPortOptionId = "Port";
+
+        /// <summary>
         /// Id for the ECR Repository Name recipe option
         /// </summary>
         public const string ECRRepositoryNameOptionId = "ECRRepositoryName";
@@ -34,5 +39,10 @@ namespace AWS.Deploy.Constants
         /// Id for the Docker Image Tag recipe option
         /// </summary>
         public const string ImageTagOptionId = "ImageTag";
+
+        /// <summary>
+        /// The environment variable that .NET uses to determine the HTTP port
+        /// </summary>
+        public static readonly string DotnetHttpPortEnvironmentVariable = "ASPNETCORE_HTTP_PORTS";
     }
 }

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -21,6 +21,7 @@ namespace AWS.Deploy.Constants
         public const string REPLACE_TOKEN_DEFAULT_VPC_ID = "{DefaultVpcId}";
         public const string REPLACE_TOKEN_HAS_DEFAULT_VPC = "{HasDefaultVpc}";
         public const string REPLACE_TOKEN_HAS_NOT_VPCS = "{HasNotVpcs}";
+        public const string REPLACE_TOKEN_DEFAULT_CONTAINER_PORT = "{DefaultContainerPort}";
 
         /// <summary>
         /// Id for the 'dotnet publish --configuration' recipe option

--- a/src/AWS.Deploy.DockerEngine/AWS.Deploy.DockerEngine.csproj
+++ b/src/AWS.Deploy.DockerEngine/AWS.Deploy.DockerEngine.csproj
@@ -24,4 +24,6 @@
     <PackageReference Include="System.Text.Json" Version="6.0.8" />
   </ItemGroup>
 
+  <Import Project="..\AWS.Deploy.Constants\AWS.Deploy.Constants.projitems" Label="Shared" />
+
 </Project>

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
-using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Utilities;
 using Newtonsoft.Json;
 
@@ -18,14 +17,23 @@ namespace AWS.Deploy.DockerEngine
         /// <summary>
         /// Generates a docker file
         /// </summary>
-        void GenerateDockerFile();
+        /// <param name="recommendation">The currently selected recommendation</param>
+        void GenerateDockerFile(Recommendation recommendation);
 
         /// <summary>
         /// Inspects the Dockerfile associated with the recommendation
         /// and determines the appropriate Docker Execution Directory,
         /// if one is not set.
         /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
         void DetermineDockerExecutionDirectory(Recommendation recommendation);
+
+        /// <summary>
+        /// Determines the appropriate HTTP port that the underlying container is using.
+        /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
+        /// <returns>The default HTTP port used by the container</returns>
+        int DetermineDefaultDockerPort(Recommendation recommendation);
     }
 
     /// <summary>
@@ -54,7 +62,8 @@ namespace AWS.Deploy.DockerEngine
         /// <summary>
         /// Generates a docker file
         /// </summary>
-        public void GenerateDockerFile()
+        /// <param name="recommendation">The currently selected recommendation</param>
+        public void GenerateDockerFile(Recommendation recommendation)
         {
             var projectFileName = Path.GetFileName(_projectPath);
             var imageMapping = GetImageMapping();
@@ -63,7 +72,13 @@ namespace AWS.Deploy.DockerEngine
                 throw new UnknownDockerImageException(DeployToolErrorCode.NoValidDockerImageForProject, $"Unable to determine a valid docker base and build image for project of type {_project.SdkType} and Target Framework {_project.TargetFramework}");
             }
 
-            var dockerFile = new DockerFile(imageMapping, projectFileName, _project.AssemblyName);
+            var dockerFile = new DockerFile(
+                imageMapping,
+                projectFileName,
+                _project.AssemblyName,
+                recommendation.DeploymentBundle.DockerfileHttpPort,
+                UseRootUser(recommendation),
+                DetermineHTTPPortEnvironmentVariable(recommendation, recommendation.DeploymentBundle.DockerfileHttpPort));
             var projectDirectory = Path.GetDirectoryName(_projectPath) ?? "";
             var projectList = GetProjectList();
             dockerFile.WriteDockerFile(projectDirectory, projectList);
@@ -171,7 +186,7 @@ namespace AWS.Deploy.DockerEngine
         /// and determines the appropriate Docker Execution Directory,
         /// if one is not set.
         /// </summary>
-        /// <param name="recommendation"></param>
+        /// <param name="recommendation">The currently selected recommendation</param>
         public void DetermineDockerExecutionDirectory(Recommendation recommendation)
         {
             if (string.IsNullOrEmpty(recommendation.DeploymentBundle.DockerExecutionDirectory))
@@ -195,6 +210,66 @@ namespace AWS.Deploy.DockerEngine
                         }
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Determines the appropriate HTTP port that the underlying container is using.
+        /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
+        /// <returns>The default HTTP port used by the container</returns>
+        public int DetermineDefaultDockerPort(Recommendation recommendation)
+        {
+            switch (recommendation.ProjectDefinition.TargetFramework)
+            {
+                case "net7.0":
+                case "net6.0":
+                case "net5.0":
+                case "netcoreapp3.1":
+                    return 80;
+
+                default:
+                    return 8080;
+            }
+        }
+
+        /// <summary>
+        /// Determines the appropriate HTTP port environment variable to set.
+        /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
+        /// <returns>The appropriate HTTP port environment variable</returns>
+        private string DetermineHTTPPortEnvironmentVariable(Recommendation recommendation, int port)
+        {
+            switch (recommendation.ProjectDefinition.TargetFramework)
+            {
+                case "net7.0":
+                case "net6.0":
+                case "net5.0":
+                case "netcoreapp3.1":
+                    return $"ASPNETCORE_URLS=http://+:{port}";
+
+                default:
+                    return $"ASPNETCORE_HTTP_PORTS={port}";
+            }
+        }
+
+        /// <summary>
+        /// Checks whether to use a root or non-root user in the underlying container.
+        /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
+        /// <returns>true if a root user is used, else false</returns>
+        private bool UseRootUser(Recommendation recommendation)
+        {
+            switch (recommendation.ProjectDefinition.TargetFramework)
+            {
+                case "net7.0":
+                case "net6.0":
+                case "net5.0":
+                case "netcoreapp3.1":
+                    return true;
+
+                default:
+                    return false;
             }
         }
     }

--- a/src/AWS.Deploy.DockerEngine/DockerFile.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerFile.cs
@@ -13,13 +13,14 @@ namespace AWS.Deploy.DockerEngine
     /// </summary>
     public class DockerFile
     {
-        private const string DockerFileName = "Dockerfile";
-
         private readonly ImageMapping _imageMapping;
         private readonly string _projectName;
         private readonly string _assemblyName;
+        private readonly int _port;
+        private readonly bool _useRootUser;
+        private readonly string _httpPortEnvironmentVariable;
 
-        public DockerFile(ImageMapping imageMapping, string projectName, string? assemblyName)
+        public DockerFile(ImageMapping imageMapping, string projectName, string? assemblyName, int port, bool useRootUser, string httpPortEnvironmentVariable)
         {
             if (imageMapping == null)
             {
@@ -39,6 +40,9 @@ namespace AWS.Deploy.DockerEngine
             _imageMapping = imageMapping;
             _projectName = projectName;
             _assemblyName = assemblyName;
+            _port = port;
+            _useRootUser = useRootUser;
+            _httpPortEnvironmentVariable = httpPortEnvironmentVariable;
         }
 
         /// <summary>
@@ -79,10 +83,46 @@ namespace AWS.Deploy.DockerEngine
                 .Replace("{project-name}", _projectName)
                 .Replace("{assembly-name}", _assemblyName);
 
+            // Microsoft exposes 8081 along with 8080 in their .NET8 templates. I am preserving that behavior here when port 8080 is used.
+            if (_port == 8080)
+            {
+                dockerFile = dockerFile
+                    .Replace("{exposed-ports}", $"EXPOSE {_port}\r\nEXPOSE 8081");
+                dockerFile = dockerFile
+                    .Replace("{http-port-env-variable}", string.Empty);
+            }
+            // Microsoft exposes 443 along with 80 in their .NET7 and older templates. I am preserving that behavior here when port 80 is used.
+            else if (_port == 80)
+            {
+                dockerFile = dockerFile
+                    .Replace("{exposed-ports}", $"EXPOSE {_port}\r\nEXPOSE 443");
+                dockerFile = dockerFile
+                    .Replace("{http-port-env-variable}", string.Empty);
+            }
+            // For all other ports, it is up to the user to expose the HTTPS port in the dockerfile. 
+            else
+            {
+                dockerFile = dockerFile
+                    .Replace("{exposed-ports}", $"EXPOSE {_port}");
+                dockerFile = dockerFile
+                    .Replace("{http-port-env-variable}", $"\r\nENV {_httpPortEnvironmentVariable}");
+            }
+
+            if (_useRootUser)
+            {
+                dockerFile = dockerFile
+                    .Replace("{non-root-user}", string.Empty);
+            }
+            else
+            {
+                dockerFile = dockerFile
+                    .Replace("{non-root-user}", "\r\nUSER app");
+            }
+
             // ProjectDefinitionParser will have transformed projectDirectory to an absolute path, 
             // and DockerFileName is static so traversal should not be possible here.
             // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
-            File.WriteAllText(Path.Combine(projectDirectory, DockerFileName), dockerFile);
+            File.WriteAllText(Path.Combine(projectDirectory, Constants.Docker.DefaultDockerfileName), dockerFile);
         }
     }
 }

--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
@@ -1,7 +1,6 @@
-FROM {docker-base-image} AS base
+FROM {docker-base-image} AS base{non-root-user}
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+{exposed-ports}
 
 FROM {docker-build-image} AS build
 WORKDIR /src
@@ -21,7 +20,7 @@ RUN apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "{project-name}" -c Release -o /app/publish
 
-FROM base AS final
+FROM base AS final{http-port-env-variable}
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "{assembly-name}.dll"]

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Amazon.ECR.Model;
@@ -14,7 +14,6 @@ using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Utilities;
 using AWS.Deploy.Constants;
-using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.Utilities;
 using Recommendation = AWS.Deploy.Common.Recommendation;
 
@@ -25,6 +24,15 @@ namespace AWS.Deploy.Orchestration
         Task BuildDockerImage(CloudApplication cloudApplication, Recommendation recommendation, string imageTag);
         Task<string> CreateDotnetPublishZip(Recommendation recommendation);
         Task PushDockerImageToECR(Recommendation recommendation, string repositoryName, string sourceTag);
+
+        /// <summary>
+        /// Inspects the already built docker image by using 'docker inspect'
+        /// to return the environment variables used in the container.
+        /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
+        /// <param name="sourceTag">The docker tag of the built image</param>
+        /// <returns>A dictionary that represents the environment varibales from the container</returns>
+        Task<Dictionary<string, string>> InspectDockerImageEnvironmentVariables(Recommendation recommendation, string sourceTag);
     }
 
     public class DeploymentBundleHandler : IDeploymentBundleHandler
@@ -266,6 +274,46 @@ namespace AWS.Deploy.Orchestration
                     errorMessage = $"Failed to push Docker Image due to the following reason:{Environment.NewLine}{result.StandardError}";
                 throw new DockerPushFailedException(DeployToolErrorCode.DockerPushFailed, errorMessage, result.ExitCode);
             }
+        }
+
+        /// <summary>
+        /// Inspects the already built docker image by using 'docker inspect'
+        /// to return the environment variables used in the container.
+        /// </summary>
+        /// <param name="recommendation">The currently selected recommendation</param>
+        /// <param name="sourceTag">The docker tag of the built image</param>
+        /// <returns>A dictionary that represents the environment varibales from the container</returns>
+        public async Task<Dictionary<string, string>> InspectDockerImageEnvironmentVariables(Recommendation recommendation, string sourceTag)
+        {
+            var dockerInspectCommand = "docker inspect --format \"{{ index (index .Config.Env) }}\" " + sourceTag;
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                dockerInspectCommand = "docker inspect --format '{{ index (index .Config.Env) }}' " + sourceTag;
+            var result = await _commandLineWrapper.TryRunWithResult(dockerInspectCommand, streamOutputToInteractiveService: false);
+
+            if (result.ExitCode != 0)
+            {
+                var errorMessage = "Failed to inspect Docker Image";
+                if (!string.IsNullOrEmpty(result.StandardError))
+                    errorMessage = $"Failed to inspect Docker Image due to the following reason:{Environment.NewLine}{result.StandardError}";
+                throw new DockerInspectFailedException(DeployToolErrorCode.DockerInspectFailed, errorMessage, result.ExitCode);
+            }
+
+            var environmentVariables = new Dictionary<string, string>();
+
+            if (!string.IsNullOrWhiteSpace(result.StandardOut))
+            {
+                var lines = result.StandardOut.TrimStart('[').TrimEnd(']').Split(' ');
+                foreach (var line in lines)
+                {
+                    var keyValuePair = line.Split('=');
+                    if (keyValuePair.Length < 2)
+                        continue;
+
+                    environmentVariables[keyValuePair[0].Trim()] = keyValuePair[1].Trim();
+                }
+            }
+
+            return environmentVariables;
         }
     }
 }

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -86,6 +86,14 @@ namespace AWS.Deploy.Orchestration
     }
 
     /// <summary>
+    /// Exception is thrown if docker inspect attempt failed
+    /// </summary>
+    public class DockerInspectFailedException : DeployToolException
+    {
+        public DockerInspectFailedException(DeployToolErrorCode errorCode, string message, int processExitCode, Exception? innerException = null) : base(errorCode, message, innerException, processExitCode) { }
+    }
+
+    /// <summary>
     /// Exception is thrown if unable to read CDK Bootstrap version from template
     /// </summary>
     public class FailedToReadCdkBootstrapVersionException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -129,6 +129,9 @@ namespace AWS.Deploy.Orchestration
                 case Constants.Docker.DockerBuildArgsOptionId:
                     recommendation.DeploymentBundle.DockerBuildArgs = value.ToString() ?? string.Empty;
                     break;
+                case Constants.Docker.DockerHttpPortOptionId:
+                    recommendation.DeploymentBundle.DockerfileHttpPort = Convert.ToInt32(value);
+                    break;
                 case Constants.Docker.ECRRepositoryNameOptionId:
                     recommendation.DeploymentBundle.ECRRepositoryName = value.ToString() ?? string.Empty;
                     break;

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using AWS.Deploy.Common;
@@ -14,11 +13,9 @@ using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Utilities;
 using AWS.Deploy.DockerEngine;
 using AWS.Deploy.Orchestration.CDK;
-using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.DeploymentCommands;
 using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Orchestration.ServiceHandlers;
-using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.Recipes;
 
 namespace AWS.Deploy.Orchestration
@@ -238,6 +235,15 @@ namespace AWS.Deploy.Orchestration
                 var vpcs = await _awsResourceQueryer.GetListOfVpcs();
                 recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_HAS_NOT_VPCS, !vpcs.Any());
             }
+            if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_CONTAINER_PORT))
+            {
+                if (_dockerEngine == null)
+                    throw new InvalidOperationException($"{nameof(_dockerEngine)} is null as part of the Orchestrator object");
+
+                var defaultPort = _dockerEngine.DetermineDefaultDockerPort(recommendation);
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_CONTAINER_PORT, defaultPort);
+                recommendation.DeploymentBundle.DockerfileHttpPort = defaultPort;
+            }
         }
 
         public async Task DeployRecommendation(CloudApplication cloudApplication, Recommendation recommendation)
@@ -297,7 +303,7 @@ namespace AWS.Deploy.Orchestration
                 _interactiveService.LogInfoMessage("Generating Dockerfile...");
                 try
                 {
-                    _dockerEngine.GenerateDockerFile();
+                    _dockerEngine.GenerateDockerFile(recommendation);
                 }
                 catch (DockerEngineExceptionBase ex)
                 {
@@ -330,6 +336,34 @@ namespace AWS.Deploy.Orchestration
             // These option settings need to be persisted back as they are not always provided by the user and we have custom logic to determine their values
             await _optionSettingHandler.SetOptionSettingValue(recommendation, Constants.Docker.DockerExecutionDirectoryOptionId, recommendation.DeploymentBundle.DockerExecutionDirectory);
             await _optionSettingHandler.SetOptionSettingValue(recommendation, Constants.Docker.DockerfileOptionId, recommendation.DeploymentBundle.DockerfilePath);
+
+            // Try to inspect the container environment variables to provide better insights on the HTTP port to use for the container.
+            // If we run into issues doing so, we can proceed without throwing a terminating exception.
+            try
+            {
+                var environmentVariables = await _deploymentBundleHandler.InspectDockerImageEnvironmentVariables(recommendation, imageTag);
+
+                if (environmentVariables.ContainsKey(Constants.Docker.DotnetHttpPortEnvironmentVariable))
+                {
+                    var httpPort = environmentVariables[Constants.Docker.DotnetHttpPortEnvironmentVariable];
+
+                    // Assuming a single value can be specified
+                    if (int.TryParse(httpPort, out var httpPortInt))
+                    {
+                        if (recommendation.DeploymentBundle.DockerfileHttpPort != httpPortInt)
+                        {
+                            _interactiveService.LogInfoMessage($"The HTTP port you have chosen in your deployment settings is different than the .NET HTTP port exposed in the container. " +
+                                $"The container has the environment variable {Constants.Docker.DotnetHttpPortEnvironmentVariable}={httpPortInt}, " +
+                                $"whereas the port you chose in the deployment settings is {recommendation.DeploymentBundle.DockerfileHttpPort}." +
+                                $"The deployment may fail the health check if these 2 ports are misaligned.");
+                        }
+                    }
+                }
+            }
+            catch (DockerInspectFailedException ex)
+            {
+                _interactiveService.LogDebugMessage($"Unable to inspect the docker container to retrieve the HTTP port used by .NET due to the following error: {ex.Message}");
+            }
 
             _interactiveService.LogSectionStart("Pushing container image to Elastic Container Registry (ECR)", "Using the docker CLI to log on to ECR and push the local image to ECR.");
             await _deploymentBundleHandler.PushDockerImageToECR(recommendation, respositoryName, imageTag);

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/Generated/Configurations/Configuration.cs
@@ -34,9 +34,9 @@ namespace AspNetAppAppRunner.Configurations
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// The port that your application listens to in the container. Defaults to port 80.
+        /// The port that your application listens to in the container. Defaults to port 8080.
         /// </summary>
-        public int Port { get; set; } = 80;
+        public int Port { get; set; } = 8080;
 
         /// <summary>
         /// An optional command that App Runner runs to start the application in the source image. If specified, this command overrides the Docker image’s default start command.
@@ -118,7 +118,7 @@ namespace AspNetAppAppRunner.Configurations
             VPCConnector = vpcConnector;
             ServiceAccessIAMRole = serviceAccessIAMRole;
             ServiceName = serviceName;
-            Port = port ?? 80;
+            Port = port ?? 8080;
             HealthCheckProtocol = healthCheckProtocol;
             Cpu = cpu;
             Memory = memory;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Configurations/Configuration.cs
@@ -29,6 +29,11 @@ namespace AspNetAppEcsFargate.Configurations
         public string ECSServiceName { get; set; }
 
         /// <summary>
+        /// The port that your application listens to in the container. Defaults to port 8080.
+        /// </summary>
+        public int Port { get; set; } = 8080;
+
+        /// <summary>
         /// The ECS cluster that will host the deployed application.
         /// </summary>
         public ECSClusterConfiguration ECSCluster { get; set; }
@@ -75,6 +80,7 @@ namespace AspNetAppEcsFargate.Configurations
         public Configuration(
             IAMRoleConfiguration applicationIAMRole,
             string ecsServiceName,
+            int? port,
             ECSClusterConfiguration ecsCluster,
             VpcConfiguration vpc,
             SortedSet<string> additionalECSServiceSecurityGroups,
@@ -85,6 +91,7 @@ namespace AspNetAppEcsFargate.Configurations
         {
             ApplicationIAMRole = applicationIAMRole;
             ECSServiceName = ecsServiceName;
+            Port = port ?? 8080;
             ECSCluster = ecsCluster;
             Vpc = vpc;
             AdditionalECSServiceSecurityGroups = additionalECSServiceSecurityGroups;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
@@ -157,7 +157,7 @@ namespace AspNetAppEcsFargate
 
             AppContainerDefinition.AddPortMappings(new PortMapping
             {
-                ContainerPort = 80,
+                ContainerPort = settings.Port,
                 Protocol = Amazon.CDK.AWS.ECS.Protocol.TCP
             });
 

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ]
@@ -113,11 +113,12 @@
         },
         {
             "Id": "Port",
-            "Name": "Port",
+            "Name": "Container Port",
             "Category": "General",
             "Description": "The port the container is listening for requests on.",
             "Type": "Int",
-            "DefaultValue": 80,
+            "TypeHint": "DockerHttpPort",
+            "DefaultValue": "{DefaultContainerPort}",
             "AdvancedSetting": false,
             "Updatable": true,
             "Validators": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -41,7 +41,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
                     }
                 }
             ]
@@ -220,6 +220,26 @@
                     "Configuration": {
                         "Min": 1,
                         "Max": 5000
+                    }
+                }
+            ]
+        },
+        {
+            "Id": "Port",
+            "Name": "Container Port",
+            "Category": "General",
+            "Description": "The port the container is listening for requests on.",
+            "Type": "Int",
+            "TypeHint": "DockerHttpPort",
+            "DefaultValue": "{DefaultContainerPort}",
+            "AdvancedSetting": false,
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "Range",
+                    "Configuration": {
+                        "Min": 0,
+                        "Max": 65535
                     }
                 }
             ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -553,7 +553,8 @@
                         "SQSQueueUrl",
                         "SNSTopicArn",
                         "FilePath",
-                        "ElasticBeanstalkVpc"
+                        "ElasticBeanstalkVpc",
+                        "DockerHttpPort"
                     ]
                 },
                 "DefaultValue": {

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -33,6 +33,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
         private const string BEANSTALK_PLATFORM_ARN_TOKEN = "{LatestDotnetBeanstalkPlatformArn}";
         private const string STACK_NAME_TOKEN = "{StackName}";
         private const string DEFAULT_VPC_ID_TOKEN = "{DefaultVpcId}";
+        private const string DEFAULT_CONTAINER_PORT_TOKEN = "{DefaultContainerPort}";
 
         public DeploymentSettingsHandlerTests()
         {
@@ -200,6 +201,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             // ARRANGE - add replacement tokens
             selectedRecommendation.AddReplacementToken(STACK_NAME_TOKEN, "MyAppStack");
             selectedRecommendation.AddReplacementToken(DEFAULT_VPC_ID_TOKEN, "vpc-12345678");
+            selectedRecommendation.AddReplacementToken(DEFAULT_CONTAINER_PORT_TOKEN, 80);
 
             // ARRANGE - Modify option setting items
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ServiceName", "MyAppRunnerService");

--- a/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
@@ -39,7 +39,9 @@
 
     <ItemGroup>
 	    <ProjectReference Include="..\..\src\AWS.Deploy.CLI\AWS.Deploy.CLI.csproj" />
-	    <ProjectReference Include="..\..\src\AWS.Deploy.DockerEngine\AWS.Deploy.DockerEngine.csproj" />
+	    <ProjectReference Include="..\..\src\AWS.Deploy.DockerEngine\AWS.Deploy.DockerEngine.csproj">
+	      <Aliases>DockerEngine</Aliases>
+	    </ProjectReference>
 	    <ProjectReference Include="..\..\src\AWS.Deploy.Recipes\AWS.Deploy.Recipes.csproj" />
 	    <ProjectReference Include="..\..\src\AWS.Deploy.ServerMode.Client\AWS.Deploy.ServerMode.Client.csproj" />
 	    <ProjectReference Include="..\AWS.Deploy.CLI.Common.UnitTests\AWS.Deploy.CLI.Common.UnitTests.csproj" />

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+extern alias DockerEngine;
+
 using System;
 using System.IO;
 using System.Reflection;
@@ -8,9 +10,11 @@ using System.Threading.Tasks;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
-using AWS.Deploy.DockerEngine;
+using DockerEngine.AWS.Deploy.DockerEngine;
 using Should;
 using Xunit;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using System.Linq;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -73,15 +77,31 @@ namespace AWS.Deploy.CLI.UnitTests
         /// </summary>
         private async Task DockerGenerateTestHelper(string topLevelFolder, string projectName)
         {
+            var fileManager = new FileManager();
+            var directoryManager = new DirectoryManager();
+
             var projectPath = ResolvePath(Path.Combine(topLevelFolder, projectName));
 
-            var fileManager = new FileManager();
+            // ARRANGE - select recommendation
+            var recommendationEngine = await HelperFunctions.BuildRecommendationEngine(
+                () => projectPath,
+                fileManager,
+                directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default"
+            );
 
-            var project = await new ProjectDefinitionParser(fileManager, new DirectoryManager()).Parse(projectPath);
+            var recommendations = await recommendationEngine.ComputeRecommendations();
+            var selectedRecommendation = recommendations.First();
 
-            var engine = new DockerEngine.DockerEngine(project, fileManager, new TestDirectoryManager());
+            var projectDefinition = await new ProjectDefinitionParser(fileManager, new DirectoryManager()).Parse(projectPath);
 
-            engine.GenerateDockerFile();
+            var engine = new DockerEngine.AWS.Deploy.DockerEngine.DockerEngine(projectDefinition, fileManager, new TestDirectoryManager());
+
+            selectedRecommendation.DeploymentBundle.DockerfileHttpPort = engine.DetermineDefaultDockerPort(selectedRecommendation);
+
+            engine.GenerateDockerFile(selectedRecommendation);
 
             AssertDockerFilesAreEqual(projectPath);
         }

--- a/test/AWS.Deploy.CLI.UnitTests/IsOptionSettingModifiedTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/IsOptionSettingModifiedTests.cs
@@ -91,6 +91,7 @@ namespace AWS.Deploy.CLI.UnitTests
             selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_STACK_NAME, "MyAppStack");
             selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_DEFAULT_VPC_ID, "vpc-12345678");
             selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_HAS_DEFAULT_VPC, true);
+            selectedRecommendation.AddReplacementToken(RecipeIdentifier.REPLACE_TOKEN_DEFAULT_CONTAINER_PORT, 80);
 
             // ARRANGE - modify settings so that they are different from their default values
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ECSServiceName", "MyECSService", skipValidation: true);

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
@@ -10,7 +10,6 @@ using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
-using AWS.Deploy.Recipes;
 using Moq;
 
 namespace AWS.Deploy.CLI.UnitTests.Utilities
@@ -25,7 +24,24 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             string awsAccountId,
             string awsProfile)
         {
-            var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
+            return await BuildRecommendationEngine(
+                () => SystemIOUtilities.ResolvePath(testProjectName),
+                fileManager,
+                directoryManager,
+                awsRegion,
+                awsAccountId,
+                awsProfile);
+        }
+
+        public static async Task<RecommendationEngine> BuildRecommendationEngine(
+            Func<string> ResolvePath,
+            IFileManager fileManager,
+            IDirectoryManager directoryManager,
+            string awsRegion,
+            string awsAccountId,
+            string awsProfile)
+        {
+            var fullPath = ResolvePath();
 
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var orchestratorInteractiveService = new TestToolOrchestratorInteractiveService();
@@ -36,7 +52,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
 
             var parser = new ProjectDefinitionParser(fileManager, directoryManager);
             var awsCredentials = new Mock<AWSCredentials>();
-            var session =  new OrchestratorSession(
+            var session = new OrchestratorSession(
                 await parser.Parse(fullPath),
                 awsCredentials.Object,
                 awsRegion,

--- a/testapps/WebAppNet8WithCustomDockerFile/Dockerfile
+++ b/testapps/WebAppNet8WithCustomDockerFile/Dockerfile
@@ -6,11 +6,11 @@ EXPOSE 8081
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["WebAppNet8.csproj", ""]
-RUN dotnet restore "WebAppNet8.csproj"
+COPY ["WebAppNet8WithCustomDockerFile.csproj", ""]
+RUN dotnet restore "WebAppNet8WithCustomDockerFile.csproj"
 COPY . .
 WORKDIR "/src/"
-RUN dotnet build "WebAppNet8.csproj" -c Release -o /app/build
+RUN dotnet build "WebAppNet8WithCustomDockerFile.csproj" -c Release -o /app/build
 
 FROM build AS publish
 RUN apt-get update -yq \
@@ -20,9 +20,10 @@ RUN apt-get update -yq \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
-RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish
+RUN dotnet publish "WebAppNet8WithCustomDockerFile.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV ASPNETCORE_HTTP_PORTS=80
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "WebAppNet8.dll"]
+ENTRYPOINT ["dotnet", "WebAppNet8WithCustomDockerFile.dll"]

--- a/testapps/WebAppNet8WithCustomDockerFile/Pages/Index.cshtml
+++ b/testapps/WebAppNet8WithCustomDockerFile/Pages/Index.cshtml
@@ -1,0 +1,10 @@
+﻿@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Home page";
+}
+
+<div class="text-center">
+    <h1 class="display-4">Welcome</h1>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div>

--- a/testapps/WebAppNet8WithCustomDockerFile/Pages/Index.cshtml.cs
+++ b/testapps/WebAppNet8WithCustomDockerFile/Pages/Index.cshtml.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace WebApplication1.Pages
+{
+    public class IndexModel : PageModel
+    {
+        private readonly ILogger<IndexModel> _logger;
+
+        public IndexModel(ILogger<IndexModel> logger)
+        {
+            _logger = logger;
+        }
+
+        public void OnGet()
+        {
+
+        }
+    }
+}

--- a/testapps/WebAppNet8WithCustomDockerFile/Pages/Shared/_Layout.cshtml
+++ b/testapps/WebAppNet8WithCustomDockerFile/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,42 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - WebApplication1</title>
+    <link rel="stylesheet" href="~/WebApplication1.styles.css" asp-append-version="true" />
+</head>
+<body>
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+            <div class="container">
+                <a class="navbar-brand" asp-area="" asp-page="/Index">WebApplication1</a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                        aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="container">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            &copy; 2023 - WebApplication1
+        </div>
+    </footer>
+
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/testapps/WebAppNet8WithCustomDockerFile/Pages/_ViewImports.cshtml
+++ b/testapps/WebAppNet8WithCustomDockerFile/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+﻿@using WebApplication1
+@namespace WebApplication1.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/testapps/WebAppNet8WithCustomDockerFile/Pages/_ViewStart.cshtml
+++ b/testapps/WebAppNet8WithCustomDockerFile/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/testapps/WebAppNet8WithCustomDockerFile/Program.cs
+++ b/testapps/WebAppNet8WithCustomDockerFile/Program.cs
@@ -1,0 +1,24 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (!app.Environment.IsDevelopment())
+{
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();

--- a/testapps/WebAppNet8WithCustomDockerFile/WebAppNet8WithCustomDockerFile.csproj
+++ b/testapps/WebAppNet8WithCustomDockerFile/WebAppNet8WithCustomDockerFile.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>2b616a02-f50f-4d6d-86f9-c75edbaeff5f</UserSecretsId>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+  </ItemGroup>
+
+</Project>

--- a/testapps/WebAppNet8WithCustomDockerFile/appsettings.Development.json
+++ b/testapps/WebAppNet8WithCustomDockerFile/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "DetailedErrors": true,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/testapps/WebAppNet8WithCustomDockerFile/appsettings.json
+++ b/testapps/WebAppNet8WithCustomDockerFile/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/testapps/WebAppNoDockerFile/ECSFargateCustomPortConfigFile.json
+++ b/testapps/WebAppNoDockerFile/ECSFargateCustomPortConfigFile.json
@@ -1,0 +1,7 @@
+{
+    "ApplicationName": "{StackName}",
+    "RecipeId": "AspNetAppEcsFargate",
+    "Settings": {
+        "Port": 51200
+    }
+}

--- a/testapps/docker/WebAppNet8/ReferenceDockerfile
+++ b/testapps/docker/WebAppNet8/ReferenceDockerfile
@@ -1,7 +1,8 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER app
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
+EXPOSE 8081
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7201

*Description of changes:*
* Updat dockerfile template with the changes required for .NET8 as well as allow dockerfile templates to conditionally generate the template based on the project target framework.
* Add new a option setting to ECS Fargate deployments that exposes the load balancer port.
* Added a new warning for users that are deploying to port different than the one used in the container. I am using `docker inspect` to access the environment variables in the container after we build it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
