### PR TITLE
fix: remove auto self-contained build for .NET 8 beanstalk deployments

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetBeanstalkPlatformArnCommand.cs
@@ -28,14 +28,14 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             _optionSettingHandler = optionSettingHandler;
         }
 
-        private async Task<List<PlatformSummary>> GetData()
+        private async Task<List<PlatformSummary>> GetData(Recommendation recommendation)
         {
-            return await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(BeanstalkPlatformType.Linux);
+            return await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(recommendation.ProjectDefinition.TargetFramework, BeanstalkPlatformType.Linux);
         }
 
         public async Task<TypeHintResourceTable> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            var platformArns = await GetData();
+            var platformArns = await GetData(recommendation);
 
             var resourceTable = new TypeHintResourceTable
             {

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetWindowsBeanstalkPlatformArnCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/DotnetWindowsBeanstalkPlatformArnCommand.cs
@@ -28,14 +28,14 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             _optionSettingHandler = optionSettingHandler;
         }
 
-        private async Task<List<PlatformSummary>> GetData()
+        private async Task<List<PlatformSummary>> GetData(Recommendation recommendation)
         {
-            return await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(BeanstalkPlatformType.Windows);
+            return await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(recommendation.ProjectDefinition.TargetFramework, BeanstalkPlatformType.Windows);
         }
 
         public async Task<TypeHintResourceTable> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
         {
-            var platformArns = await GetData();
+            var platformArns = await GetData(recommendation);
 
             var resourceTable = new TypeHintResourceTable
             {

--- a/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
@@ -256,15 +256,15 @@ namespace AWS.Deploy.CLI.ServerMode.Services
         }
 
         /// <inheritdoc/>
-        public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(params BeanstalkPlatformType[]? platformTypes)
+        public async Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(string? targetFramework, params BeanstalkPlatformType[]? platformTypes)
         {
-            return (await GetAndCache(async () => await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(platformTypes), new object?[] { platformTypes }))!;
+            return (await GetAndCache(async () => await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(targetFramework, platformTypes), new object?[] { platformTypes }))!;
         }
 
         /// <inheritdoc/>
-        public async Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType platformType)
+        public async Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(string? targetFramework, BeanstalkPlatformType platformType)
         {
-            return (await GetAndCache(async () => await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(platformType), new object[] { platformType }))!;
+            return (await GetAndCache(async () => await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(targetFramework, platformType), new object[] { platformType }))!;
         }
 
         /// <inheritdoc/>

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -69,8 +69,8 @@ namespace AWS.Deploy.Common.Data
         Task<string> CreateEC2KeyPair(string keyName, string saveLocation);
         Task<List<Role>> ListOfIAMRoles(string? servicePrincipal);
         Task<List<Vpc>> GetListOfVpcs();
-        Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(params BeanstalkPlatformType[]? platformTypes);
-        Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType platformType);
+        Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(string? targetFramework, params BeanstalkPlatformType[]? platformTypes);
+        Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(string? targetFramework, BeanstalkPlatformType platformType);
         Task<List<AuthorizationData>> GetECRAuthorizationToken();
         Task<List<Repository>> GetECRRepositories(List<string>? repositoryNames = null);
 

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -128,8 +128,7 @@ namespace AWS.Deploy.Common
         FailedToSaveDeploymentSettings = 10010600,
         InvalidWindowsManifestFile = 10010700,
         UserDeploymentFileNotFound = 10010800,
-        DockerInspectFailed = 10004200,
-        InvalidElasticBeanstalkPlatform = 10010900
+        DockerInspectFailed = 10004200
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -129,6 +129,7 @@ namespace AWS.Deploy.Common
         InvalidWindowsManifestFile = 10010700,
         UserDeploymentFileNotFound = 10010800,
         DockerInspectFailed = 10004200,
