### PR TITLE
Adjust role used by GitHub action that builds docs.

### DIFF
--- a/.github/workflows/DetectDocGeneratorChanges.yml
+++ b/.github/workflows/DetectDocGeneratorChanges.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
       with:
-        role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+        role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
         role-duration-seconds: 7200
         aws-region: us-west-2
     - uses: actions/checkout@v3

--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
         with:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
           role-duration-seconds: 7200
@@ -40,7 +40,7 @@ jobs:
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
 
       - name: Configure Test Runner Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
         with:
           role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200

--- a/.github/workflows/doc-builder.yml
+++ b/.github/workflows/doc-builder.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
         with:
-          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
           aws-region: us-west-2
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
1. Fixes a CI failure on #807. We recently adjusted some internal accounts where we run integration tests, so `CI_AWS_ROLE_ARN` is no longer valid. This reuses the `CI_MAIN_TESTING_ACCOUNT_ROLE_ARN` instead.
    * The doc generator uses server mode, which requires AWS credentials to pass its health check. I didn't actually see it make any requests when running locally.
3. Also upgraded the credential action while here, there was a warning about old Node versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
