### PR TITLE
chore: revert newtonsoft version bump due to VS Toolkit compatibility

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -320,7 +320,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** Newtonsoft.Json; version 13.0.3 -- https://www.nuget.org/packages/Newtonsoft.Json/
+** Newtonsoft.Json; version 13.0.1 -- https://www.nuget.org/packages/Newtonsoft.Json/
 Copyright (c) 2007 James Newton-King
 ** YamlDotNet; version 13.4.0 -- https://www.nuget.org/packages/YamlDotNet
 Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014 Antoine Aubry and

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.200.42" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.200.42" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.200.43" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" Version="3.7.201.27" />
   </ItemGroup>

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="5.0.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="5.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="13.4.0" />
   </ItemGroup>

--- a/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
+++ b/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
@@ -17,7 +17,9 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.202.11" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.22" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!-- We are pining Newtonsoft.Json to 13.0.1 to maintain compatibility with the VS Toolkit. 
+    https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/-->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*
Revert Newtonsoft version bump from 13.0.3 to 13.0.1 due to VS Toolkit compatibility upon @awschristou's request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