+        InvalidElasticBeanstalkPlatform = 10010900
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
@@ -370,6 +370,10 @@ Resources:
             Resource:
               - Fn::Sub: ${StagingBucket.Arn}
               - Fn::Sub: ${StagingBucket.Arn}/*
+            Condition:
+              StringEquals:
+                aws:ResourceAccount:
+                  - Fn::Sub: ${AWS::AccountId}
             Effect: Allow
           - Action:
               - kms:Decrypt
@@ -585,7 +589,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: /cdk-bootstrap/${Qualifier}/version
-      Value: "20"
+      Value: "21"
 Outputs:
   BucketName:
     Description: The name of the S3 bucket owned by the CDK toolkit stack

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -43,6 +44,7 @@ namespace AWS.Deploy.Orchestration
         private readonly IDirectoryManager _directoryManager;
         private readonly IZipFileManager _zipFileManager;
         private readonly IFileManager _fileManager;
+        private readonly IOptionSettingHandler _optionSettingHandler;
 
         public DeploymentBundleHandler(
             ICommandLineWrapper commandLineWrapper,
@@ -50,7 +52,8 @@ namespace AWS.Deploy.Orchestration
             IOrchestratorInteractiveService interactiveService,
             IDirectoryManager directoryManager,
             IZipFileManager zipFileManager,
-            IFileManager fileManager)
+            IFileManager fileManager,
+            IOptionSettingHandler optionSettingHandler)
         {
             _commandLineWrapper = commandLineWrapper;
             _awsResourceQueryer = awsResourceQueryer;
@@ -58,6 +61,7 @@ namespace AWS.Deploy.Orchestration
             _directoryManager = directoryManager;
             _zipFileManager = zipFileManager;
             _fileManager = fileManager;
+            _optionSettingHandler = optionSettingHandler;
         }
 
         public async Task BuildDockerImage(CloudApplication cloudApplication, Recommendation recommendation, string imageTag)
@@ -108,21 +112,70 @@ namespace AWS.Deploy.Orchestration
             recommendation.DeploymentBundle.ECRImageTag = tagSuffix;
         }
 
+        /// <summary>
+        /// The supported .NET versions on Elastic Beanstalk are dependent on the available platform versions.
+        /// These versions do not always have the required .NET runtimes installed so we need to perform extra checks
+        /// and perform a self-contained publish when creating the deployment bundle if needed.
+        /// </summary>
+        private void SwitchToSelfContainedBuildIfNeeded(Recommendation recommendation)
+        {
+            if (recommendation.Recipe.TargetService == RecipeIdentifier.TARGET_SERVICE_ELASTIC_BEANSTALK)
+            {
+                var targetFramework = recommendation.ProjectDefinition.TargetFramework ?? string.Empty;
+
+                // Elastic Beanstalk doesn't currently have .NET 7 preinstalled.
+                var unavailableFramework = new List<string> { "net7.0" };
+                var frameworkNames = new Dictionary<string, string> { { "net7.0", ".NET 7" } };
+                if (unavailableFramework.Contains(targetFramework))
+                {
+                    _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have {frameworkNames[targetFramework]} preinstalled");
+                    recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
+                    return;
+                }
+
+                var beanstalkPlatformSetting = recommendation.Recipe.OptionSettings.FirstOrDefault(x => x.Id.Equals("ElasticBeanstalkPlatformArn"));
+                if (beanstalkPlatformSetting != null)
+                {
+                    var beanstalkPlatformSettingValue = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, beanstalkPlatformSetting);
+                    var beanstalkPlatformSettingValueSplit = beanstalkPlatformSettingValue?.Split("/");
+                    if (beanstalkPlatformSettingValueSplit?.Length != 3)
+                        throw new InvalidElasticBeanstalkPlatformException(DeployToolErrorCode.InvalidElasticBeanstalkPlatform, $"The selected Elastic Beanstalk platform version '{beanstalkPlatformSettingValue}' is invalid.");
+                    var beanstalkPlatformName = beanstalkPlatformSettingValueSplit[1];
+                    if (!Version.TryParse(beanstalkPlatformSettingValueSplit[2], out var beanstalkPlatformVersion))
+                        throw new InvalidElasticBeanstalkPlatformException(DeployToolErrorCode.InvalidElasticBeanstalkPlatform, $"The selected Elastic Beanstalk platform version '{beanstalkPlatformSettingValue}' is invalid.");
+
+                    // Elastic Beanstalk recently added .NET8 support in
+                    // platform '.NET 8 on AL2023 version 3.1.1' and '.NET Core on AL2 version 2.8.0'.
+                    // If users are using platform versions other than the above or older than '2.8.0' for '.NET Core'
+                    // we need to perform a self-contained publish.
+                    if (targetFramework.Equals("net8.0"))
+                    {
+                        if (beanstalkPlatformName.Contains(".NET Core"))
+                        {
+                            if (beanstalkPlatformVersion < new Version(2, 8, 0))
+                            {
+                                _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have .NET 8 preinstalled on {beanstalkPlatformName} ({beanstalkPlatformVersion.ToString()})");
+                                recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
+                                return;
+                            }
+                        }
+                        else if (!beanstalkPlatformName.Contains(".NET 8"))
+                        {
+                            _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have .NET 8 preinstalled on {beanstalkPlatformName} ({beanstalkPlatformVersion.ToString()})");
+                            recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         public async Task<string> CreateDotnetPublishZip(Recommendation recommendation)
         {
             _interactiveService.LogInfoMessage(string.Empty);
             _interactiveService.LogInfoMessage("Creating Dotnet Publish Zip file...");
 
-            // Since Beanstalk doesn't currently have .NET 7 and .NET 8 preinstalled we need to make sure we are doing a self-contained publish when creating the deployment bundle.
-            var targetFramework = recommendation.ProjectDefinition.TargetFramework ?? string.Empty;
-            var unavailableFramework = new List<string> { "net7.0", "net8.0" };
-            var frameworkNames = new Dictionary<string, string> { { "net7.0", ".NET 7" }, { "net8.0", ".NET 8" } };
-            if (recommendation.Recipe.TargetService == RecipeIdentifier.TARGET_SERVICE_ELASTIC_BEANSTALK &&
-                unavailableFramework.Contains(targetFramework))
-            {
-                _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have {frameworkNames[targetFramework]} preinstalled");
-                recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
-            }
+            SwitchToSelfContainedBuildIfNeeded(recommendation);
 
             var publishDirectoryInfo = _directoryManager.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var additionalArguments = recommendation.DeploymentBundle.DotnetPublishAdditionalBuildArguments;

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -236,7 +236,7 @@ namespace AWS.Deploy.Orchestration
     {
         public ElasticBeanstalkException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
-    
+
     /// <summary>
     /// Throw if unable to access the specified AWS Region.
     /// </summary>
@@ -275,5 +275,13 @@ namespace AWS.Deploy.Orchestration
     public class InvalidWindowsManifestFileException : DeployToolException
     {
         public InvalidWindowsManifestFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
+    }
+
+    /// <summary>
+    /// Throw if the deploy tool encounters an invalid Elastic Beanstalk platform version.
+    /// </summary>
+    public class InvalidElasticBeanstalkPlatformException : DeployToolException
+    {
+        public InvalidElasticBeanstalkPlatformException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
 }

--- a/src/AWS.Deploy.Orchestration/Exceptions.cs
+++ b/src/AWS.Deploy.Orchestration/Exceptions.cs
@@ -276,12 +276,4 @@ namespace AWS.Deploy.Orchestration
     {
         public InvalidWindowsManifestFileException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
     }
-
-    /// <summary>
-    /// Throw if the deploy tool encounters an invalid Elastic Beanstalk platform version.
-    /// </summary>
-    public class InvalidElasticBeanstalkPlatformException : DeployToolException
-    {
-        public InvalidElasticBeanstalkPlatformException(DeployToolErrorCode errorCode, string message, Exception? innerException = null) : base(errorCode, message, innerException) { }
-    }
 }

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -94,7 +94,7 @@ namespace AWS.Deploy.Orchestration
                 throw new InvalidOperationException($"{nameof(_session)} is null as part of the orchestartor object");
             if (_recipeHandler == null)
                 throw new InvalidOperationException($"{nameof(_recipeHandler)} is null as part of the orchestartor object");
-            
+
             var engine = new RecommendationEngine.RecommendationEngine(_session, _recipeHandler);
             var recipePaths = new HashSet<string> { RecipeLocator.FindRecipeDefinitionsPath() };
             var customRecipePaths = await _recipeHandler.LocateCustomRecipePaths(_session.ProjectDefinition);
@@ -112,7 +112,7 @@ namespace AWS.Deploy.Orchestration
                 throw new InvalidOperationException($"{nameof(_session)} is null as part of the orchestartor object");
             if (_recipeHandler == null)
                 throw new InvalidOperationException($"{nameof(_recipeHandler)} is null as part of the orchestartor object");
-            
+
             var engine = new RecommendationEngine.RecommendationEngine(_session, _recipeHandler);
             var compatibleRecommendations = await engine.ComputeRecommendations();
             var cdkRecommendations = compatibleRecommendations.Where(x => x.Recipe.DeploymentType == DeploymentTypes.CdkProject).ToList();
@@ -180,7 +180,7 @@ namespace AWS.Deploy.Orchestration
                 if (_awsResourceQueryer == null)
                     throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
 
-                var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType.Linux);
+                var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(recommendation.ProjectDefinition.TargetFramework, BeanstalkPlatformType.Linux);
                 recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_LATEST_DOTNET_BEANSTALK_PLATFORM_ARN, latestPlatform.PlatformArn);
             }
             if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_LATEST_DOTNET_WINDOWS_BEANSTALK_PLATFORM_ARN))
@@ -188,7 +188,7 @@ namespace AWS.Deploy.Orchestration
                 if (_awsResourceQueryer == null)
                     throw new InvalidOperationException($"{nameof(_awsResourceQueryer)} is null as part of the Orchestrator object");
 
-                var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType.Windows);
+                var latestPlatform = await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(recommendation.ProjectDefinition.TargetFramework, BeanstalkPlatformType.Windows);
                 recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_LATEST_DOTNET_WINDOWS_BEANSTALK_PLATFORM_ARN, latestPlatform.PlatformArn);
             }
             if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_STACK_NAME))
@@ -315,7 +315,7 @@ namespace AWS.Deploy.Orchestration
             _dockerEngine.DetermineDockerExecutionDirectory(recommendation);
 
             // Read this from the OptionSetting instead of recommendation.DeploymentBundle.
-            // When its value comes from a replacement token, it wouldn't have been set back to the DeploymentBundle 
+            // When its value comes from a replacement token, it wouldn't have been set back to the DeploymentBundle
             var respositoryName = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, Constants.Docker.ECRRepositoryNameOptionId));
             if (respositoryName == null)
                 throw new InvalidECRRepositoryNameException(DeployToolErrorCode.ECRRepositoryNameIsNull, "The ECR Repository Name is null.");

--- a/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Utilities/DeployedApplicationQueryer.cs
@@ -218,7 +218,7 @@ namespace AWS.Deploy.Orchestration.Utilities
             if (!environments.Any())
                 return validEnvironments;
 
-            var dotnetPlatforms = await _awsResourceQueryer.GetElasticBeanstalkPlatformArns();
+            var dotnetPlatforms = await _awsResourceQueryer.GetElasticBeanstalkPlatformArns(string.Empty);
             var dotnetPlatformArns = dotnetPlatforms.Select(x => x.PlatformArn).ToList();
 
             // only select environments that have a dotnet specific platform ARN.

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixture.cs
@@ -122,7 +122,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests.E
 
             await EBHelper.CreateApplicationAsync(ApplicationName);
             await EBHelper.CreateApplicationVersionAsync(ApplicationName, VersionLabel, zipFilePath);
-            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, VersionLabel, BeanstalkPlatformType.Windows, RoleName);
+            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, "net6.0", VersionLabel, BeanstalkPlatformType.Windows, RoleName);
             Assert.True(success);
 
             var environmentDescription = await AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
@@ -114,7 +114,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
 
             await EBHelper.CreateApplicationAsync(ApplicationName);
             await EBHelper.CreateApplicationVersionAsync(ApplicationName, VersionLabel, zipFilePath);
-            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, VersionLabel, BeanstalkPlatformType.Linux, RoleName);
+            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, "net6.0", VersionLabel, BeanstalkPlatformType.Linux, RoleName);
             Assert.True(success);
 
             var environmentDescription = await AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/ElasticBeanstalkHelper.cs
@@ -61,7 +61,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
             });
         }
 
-        public async Task<bool> CreateEnvironmentAsync(string applicationName, string environmentName, string versionLabel, BeanstalkPlatformType platformType, string ec2Role)
+        public async Task<bool> CreateEnvironmentAsync(string applicationName, string environmentName, string targetFramework, string versionLabel, BeanstalkPlatformType platformType, string ec2Role)
         {
             _interactiveService.WriteLine($"Creating new Elastic Beanstalk environment {environmentName} with versionLabel {versionLabel}");
 
@@ -72,7 +72,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
                 ApplicationName = applicationName,
                 EnvironmentName = environmentName,
                 VersionLabel = versionLabel,
-                PlatformArn = (await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(platformType)).PlatformArn,
+                PlatformArn = (await _awsResourceQueryer.GetLatestElasticBeanstalkPlatformArn(targetFramework, platformType)).PlatformArn,
                 OptionSettings = new List<ConfigurationOptionSetting>
                 {
                     new ConfigurationOptionSetting("aws:autoscaling:launchconfiguration", "IamInstanceProfile", ec2Role),

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -25,7 +25,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
 {
     public class TestToolAWSResourceQueryer : IAWSResourceQueryer
     {
-        public Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType platformType)
+        public Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(string targetFramework, BeanstalkPlatformType platformType)
         {
             return System.Threading.Tasks.Task.FromResult(new PlatformSummary() { PlatformArn = string.Empty });
         }
@@ -41,7 +41,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<Stack> GetCloudFormationStack(string stackName) => throw new NotImplementedException();
         public Task<List<AuthorizationData>> GetECRAuthorizationToken() => throw new NotImplementedException();
         public Task<List<Repository>> GetECRRepositories(List<string> repositoryNames) => throw new NotImplementedException();
-        public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(params BeanstalkPlatformType[] platformTypes) => throw new NotImplementedException();
+        public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(string targetFramework, params BeanstalkPlatformType[] platformTypes) => throw new NotImplementedException();
         public Task<List<Vpc>> GetListOfVpcs() => throw new NotImplementedException();
         public Task<string> GetS3BucketLocation(string bucketName) => throw new NotImplementedException();
         public Task<Amazon.S3.Model.WebsiteConfiguration> GetS3BucketWebSiteConfiguration(string bucketName) => throw new NotImplementedException();

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -56,12 +56,12 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             return Task.FromResult<List<Repository>>(new List<Repository>() { repository });
         }
 
-        public Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(BeanstalkPlatformType platformType)
+        public Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(string targetFramework, BeanstalkPlatformType platformType)
         {
             return Task.FromResult(new PlatformSummary() { PlatformArn = string.Empty });
         }
 
-        public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(params BeanstalkPlatformType[] platformTypes) => throw new NotImplementedException();
+        public Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(string targetFramework, params BeanstalkPlatformType[] platformTypes) => throw new NotImplementedException();
         public Task<List<Vpc>> GetListOfVpcs() => throw new NotImplementedException();
         public Task<List<KeyPairInfo>> ListOfEC2KeyPairs() => throw new NotImplementedException();
         public Task<List<Amazon.ECS.Model.Cluster>> ListOfECSClusters(string ecsClusterName) => throw new NotImplementedException();

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWSResourceQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWSResourceQueryerTests.cs
@@ -176,6 +176,173 @@ namespace AWS.Deploy.Orchestration.UnitTests
         }
 
         [Fact]
+        public void SortElasticBeanstalkLinuxPlatforms()
+        {
+            // Use PlatformOwner as a placeholder to store where the summary should be sorted to.
+            var platforms = new List<PlatformSummary>()
+            {
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "1"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.1.2",
+                    PlatformBranchName = ".NET 6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.2",
+                    PlatformOwner = "2"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.0.6",
+                    PlatformBranchName = ".NET 6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.0.6",
+                    PlatformOwner = "3"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.0.5",
+                    PlatformBranchName = ".NET 6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.0.5",
+                    PlatformOwner = "4"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 8 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 8 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "0"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/2.8.0",
+                    PlatformBranchName = ".NET Core running on 64bit Amazon Linux 2",
+                    PlatformVersion = "2.8.0",
+                    PlatformOwner = "5"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/2.7.3",
+                    PlatformBranchName = ".NET Core running on 64bit Amazon Linux 2",
+                    PlatformVersion = "2.7.3",
+                    PlatformOwner = "6"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/2.6.0",
+                    PlatformBranchName = ".NET Core running on 64bit Amazon Linux 2",
+                    PlatformVersion = "2.6.0",
+                    PlatformOwner = "7"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/2.5.7",
+                    PlatformBranchName = ".NET Core running on 64bit Amazon Linux 2",
+                    PlatformVersion = "2.5.7",
+                    PlatformOwner = "8"
+                }
+            };
+
+            var sortedPlatforms = AWSResourceQueryer.SortElasticBeanstalkLinuxPlatforms(string.Empty, platforms);
+
+            for (var i = 0; i < sortedPlatforms.Count; i++)
+            {
+                Assert.Equal(i.ToString(), sortedPlatforms[i].PlatformOwner);
+            }
+        }
+
+        [Fact]
+        public void SortElasticBeanstalkLinuxPlatforms_InvalidPlatform_RunningStringNotFound()
+        {
+            // Use PlatformOwner as a placeholder to store where the summary should be sorted to.
+            var platforms = new List<PlatformSummary>()
+            {
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 6 on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "2"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "1"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 8 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 8 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "0"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/3.1.3",
+                    PlatformBranchName = ".NET Core running on 64bit Amazon Linux 2",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "3"
+                }
+            };
+
+            var sortedPlatforms = AWSResourceQueryer.SortElasticBeanstalkLinuxPlatforms(string.Empty, platforms);
+
+            for (var i = 0; i < sortedPlatforms.Count; i++)
+            {
+                Assert.Equal(i.ToString(), sortedPlatforms[i].PlatformOwner);
+            }
+        }
+
+        [Fact]
+        public void SortElasticBeanstalkLinuxPlatforms_InvalidPlatform_InvalidBranchName()
+        {
+            // Use PlatformOwner as a placeholder to store where the summary should be sorted to.
+            var platforms = new List<PlatformSummary>()
+            {
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET6 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "2"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 6 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "1"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET 8 running on 64bit Amazon Linux 2023/3.1.3",
+                    PlatformBranchName = ".NET 8 running on 64bit Amazon Linux 2023",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "0"
+                },
+                new PlatformSummary
+                {
+                    PlatformArn = "arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/3.1.3",
+                    PlatformBranchName = ".NET Core running on 64bit Amazon Linux 2",
+                    PlatformVersion = "3.1.3",
+                    PlatformOwner = "3"
+                }
+            };
+
+            var sortedPlatforms = AWSResourceQueryer.SortElasticBeanstalkLinuxPlatforms(string.Empty, platforms);
+
+            for (var i = 0; i < sortedPlatforms.Count; i++)
+            {
+                Assert.Equal(i.ToString(), sortedPlatforms[i].PlatformOwner);
+            }
+        }
+
+        [Fact]
         public async Task CreateRepository_TagsWithRecipeName_Success()
         {
             var awsResourceQueryer = new AWSResourceQueryer(_mockAWSClientFactory.Object);

--- a/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DeployedApplicationQueryerTests.cs
@@ -283,7 +283,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(environments));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.GetElasticBeanstalkPlatformArns())
+                .Setup(x => x.GetElasticBeanstalkPlatformArns(It.IsAny<string>()))
                 .Returns(Task.FromResult(platforms));
 
             _mockAWSResourceQueryer
@@ -337,7 +337,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(environments));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.GetElasticBeanstalkPlatformArns())
+                .Setup(x => x.GetElasticBeanstalkPlatformArns(It.IsAny<string>()))
                 .Returns(Task.FromResult(platforms));
 
             _mockAWSResourceQueryer
@@ -399,7 +399,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
                 .Returns(Task.FromResult(environments));
 
             _mockAWSResourceQueryer
-                .Setup(x => x.GetElasticBeanstalkPlatformArns())
+                .Setup(x => x.GetElasticBeanstalkPlatformArns(It.IsAny<string>()))
                 .Returns(Task.FromResult(platforms));
 
             _mockAWSResourceQueryer


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7212

*Description of changes:*
In order to support deploying .NET8 apps on Beanstalk prior to Beanstalk adding .NET8 support, we had to force .NET8 apps to be self-contained in order to allow for Beanstalk support. Beanstalk has since added .NET8 support, so this PR removes this restriction to allow .NET8 apps to be deployed to Beanstalk not as self-contained apps.

This PR also improves the sorting of Beanstalk platforms to show the latest .NET versions first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
