### PR TITLE
feat: Expose Load Balancer Scheme for EB Recipes

### DIFF
--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Linux.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Linux.md
@@ -42,6 +42,10 @@
     * ID: LoadBalancerType
     * Description: The type of load balancer for your environment.
     * Type: String
+* **Load Balancer Scheme**
+    * ID: LoadBalancerScheme
+    * Description: Specify "Internal" if your application serves requests only from connected VPCs. "Public" load balancers serve requests from the Internet.
+    * Type: String
 * **Application IAM Role**
     * ID: ApplicationIAMRole
     * Description: The Identity and Access Management (IAM) role that provides AWS credentials to the application to access AWS services.

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Windows.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Windows.md
@@ -37,6 +37,10 @@
     * ID: LoadBalancerType
     * Description: The type of load balancer for your environment.
     * Type: String
+* **Load Balancer Scheme**
+    * ID: LoadBalancerScheme
+    * Description: Specify "Internal" if your application serves requests only from connected VPCs. "Public" load balancers serve requests from the Internet.
+    * Type: String
 * **Application IAM Role**
     * ID: ApplicationIAMRole
     * Description: The Identity and Access Management (IAM) role that provides AWS credentials to the application to access AWS services.

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -54,6 +54,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         public string LoadBalancerType { get; set; } = Recipe.LOADBALANCERTYPE_APPLICATION;
 
         /// <summary>
+        /// Whether the load balancer is visibile to the public internet ("public") or only to the connected VPC ("internal").
+        /// </summary>
+        public string LoadBalancerScheme { get; set; } = Recipe.LOADBALANCERSCHEME_PUBLIC;
+
+        /// <summary>
         /// The EC2 Key Pair used for the Beanstalk Application.
         /// </summary>
         public string EC2KeyPair { get; set; }
@@ -131,7 +136,8 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
             string reverseProxy = Recipe.REVERSEPROXY_NGINX,
             bool xrayTracingSupportEnabled = false,
-            string enhancedHealthReporting = Recipe.ENHANCED_HEALTH_REPORTING)
+            string enhancedHealthReporting = Recipe.ENHANCED_HEALTH_REPORTING,
+            string loadBalancerScheme = Recipe.LOADBALANCERSCHEME_PUBLIC)
         {
             ApplicationIAMRole = applicationIAMRole;
             ServiceIAMRole = serviceIAMRole;
@@ -146,6 +152,7 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
             VPC = vpc;
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
+            LoadBalancerScheme = loadBalancerScheme;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;
             ReverseProxy = reverseProxy;
             EnhancedHealthReporting = enhancedHealthReporting;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Recipe.cs
@@ -31,6 +31,7 @@ namespace AspNetAppElasticBeanstalkLinux
         public const string ENVIRONMENTTYPE_LOADBALANCED = "LoadBalanced";
 
         public const string LOADBALANCERTYPE_APPLICATION = "application";
+        public const string LOADBALANCERSCHEME_PUBLIC = "public";
 
         public const string REVERSEPROXY_NGINX = "nginx";
         
@@ -249,14 +250,19 @@ namespace AspNetAppElasticBeanstalkLinux
 
             if (settings.EnvironmentType.Equals(ENVIRONMENTTYPE_LOADBALANCED))
             {
-                optionSettingProperties.Add(
-                    new CfnEnvironment.OptionSettingProperty
-                    {
-                        Namespace = "aws:elasticbeanstalk:environment",
-                        OptionName = "LoadBalancerType",
-                        Value = settings.LoadBalancerType
-                    }
-                );
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:elasticbeanstalk:environment",
+                    OptionName = "LoadBalancerType",
+                    Value = settings.LoadBalancerType
+                });
+
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:ec2:vpc",
+                    OptionName = "ELBScheme",
+                    Value = settings.LoadBalancerScheme
+                });
 
                 if (!string.IsNullOrEmpty(settings.HealthCheckURL))
                 {

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Configurations/Configuration.cs
@@ -54,6 +54,11 @@ namespace AspNetAppElasticBeanstalkWindows.Configurations
         public string LoadBalancerType { get; set; } = Recipe.LOADBALANCERTYPE_APPLICATION;
 
         /// <summary>
+        /// Whether the load balancer is visibile to the public internet ("public") or only to the connected VPC ("internal").
+        /// </summary>
+        public string LoadBalancerScheme { get; set; } = Recipe.LOADBALANCERSCHEME_PUBLIC;
+
+        /// <summary>
         /// The EC2 Key Pair used for the Beanstalk Application.
         /// </summary>
         public string EC2KeyPair { get; set; }
@@ -135,7 +140,8 @@ namespace AspNetAppElasticBeanstalkWindows.Configurations
             string environmentType = Recipe.ENVIRONMENTTYPE_SINGLEINSTANCE,
             string loadBalancerType = Recipe.LOADBALANCERTYPE_APPLICATION,
             bool xrayTracingSupportEnabled = false,
-            string enhancedHealthReporting = Recipe.ENHANCED_HEALTH_REPORTING)
+            string enhancedHealthReporting = Recipe.ENHANCED_HEALTH_REPORTING,
+            string loadBalancerScheme = Recipe.LOADBALANCERSCHEME_PUBLIC)
         {
             ApplicationIAMRole = applicationIAMRole;
             ServiceIAMRole = serviceIAMRole;
@@ -150,6 +156,7 @@ namespace AspNetAppElasticBeanstalkWindows.Configurations
             VPC = vpc;
             EnvironmentType = environmentType;
             LoadBalancerType = loadBalancerType;
+            LoadBalancerScheme = loadBalancerScheme;
             XRayTracingSupportEnabled = xrayTracingSupportEnabled;
             EnhancedHealthReporting = enhancedHealthReporting;
             HealthCheckURL = healthCheckURL;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Recipe.cs
@@ -31,6 +31,7 @@ namespace AspNetAppElasticBeanstalkWindows
         public const string ENVIRONMENTTYPE_LOADBALANCED = "LoadBalanced";
 
         public const string LOADBALANCERTYPE_APPLICATION = "application";
+        public const string LOADBALANCERSCHEME_PUBLIC = "public";
 
         public const string REVERSEPROXY_NGINX = "nginx";
         
@@ -257,6 +258,13 @@ namespace AspNetAppElasticBeanstalkWindows
                         Value = settings.LoadBalancerType
                     }
                 );
