### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/DetectCDKBootstrapVersionChanges.yml
+++ b/.github/workflows/DetectCDKBootstrapVersionChanges.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Get Staging Bucket Update/Replace Policy
       id: stagingBucketUpdateReplacePolicy
       run: |
-        echo "::set-output name=update-replace-policy::$(yq '.Resources.StagingBucket.UpdateReplacePolicy' 'src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml')"
+        echo "update-replace-policy=$(yq '.Resources.StagingBucket.UpdateReplacePolicy' 'src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml')" >> $GITHUB_OUTPUT
     - name: Get Staging Bucket Deletion Policy
       id: stagingBucketDeletionPolicy
       run: |
-        echo "::set-output name=deletion-policy::$(yq '.Resources.StagingBucket.DeletionPolicy' 'src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml')"
+        echo "deletion-policy=$(yq '.Resources.StagingBucket.DeletionPolicy' 'src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml')" >> $GITHUB_OUTPUT
     - name: Fail If Update/Replace Policy Not 'Delete'
       if: steps.stagingBucketUpdateReplacePolicy.outputs.update-replace-policy != 'Delete'
       run: |
@@ -38,11 +38,11 @@ jobs:
     - name: Get Latest CDK Bootstrap Version
       id: latestBootstrapVersion
       run: |
-        echo "::set-output name=latest-version::$(yq '.Resources.CdkBootstrapVersion.Properties.Value' 'newTemplate.yml')"
+        echo "latest-version=$(yq '.Resources.CdkBootstrapVersion.Properties.Value' 'newTemplate.yml')" >> $GITHUB_OUTPUT
     - name: Get Current CDK Bootstrap Version
       id: currentBootstrapVersion
       run: |
-        echo "::set-output name=current-version::$(yq '.Resources.CdkBootstrapVersion.Properties.Value' 'src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml')"
+        echo "current-version=$(yq '.Resources.CdkBootstrapVersion.Properties.Value' 'src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml')" >> $GITHUB_OUTPUT
     - name: Fail If CDK Bootstrap Template Changes Detected
       if: steps.currentBootstrapVersion.outputs.current-version != steps.latestBootstrapVersion.outputs.latest-version
       run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,7 +25,7 @@ jobs:
       id: read-current-version
       run: |
         version=$(jq -r ".version" version.json)
-        echo "::set-output name=VERSION::$version"
+        echo "VERSION=$version" >> $GITHUB_OUTPUT
 
     - name: Pull Request
       id: pull-request
@@ -52,7 +52,7 @@ jobs:
         version=$(jq -r .version version.json)
         major=$(echo $version | awk '{split($0, components, "."); print components[1]}')
         minor=$(echo $version | awk '{split($0, components, "."); print components[2]+1}')
-        echo "::set-output name=VERSION::$major.$minor"
+        echo "VERSION=$major.$minor" >> $GITHUB_OUTPUT
 
     - name: Commit and Push next version
       id: commit-push
@@ -66,7 +66,7 @@ jobs:
         git add version.json
         git commit -m "build: version bump to ${{ steps.build-next-version.outputs.VERSION }}"
         git push origin $branch
-        echo "::set-output name=BRANCH::$branch"
+        echo "BRANCH=$branch" >> $GITHUB_OUTPUT
 
     - name: pull-request
       uses: repo-sync/pull-request@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter