### PR TITLE
fix: Enable selecting the '.NET 6 on AL2023' platform when deploying to Elastic Beanstalk on Linux

### DIFF
--- a/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
+++ b/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.Constants
         public const string HealthCheckURLOptionNameSpace = "aws:elasticbeanstalk:application";
         public const string HealthCheckURLOptionName = "Application Healthcheck URL";
 
-        public const string LinuxPlatformType = ".NET Core";
+        public const string LinuxPlatformType = ".NET";
         public const string WindowsPlatformType = "Windows Server";
 
         public const string IISAppPathOptionId = "IISAppPath";

--- a/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
+++ b/src/AWS.Deploy.Constants/ElasticBeanstalk.cs
@@ -22,7 +22,7 @@ namespace AWS.Deploy.Constants
         public const string HealthCheckURLOptionNameSpace = "aws:elasticbeanstalk:application";
         public const string HealthCheckURLOptionName = "Application Healthcheck URL";
 
-        public const string LinuxPlatformType = ".NET";
+        public const string LinuxPlatformType = ".NET ";
         public const string WindowsPlatformType = "Windows Server";
 
         public const string IISAppPathOptionId = "IISAppPath";


### PR DESCRIPTION
*Issue #, if available:* #806 (I had tested this quickly when talking to @shruti0085 internally about this issue)

*Description of changes:*

This widens the string we use to filter Beanstalk Platform options when deploying to Linux, to include the new ".NET 6 on AL2023" platform that was [released in October](https://docs.aws.amazon.com/elasticbeanstalk/latest/relnotes/release-2023-10-19-al2023.html).

![image](https://github.com/aws/aws-dotnet-deploy/assets/1170880/9e4b3068-4747-45e2-b124-cd77b6357bdb)

**Considerations**:
* The sort order we're getting back from the service call is what I think we want, so didn't introduce custom sorting like we have for Windows here: https://github.com/aws/aws-dotnet-deploy/blob/03abb117585784ad0fec360e7c5093e37ddf7993/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs#L627
* Per the [docs](https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platform-history-dotnetlinux.html), the new platform only has .NET 6 installed. However our Beanstalk recipes still allow `netcoreapp3.1` or greater:
https://github.com/aws/aws-dotnet-deploy/blob/03abb117585784ad0fec360e7c5093e37ddf7993/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe#L36
Deploying an application with an older target (in this case .NET 5) to the new AL2023 platform results in:
```
Dec  5 22:10:04 ip-172-31-83-112 web[2147]: You must install or update .NET to run this application.
Dec  5 22:10:04 ip-172-31-83-112 web[2147]: App: /var/app/current/ASPNet5.dll
Dec  5 22:10:04 ip-172-31-83-112 web[2147]: Architecture: x64
Dec  5 22:10:04 ip-172-31-83-112 web[2147]: Framework: 'Microsoft.AspNetCore.App', version '5.0.0' (x64)
```

However **this is true even for the recent AL2 platform versions as well**. Unsure if we want to unblock AL2023 initially with this, then better handle the compatibility between the application being deploying and the specific selected platform later? Or try to tackle both issues together



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
