### PR TITLE
chore: update CDK version used by Recipes

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -21,7 +21,7 @@
 ** AWSSDK.ElasticLoadBalancingV2; version 3.7.302.33 -- https://www.nuget.org/packages/AWSSDK.ElasticLoadBalancingV2/
 ** AWSSDK.Core; version 3.7.303.20 -- https://www.nuget.org/packages/AWSSDK.Core
 ** AWSSDK.CloudWatchLogs; version 3.7.305.18 -- https://www.nuget.org/packages/AWSSDK.CloudWatchLogs
-** Amazon.CDK.Lib; version 2.131.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
+** Amazon.CDK.Lib; version 2.146.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
  
 Apache License
 Version 2.0, January 2004

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.131.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.146.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7536

*Description of changes:*
* Update CDK version used by Recipes to 2.146.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
