### PR TITLE
chore: Add debugger display hints for servermode clients

### DIFF
--- a/src/AWS.Deploy.ServerMode.Client/AnnotatedModels.cs
+++ b/src/AWS.Deploy.ServerMode.Client/AnnotatedModels.cs
@@ -19,4 +19,14 @@ namespace AWS.Deploy.ServerMode.Client
     public partial class RecommendationSummary
     {
     }
+
+    [DebuggerDisplay(value: "{DisplayName}")]
+    public partial class TypeHintResourceColumn
+    {
+    }
+
+    [DebuggerDisplay(value: "SystemName: {SystemName}, DisplayName: {DisplayName}")]
+    public partial class TypeHintResourceSummary
+    {
+    }
 }


### PR DESCRIPTION
This change adds the `DebuggerDisplay` attribute to more models that get visually inspected when debugging in the Toolkit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