+
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:ec2:vpc",
+                    OptionName = "ELBScheme",
+                    Value = settings.LoadBalancerScheme
+                });
 
                 if (!string.IsNullOrEmpty(settings.HealthCheckURL))
                 {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -306,7 +306,7 @@
             "Id": "LoadBalancerScheme",
             "Name": "Load Balancer Scheme",
             "Category": "LoadBalancer",
-            "Description": "Specify \"Internal\" if your application serves requests only from connected VPCs. Public load balancers serve requests from the Internet.",
+            "Description": "Specify \"Internal\" if your application serves requests only from connected VPCs. \"Public\" load balancers serve requests from the Internet.",
             "Type": "String",
             "DefaultValue": "public",
             "AllowedValues": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -107,7 +107,7 @@
         },
         {
             "Id": "LoadBalancer",
-            "DisplayName": "LoadBalancer",
+            "DisplayName": "Load Balancer",
             "Order": 70
         },
         {
@@ -297,6 +297,34 @@
                 {
                     "Id": "EnvironmentType",
                     "Value": "LoadBalanced"
+                }
+            ],
+            "AdvancedSetting": true,
+            "Updatable": true
+        },
+        {
+            "Id": "LoadBalancerScheme",
+            "Name": "Load Balancer Scheme",
+            "Category": "LoadBalancer",
+            "Description": "Specify \"Internal\" if your application serves requests only from connected VPCs. Public load balancers serve requests from the Internet.",
+            "Type": "String",
+            "DefaultValue": "public",
+            "AllowedValues": [
+                "public",
+                "internal"
+            ],
+            "ValueMapping": {
+                "public": "Public",
+                "internal": "Internal"
+            },
+            "DependsOn": [
+                {
+                    "Id": "EnvironmentType",
+                    "Value": "LoadBalanced"
+                },
+                {
+                    "Id": "VPC.UseVPC",
+                    "Value": true
                 }
             ],
             "AdvancedSetting": true,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -107,7 +107,7 @@
         },
         {
             "Id": "LoadBalancer",
-            "DisplayName": "LoadBalancer",
+            "DisplayName": "Load Balancer",
             "Order": 70
         },
         {
@@ -286,6 +286,34 @@
                 {
                     "Id": "EnvironmentType",
                     "Value": "LoadBalanced"
+                }
+            ],
+            "AdvancedSetting": true,
+            "Updatable": true
+        },
+        {
+            "Id": "LoadBalancerScheme",
+            "Name": "Load Balancer Scheme",
+            "Category": "LoadBalancer",
+            "Description": "Specify \"Internal\" if your application serves requests only from connected VPCs. Public load balancers serve requests from the Internet.",
+            "Type": "String",
+            "DefaultValue": "public",
+            "AllowedValues": [
+                "public",
+                "internal"
+            ],
+            "ValueMapping": {
+                "public": "Public",
+                "internal": "Internal"
+            },
+            "DependsOn": [
+                {
+                    "Id": "EnvironmentType",
+                    "Value": "LoadBalanced"
+                },
+                {
+                    "Id": "VPC.UseVPC",
+                    "Value": true
                 }
             ],
             "AdvancedSetting": true,

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -295,7 +295,7 @@
             "Id": "LoadBalancerScheme",
             "Name": "Load Balancer Scheme",
             "Category": "LoadBalancer",
-            "Description": "Specify \"Internal\" if your application serves requests only from connected VPCs. Public load balancers serve requests from the Internet.",
+            "Description": "Specify \"Internal\" if your application serves requests only from connected VPCs. \"Public\" load balancers serve requests from the Internet.",
             "Type": "String",
             "DefaultValue": "public",
             "AllowedValues": [

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
@@ -11,6 +11,7 @@
     "InstanceType": "",
     "EnvironmentType": "LoadBalanced",
     "LoadBalancerType": "application",
+    "LoadBalancerScheme": "public",
     "ApplicationIAMRole": {
       "CreateNew": true
     },


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7553

*Description of changes:* 

This adds a new option setting for "Load Balancer Scheme" to Linux and Windows Elastic Beanstalk recipes.
![image](https://github.com/aws/aws-dotnet-deploy/assets/1170880/771dbe9b-85e9-4655-9fa0-6d3eaa8a155d)

This is only visible when:
* Deploying a Load Balanced application (as opposed to single instance)
* Deploying into a VPC (otherwise it's implicitly "public")

This corresponds to the `ELBScheme` option in the `aws:ec2:vpc` namespace: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-ec2vpc

**Note:** I didn't add an integration test for this because it requires valid VPC selections, and I don't believe we're covering every possible option. Let me know if you think we should add one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
