### PR TITLE
Merge main -> dev after docs-only "release"

### DIFF
--- a/site/content/index.md
+++ b/site/content/index.md
@@ -1,6 +1,6 @@
 # About the AWS Deploy Tool for .NET
 
-** AWS Deploy Tool for .NET** is an interactive tool for the .NET CLI and the AWS Toolkit for Visual Studio that helps deploy .NET applications with minimum AWS knowledge, and with the fewest clicks or commands.
+**AWS Deploy Tool for .NET** is an interactive tool for the .NET CLI and the AWS Toolkit for Visual Studio that helps deploy .NET applications with minimum AWS knowledge, and with the fewest clicks or commands.
 
 ### Key capabilities
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I merged #799 directly to `main` (skipping `dev`) since it was a docs-only change.

This is merging `main`->`dev` so that change is present in dev as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
