### PR TITLE
Fix escaping for Lambda invocation that selects which account to run integration tests in

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: lambda
         shell: pwsh
         run: |
-          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{\"Roles\": \"${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}\", \"ProjectName\": \"${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}\", \"Branch\": \"${{ github.sha }}\"}'
+          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Roles": "${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}", "ProjectName": "${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}", "Branch": "${{ github.sha }}"}'
           $roleArn=$(cat ./response.json)
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Same as https://github.com/awslabs/aws-dotnet-messaging/pull/94, I'm still not sure what changed that led to this but fixing it up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
