### PR TITLE
docs: remove space to render bold correctly

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -1,6 +1,6 @@
 # About the AWS Deploy Tool for .NET
 
-** AWS Deploy Tool for .NET** is an interactive tool for the .NET CLI and the AWS Toolkit for Visual Studio that helps deploy .NET applications with minimum AWS knowledge, and with the fewest clicks or commands.
+**AWS Deploy Tool for .NET** is an interactive tool for the .NET CLI and the AWS Toolkit for Visual Studio that helps deploy .NET applications with minimum AWS knowledge, and with the fewest clicks or commands.
 
 ### Key capabilities
 


### PR DESCRIPTION
*Description of changes:*

The space cause the text rendered as plain text in the [page](https://aws.github.io/aws-dotnet-deploy/)

![image](https://github.com/aws/aws-dotnet-deploy/assets/26602565/5e21a66e-f8d6-4a5a-8056-3b8eff1cfe2a)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
