### PR TITLE
ci: Disambiguate GitHub job IDs to fix required status checks

### DIFF
--- a/.github/workflows/DetectCDKBootstrapVersionChanges.yml
+++ b/.github/workflows/DetectCDKBootstrapVersionChanges.yml
@@ -3,10 +3,8 @@ name: Detect CDK Bootstrap Version Changes
 on: [pull_request]
 
 jobs:
-  build:
-
+  detect-cdk-bootstrap-changes:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/DetectDocGeneratorChanges.yml
+++ b/.github/workflows/DetectDocGeneratorChanges.yml
@@ -6,10 +6,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-
+  detect-documentation-changes:
     runs-on: ubuntu-latest
-
     steps:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4

--- a/.github/workflows/DetectRestAPIClientChanges.yml
+++ b/.github/workflows/DetectRestAPIClientChanges.yml
@@ -3,10 +3,8 @@ name: Detect Rest API Client Changes
 on: [pull_request]
 
 jobs:
-  build:
-
+  detect-restapi-client-changes:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -16,7 +16,7 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  run-integration-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We noticed while attempting to merge #813 that we were unable to. 
* GitHub checks are failing because the PR is from a fork. Typically a maintainer will review, run tests locally if necessary, then merge despite the failures. 
* However we recently cleaned up our GitHub team structure, which removed the ability to merge despite failing checks for most maintainers.
* This repository is configured to require on the `build` status check, but we had used that name across different actions, so more were required than what we intended.

I think this was unintentional, so I'm renaming these actions so that the only `build` one is the build+unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
