### PR TITLE
feat: Add a "aws-dotnet-deply" tag to ECR repositories that are created during deployment if an existing repository is not provided.

### DIFF
--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -73,7 +73,15 @@ namespace AWS.Deploy.Common.Data
         Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType platformType);
         Task<List<AuthorizationData>> GetECRAuthorizationToken();
         Task<List<Repository>> GetECRRepositories(List<string>? repositoryNames = null);
-        Task<Repository> CreateECRRepository(string repositoryName);
+
+        /// <summary>
+        /// Creates a new ECR repository
+        /// </summary>
+        /// <param name="repositoryName">The name to use for the repository</param>
+        /// <param name="recipeId">The id of the recipe that's being deployd, set as the value of the "aws-dotnet-deploy" tag</param>
+        /// <returns>The repository that was created</returns>
+        Task<Repository> CreateECRRepository(string repositoryName, string recipeId);
+
         Task<List<Stack>> GetCloudFormationStacks();
         Task<Stack?> GetCloudFormationStack(string stackName);
         Task<GetCallerIdentityResponse> GetCallerIdentity(string awsRegion);

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -97,7 +97,7 @@ namespace AWS.Deploy.Orchestration
             await InitiateDockerLogin();
 
             var tagSuffix = sourceTag.Split(":")[1];
-            var repository = await SetupECRRepository(repositoryName);
+            var repository = await SetupECRRepository(repositoryName, recommendation.Recipe.Id);
             var targetTag = $"{repository.RepositoryUri}:{tagSuffix}";
 
             await TagDockerImage(sourceTag, targetTag);
@@ -234,7 +234,7 @@ namespace AWS.Deploy.Orchestration
             }
         }
 
-        private async Task<Repository> SetupECRRepository(string ecrRepositoryName)
+        private async Task<Repository> SetupECRRepository(string ecrRepositoryName, string recipeId)
         {
             var existingRepositories = await _awsResourceQueryer.GetECRRepositories(new List<string> { ecrRepositoryName });
 
@@ -244,7 +244,7 @@ namespace AWS.Deploy.Orchestration
             }
             else
             {
-                return await _awsResourceQueryer.CreateECRRepository(ecrRepositoryName);
+                return await _awsResourceQueryer.CreateECRRepository(ecrRepositoryName, recipeId);
             }
         }
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -31,7 +31,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         }
 
         public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
-        public Task<Repository> CreateECRRepository(string repositoryName) => throw new NotImplementedException();
+        public Task<Repository> CreateECRRepository(string repositoryName, string recipeId) => throw new NotImplementedException();
         public Task<List<StackResource>> DescribeCloudFormationResources(string stackName) => throw new NotImplementedException();
         public Task<DescribeRuleResponse> DescribeCloudWatchRule(string ruleName) => throw new NotImplementedException();
         public Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentId) => throw new NotImplementedException();

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -28,7 +28,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn) => throw new NotImplementedException();
 
         public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
-        public Task<Repository> CreateECRRepository(string repositoryName) => throw new NotImplementedException();
+        public Task<Repository> CreateECRRepository(string repositoryName, string recipeId) => throw new NotImplementedException();
         public Task<List<Stack>> GetCloudFormationStacks() => throw new NotImplementedException();
         public Task<Stack> GetCloudFormationStack(string stackName) => throw new NotImplementedException();
 


### PR DESCRIPTION
*Issue #, if available:* N/A, from internal discussion around #823 

*Description of changes:* Adds the "aws-dotnet-deploy" tag to newly created ECR repositories. This will allow us to clean these up more easily after integration tests and canaries.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
