### PR TITLE
Adjust Security Group type hints to show the group name and id

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSecurityGroupsCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/ExistingSecurityGroupsCommand.cs
@@ -52,7 +52,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
             foreach (var securityGroup in securityGroups.OrderBy(securityGroup => securityGroup.VpcId))
             {
-                var row = new TypeHintResource(securityGroup.GroupId, securityGroup.GroupId);
+                var row = new TypeHintResource(securityGroup.GroupId, $"{securityGroup.GroupName} ({securityGroup.GroupId})");
                 row.ColumnValues.Add(securityGroup.GroupName);
                 row.ColumnValues.Add(securityGroup.GroupId);
                 row.ColumnValues.Add(securityGroup.VpcId);

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/ExistingSecurityGroubsCommandTest.cs
@@ -68,15 +68,16 @@ namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
                 {
                     new SecurityGroup()
                     {
-                        GroupId = "group1"
+                        GroupId = "group1-id",
+                        GroupName = "group1-name"
                     }
                 });
 
             var resources = await command.GetResources(appRunnerRecommendation, securityGroupsOptionSetting);
 
             Assert.Single(resources.Rows);
-            Assert.Equal("group1", resources.Rows[0].DisplayName);
-            Assert.Equal("group1", resources.Rows[0].SystemName);
+            Assert.Equal("group1-name (group1-id)", resources.Rows[0].DisplayName);
+            Assert.Equal("group1-id", resources.Rows[0].SystemName);
         }
 
         [Fact]


### PR DESCRIPTION
Security Group IDs don't provide enough context on their own for users to choose the right ones from their account. We received Toolkit feedback that users ended up logging into the web console in order to verify they are selecting the correct security group(s) when deploying their project.

This change updates the display value for security groups, so that it shows the group name and id.

Here is an example using this change:
![image](https://github.com/aws/aws-dotnet-deploy/assets/39839589/22e3edc4-4757-4ff3-ba66-575669d5d769)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
