### PR TITLE
chore: Update the version of Amazon.CDK.Lib that is referenced by the recipe CDK projects

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -21,7 +21,7 @@
 ** AWSSDK.ElasticLoadBalancingV2; version 3.7.201.27 -- https://www.nuget.org/packages/AWSSDK.ElasticLoadBalancingV2/
 ** AWSSDK.Core; version 3.7.202.11 -- https://www.nuget.org/packages/AWSSDK.Core
 ** AWSSDK.CloudWatchLogs; version 3.7.200.42 -- https://www.nuget.org/packages/AWSSDK.CloudWatchLogs
-** Amazon.CDK.Lib; version 2.43.1 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
+** Amazon.CDK.Lib; version 2.131.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
  
 Apache License
 Version 2.0, January 2004

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -193,7 +193,7 @@ namespace AspNetAppElasticBeanstalkLinux
                     ApplicationName = beanstalkApplicationName
                 }));
 
-                ApplicationVersion.AddDependsOn(BeanstalkApplication);
+                ApplicationVersion.AddDependency(BeanstalkApplication);
             }
 
             return beanstalkApplicationName;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Recipe.cs
@@ -193,7 +193,7 @@ namespace AspNetAppElasticBeanstalkWindows
                     ApplicationName = beanstalkApplicationName
                 }));
 
-                ApplicationVersion.AddDependsOn(BeanstalkApplication);
+                ApplicationVersion.AddDependency(BeanstalkApplication);
             }
 
             return beanstalkApplicationName;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs
@@ -132,6 +132,7 @@ namespace BlazorWasm
                     var loggingBucket = new Bucket(this, nameof(AccessLoggingBucket), InvokeCustomizeCDKPropsEvent(nameof(AccessLoggingBucket), this, new BucketProps
                     {
                         RemovalPolicy = RemovalPolicy.RETAIN,
+                        AccessControl = BucketAccessControl.LOG_DELIVERY_WRITE
                     }));
 
                     distributionProps.LogBucket = loggingBucket;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.43.1" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 

Our integration tests began failing for the Blazor recipe:
* Example CI failure: https://github.com/aws/aws-dotnet-deploy/actions/runs/8193118953/job/22406129833
  > 2024-03-07T18:42:09.0042659Z BlazorWasm60c01024a63d82 |  6/14 | 6:37:45 PM | CREATE_FAILED        | AWS::Lambda::Function                           | Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler (CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F) Resource handler returned message: "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs20.x) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 3674fb8b-b71f-4624-a88d-3df206a02179)" (RequestToken: f152ff23-1334-fc62-7d71-aba03b7982cb, HandlerErrorCode: InvalidRequest)

By setting `AutoDeleteObjects` on the S3 bucket in the recipe to true, a CDK-defined Node 14 Lambda is deployed (which is [no longer supported as of 1/19/24](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated)):
https://github.com/aws/aws-dotnet-deploy/blob/5505e4042a4759c762deef9683824b88bec3ea28/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs#L57

This updates the `Amazon.CDK.Lib` for all of the recipes to the latest. I believe they went to Node 18 for custom resources in 2.87 via https://github.com/aws/aws-cdk/pull/26212.
* [WIP] - I haven't done any manual testing yet. Not sure if we might have any issues where a project deployed via 2.43.1 might fail to redeploy on 2.131.0, which we don't have covered by the current automated tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
