### PR TITLE
feat: Remove disabled fields from showing on redeployment in server mode

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -208,7 +208,9 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                     Value = optionSettingHandler.GetOptionSettingValue(recommendation, setting),
                     Advanced = setting.AdvancedSetting,
                     ReadOnly = recommendation.IsExistingCloudApplication && !setting.Updatable,
-                    Visible = optionSettingHandler.IsOptionSettingDisplayable(recommendation, setting),
+                    Visible =
+                        optionSettingHandler.IsOptionSettingDisplayable(recommendation, setting) &&
+                        !(recommendation.IsExistingCloudApplication && !setting.Updatable && !setting.VisibleOnRedeployment),
                     SummaryDisplayable = optionSettingHandler.IsSummaryDisplayable(recommendation, setting),
                     AllowedValues = setting.AllowedValues,
                     ValueMapping = setting.ValueMapping,

--- a/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Controllers/DeploymentController.cs
@@ -200,7 +200,12 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
 
             foreach (var setting in configurableOptionSettings)
             {
-                var settingSummary = new OptionSettingItemSummary(setting.Id, setting.FullyQualifiedId, setting.Name, setting.Description, setting.Type.ToString())
+                var settingSummary = new OptionSettingItemSummary(
+                    setting.Id,
+                    setting.FullyQualifiedId,
+                    setting.Name,
+                    setting.Description,
+                    setting.Type.ToString())
                 {
                     Category = setting.Category,
                     TypeHint = setting.TypeHint?.ToString(),
@@ -210,6 +215,8 @@ namespace AWS.Deploy.CLI.ServerMode.Controllers
                     ReadOnly = recommendation.IsExistingCloudApplication && !setting.Updatable,
                     Visible =
                         optionSettingHandler.IsOptionSettingDisplayable(recommendation, setting) &&
+                        // Updating visibility of settings in server-mode to be determined by 'VisibleOnRedeployment'
+                        // when performing a redeployment and 'Updatable' is set to false.
                         !(recommendation.IsExistingCloudApplication && !setting.Updatable && !setting.VisibleOnRedeployment),
                     SummaryDisplayable = optionSettingHandler.IsSummaryDisplayable(recommendation, setting),
                     AllowedValues = setting.AllowedValues,

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingItem.cs
@@ -125,6 +125,11 @@ namespace AWS.Deploy.Common.Recipes
         public bool Updatable { get; set; }
 
         /// <summary>
+        /// If the value is true, the setting will be displayed during a redeployment. This only applies to server-mode clients.
+        /// </summary>
+        public bool VisibleOnRedeployment { get; set; }
+
+        /// <summary>
         /// List of all validators that should be run when configuring this OptionSettingItem.
         /// </summary>
         public List<OptionSettingItemValidatorConfig> Validators { get; set; } = new ();

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -289,6 +289,7 @@
             "Type": "String",
             "AdvancedSetting": true,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -100,6 +100,7 @@
             "TypeHint": "AppRunnerService",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "DefaultValue": "{StackName}-service",
             "Validators": [
                 {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -118,6 +118,7 @@
             "TypeHint": "ECSCluster",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -136,6 +137,7 @@
                     "TypeHint": "ExistingECSCluster",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
@@ -160,6 +162,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
@@ -195,6 +198,7 @@
             "DefaultValue": "{StackName}-service",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",
@@ -738,7 +742,8 @@
                     "Type": "Bool",
                     "DefaultValue": true,
                     "AdvancedSetting": false,
-                    "Updatable": false
+                    "Updatable": false,
+                    "VisibleOnRedeployment": true
                 }
             ]
         },

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -308,6 +308,7 @@
             "TypeHint": "Vpc",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "IsDefault",
@@ -364,6 +365,7 @@
                     "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
@@ -537,6 +539,7 @@
                     "DefaultValue": null,
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -319,6 +319,7 @@
             },
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -340,6 +341,7 @@
                     },
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "ApplicationIAMRole.CreateNew",
@@ -370,6 +372,7 @@
             },
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -391,6 +394,7 @@
                     },
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "ServiceIAMRole.CreateNew",
@@ -419,6 +423,7 @@
             "DefaultValue": "",
             "AdvancedSetting": true,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",
@@ -798,6 +803,7 @@
                     "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": true,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -137,6 +137,7 @@
             "TypeHint": "BeanstalkApplication",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -155,6 +156,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "BeanstalkApplication.CreateNew",
@@ -187,6 +189,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "BeanstalkApplication.CreateNew",
@@ -215,6 +218,7 @@
             "Type": "Object",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "EnvironmentName",
@@ -225,6 +229,7 @@
                     "DefaultValue": "{StackName}-dev",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -137,6 +137,7 @@
             "TypeHint": "BeanstalkApplication",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -155,6 +156,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "BeanstalkApplication.CreateNew",
@@ -187,6 +189,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "BeanstalkApplication.CreateNew",
@@ -216,6 +219,7 @@
             "DefaultValue": "{StackName}-dev",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -307,6 +307,7 @@
             },
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -328,6 +329,7 @@
                     },
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "ApplicationIAMRole.CreateNew",
@@ -358,6 +360,7 @@
             },
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -379,6 +382,7 @@
                     },
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "DependsOn": [
                         {
                             "Id": "ServiceIAMRole.CreateNew",
@@ -407,6 +411,7 @@
             "DefaultValue": "",
             "AdvancedSetting": true,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",
@@ -792,6 +797,7 @@
                     "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": true,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -136,6 +136,7 @@
             "TypeHint": "ECSCluster",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -154,6 +155,7 @@
                     "TypeHint": "ExistingECSCluster",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
@@ -178,6 +180,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -326,6 +326,7 @@
                     "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -340,6 +340,7 @@
             "TypeHint": "Vpc",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "IsDefault",
@@ -396,6 +397,7 @@
                     "DefaultValue": "{DefaultVpcId}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -176,6 +176,7 @@
             "TypeHint": "ECSCluster",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "ChildOptionSettings": [
                 {
                     "Id": "CreateNew",
@@ -194,6 +195,7 @@
                     "TypeHint": "ExistingECSCluster",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
@@ -218,6 +220,7 @@
                     "DefaultValue": "{StackName}",
                     "AdvancedSetting": false,
                     "Updatable": false,
+                    "VisibleOnRedeployment": true,
                     "Validators": [
                         {
                             "ValidatorType": "Regex",
@@ -247,6 +250,7 @@
             "DefaultValue": "{StackName}-service",
             "AdvancedSetting": false,
             "Updatable": false,
+            "VisibleOnRedeployment": true,
             "Validators": [
                 {
                     "ValidatorType": "Regex",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -587,6 +587,12 @@
                     "description": "If the setting is false the setting can not be changed during redeployment.",
                     "minLength": 1
                 },
+                "VisibleOnRedeployment": {
+                    "type": "boolean",
+                    "title": "VisibleOnRedeployment",
+                    "description": "If the value is true, the setting will be displayed during a redeployment. This only applies to server-mode clients.",
+                    "minLength": 1
+                },
                 "DependsOn": {
                     "type": "array",
                     "title": "",

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerModeTests.cs
@@ -262,7 +262,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
                 var settings = await restClient.GetConfigSettingsAsync(redeploymentSessionId);
 
                 Assert.True(settings.OptionSettings.First(x => x.Id.Equals("ServiceName")).Visible);
-                Assert.False(settings.OptionSettings.First(x => x.Id.Equals("EncryptionKmsKey")).Visible);
+                Assert.True(settings.OptionSettings.First(x => x.Id.Equals("EncryptionKmsKey")).Visible);
             }
             finally
             {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6316

*Description of changes:*
* Added a 'VisibileOnRedeployment' boolean on the option settings in the Recipe which determines the visibility of a setting during a redeployment when 'Updatable' is false
* The setting is false by default, meaning any setting with 'Updatable' = false will not be visible during redeployment.
* I have set the fields that have important names as visible during redeployment
* I have tested this behavior with the toolkit and CLI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
