### PR TITLE
chore: add ability to select a supported architecture

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
 codecov:
   branch: dev # set the default branch to 'dev'. This branch provides the coverage baselines during pull requests.
+
+coverage:
+  exclude:
+    - "test/**"

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS App Runner.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS App Runner.md
@@ -115,6 +115,10 @@
     * ID: AppRunnerEnvironmentVariables
     * Description: Configure environment properties for your application.
     * Type: KeyValue
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Docker Build Args**
     * ID: DockerBuildArgs
     * Description: The list of additional options to append to the `docker build` command.

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Linux.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Linux.md
@@ -175,6 +175,10 @@
             * ID: SecurityGroups
             * Description: Lists the Amazon EC2 security groups to assign to the EC2 instances in the Auto Scaling group to define firewall rules for the instances.
             * Type: List
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Dotnet Build Configuration**
     * ID: DotnetBuildConfiguration
     * Description: The build configuration to use for the dotnet build

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Windows.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Windows.md
@@ -174,6 +174,10 @@
             * ID: SecurityGroups
             * Description: Lists the Amazon EC2 security groups to assign to the EC2 instances in the Auto Scaling group to define firewall rules for the instances.
             * Type: List
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Dotnet Build Configuration**
     * ID: DotnetBuildConfiguration
     * Description: The build configuration to use for the dotnet build

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon ECS using AWS Fargate.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon ECS using AWS Fargate.md
@@ -189,6 +189,10 @@
     * ID: ECSEnvironmentVariables
     * Description: Configure environment properties for your application.
     * Type: KeyValue
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Docker Build Args**
     * ID: DockerBuildArgs
     * Description: The list of additional options to append to the `docker build` command.

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Existing AWS Elastic Beanstalk Environment.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Existing AWS Elastic Beanstalk Environment.md
@@ -20,6 +20,10 @@
     * ID: HealthCheckURL
     * Description: Customize the load balancer health check to ensure that your application, and not just the web server, is in a good state.
     * Type: String
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Dotnet Build Configuration**
     * ID: DotnetBuildConfiguration
     * Description: The build configuration to use for the dotnet build

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment.md
@@ -24,6 +24,10 @@
     * ID: HealthCheckURL
     * Description: Customize the load balancer health check to ensure that your application, and not just the web server, is in a good state.
     * Type: String
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Dotnet Build Configuration**
     * ID: DotnetBuildConfiguration
     * Description: The build configuration to use for the dotnet build

--- a/site/content/docs/cicd/recipes/Blazor WebAssembly App.md
+++ b/site/content/docs/cicd/recipes/Blazor WebAssembly App.md
@@ -74,6 +74,10 @@
     * ID: WebAclId
     * Description: The AWS WAF (web application firewall) ACL arn
     * Type: String
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Dotnet Build Configuration**
     * ID: DotnetBuildConfiguration
     * Description: The build configuration to use for the dotnet build

--- a/site/content/docs/cicd/recipes/Container Image to Amazon Elastic Container Registry (ECR).md
+++ b/site/content/docs/cicd/recipes/Container Image to Amazon Elastic Container Registry (ECR).md
@@ -8,6 +8,10 @@
     * ID: ImageTag
     * Description: This tag will be associated to the container images which are pushed to Amazon Elastic Container Registry.
     * Type: String
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Docker Build Args**
     * ID: DockerBuildArgs
     * Description: The list of additional options to append to the `docker build` command.

--- a/site/content/docs/cicd/recipes/Scheduled Task on Amazon Elastic Container Service (ECS) using AWS Fargate.md
+++ b/site/content/docs/cicd/recipes/Scheduled Task on Amazon Elastic Container Service (ECS) using AWS Fargate.md
@@ -67,6 +67,10 @@
     * ID: ECSEnvironmentVariables
     * Description: Configure environment properties for your application.
     * Type: KeyValue
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Docker Build Args**
     * ID: DockerBuildArgs
     * Description: The list of additional options to append to the `docker build` command.

--- a/site/content/docs/cicd/recipes/Service on Amazon Elastic Container Service (ECS) using AWS Fargate.md
+++ b/site/content/docs/cicd/recipes/Service on Amazon Elastic Container Service (ECS) using AWS Fargate.md
@@ -120,6 +120,10 @@
     * ID: ECSEnvironmentVariables
     * Description: Configure environment properties for your application.
     * Type: KeyValue
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
 * **Docker Build Args**
     * ID: DockerBuildArgs
     * Description: The list of additional options to append to the `docker build` command.

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EnvironmentArchitectureCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EnvironmentArchitectureCommand.cs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class EnvironmentArchitectureCommand : ITypeHintCommand
+    {
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public EnvironmentArchitectureCommand(IConsoleUtilities consoleUtilities, IOptionSettingHandler optionSettingHandler)
+        {
+            _consoleUtilities = consoleUtilities;
+            _optionSettingHandler = optionSettingHandler;
+        }
+
+        public Task<TypeHintResourceTable> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var resourceTable = new TypeHintResourceTable
+            {
+                Columns = new List<TypeHintResourceColumn>()
+                {
+                    new TypeHintResourceColumn("Architecture")
+                }
+            };
+
+            foreach (var value in recommendation.Recipe.SupportedArchitectures ?? new List<SupportedArchitecture> { SupportedArchitecture.X86_64 })
+            {
+                var stringValue = value.ToString();
+                var row = new TypeHintResource(stringValue, stringValue);
+                row.ColumnValues.Add(stringValue);
+
+                resourceTable.Rows.Add(row);
+            }
+
+            return Task.FromResult(resourceTable);
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var currentValue = _optionSettingHandler.GetOptionSettingValue(recommendation, optionSetting);
+            var resourceTable = await GetResources(recommendation, optionSetting);
+
+            var userInputConfiguration = new UserInputConfiguration<TypeHintResource>(
+                idSelector: platform => platform.SystemName,
+                displaySelector: platform => platform.DisplayName,
+                defaultSelector: platform => platform.SystemName.Equals(currentValue))
+            {
+                CreateNew = false
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(resourceTable.Rows, "Select the Platform to use:", userInputConfiguration);
+
+            var result = userResponse.SelectedOption?.SystemName!;
+            recommendation.DeploymentBundle.EnvironmentArchitecture = Enum.Parse<SupportedArchitecture>(result);
+            return result;
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/EnvironmentArchitectureCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/EnvironmentArchitectureCommand.cs
@@ -31,7 +31,8 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 }
             };
 
-            foreach (var value in recommendation.Recipe.SupportedArchitectures ?? new List<SupportedArchitecture> { SupportedArchitecture.X86_64 })
+            foreach (var value in recommendation.Recipe.SupportedArchitectures ??
+                                  new List<SupportedArchitecture> { Enum.Parse<SupportedArchitecture>(Constants.Recipe.DefaultSupportedArchitecture) })
             {
                 var stringValue = value.ToString();
                 var row = new TypeHintResource(stringValue, stringValue);

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -73,6 +73,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.FilePath, ActivatorUtilities.CreateInstance<FilePathCommand>(serviceProvider) },
                 { OptionSettingTypeHint.ElasticBeanstalkVpc, ActivatorUtilities.CreateInstance<ElasticBeanstalkVpcCommand>(serviceProvider) },
                 { OptionSettingTypeHint.DockerHttpPort, ActivatorUtilities.CreateInstance<DockerHttpPortCommand>(serviceProvider) },
+                { OptionSettingTypeHint.EnvironmentArchitecture, ActivatorUtilities.CreateInstance<EnvironmentArchitectureCommand>(serviceProvider) },
             };
         }
 

--- a/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
+++ b/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using AWS.Deploy.Common.Recipes;
 
 namespace AWS.Deploy.Common
@@ -69,6 +70,6 @@ namespace AWS.Deploy.Common
         /// <summary>
         /// The CPU architecture of the environment to create.
         /// </summary>
-        public SupportedArchitecture EnvironmentArchitecture { get; set; } = SupportedArchitecture.X86_64;
+        public SupportedArchitecture EnvironmentArchitecture { get; set; } = Enum.Parse<SupportedArchitecture>(Constants.Recipe.DefaultSupportedArchitecture);
     }
 }

--- a/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
+++ b/src/AWS.Deploy.Common/DeploymentBundles/DeploymentBundle.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Deploy.Common.Recipes;
+
 namespace AWS.Deploy.Common
 {
     /// <summary>
@@ -63,5 +65,10 @@ namespace AWS.Deploy.Common
         /// The list of additional dotnet publish args passed to the target application.
         /// </summary>
         public string DotnetPublishAdditionalBuildArguments { get; set; } = "";
+
+        /// <summary>
+        /// The CPU architecture of the environment to create.
+        /// </summary>
+        public SupportedArchitecture EnvironmentArchitecture { get; set; } = SupportedArchitecture.X86_64;
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -40,6 +40,7 @@ namespace AWS.Deploy.Common.Recipes
         VPCConnector,
         FilePath,
         ElasticBeanstalkVpc,
-        DockerHttpPort
+        DockerHttpPort,
+        EnvironmentArchitecture
     };
 }

--- a/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
+++ b/src/AWS.Deploy.Common/Recipes/RecipeDefinition.cs
@@ -61,6 +61,11 @@ namespace AWS.Deploy.Common.Recipes
         public TargetPlatform? TargetPlatform { get; set; }
 
         /// <summary>
+        /// The CPU architecture that is supported by the recipe.
+        /// </summary>
+        public List<SupportedArchitecture>? SupportedArchitectures { get; set; }
+
+        /// <summary>
         /// The list of DisplayedResources that lists logical CloudFormation IDs with a description.
         /// </summary>
         public List<DisplayedResource>? DisplayedResources { get; set; }

--- a/src/AWS.Deploy.Common/Recipes/SupportedArchitecture.cs
+++ b/src/AWS.Deploy.Common/Recipes/SupportedArchitecture.cs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.Recipes;
+
+public enum SupportedArchitecture
+{
+    X86_64,
+    Arm64
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RequiredValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/OptionSettingItemValidators/RequiredValidator.cs
@@ -19,7 +19,7 @@ namespace AWS.Deploy.Common.Recipes.Validation
         public Task<ValidationResult> Validate(object input, Recommendation recommendation, OptionSettingItem optionSettingItem)
         {
             var message = ValidationFailedMessage.Replace("{{OptionSetting}}", optionSettingItem.Name);
-            if (input?.TryDeserialize<SortedSet<string>>(out var inputList) ?? false && inputList != null)
+            if (input?.TryDeserialize<SortedSet<string>>(out var inputList) ?? false)
             {
                 return Task.FromResult<ValidationResult>(new()
                 {

--- a/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
+++ b/src/AWS.Deploy.Constants/AWS.Deploy.Constants.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Docker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EC2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ElasticBeanstalk.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Recipe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RecipeIdentifier.cs" />
   </ItemGroup>
 </Project>

--- a/src/AWS.Deploy.Constants/Recipe.cs
+++ b/src/AWS.Deploy.Constants/Recipe.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Constants
+{
+    internal class Recipe
+    {
+        /// <summary>
+        /// The default supported architecture
+        /// </summary>
+        public const string DefaultSupportedArchitecture = "X86_64";
+    }
+}

--- a/src/AWS.Deploy.Constants/RecipeIdentifier.cs
+++ b/src/AWS.Deploy.Constants/RecipeIdentifier.cs
@@ -22,6 +22,7 @@ namespace AWS.Deploy.Constants
         public const string REPLACE_TOKEN_HAS_DEFAULT_VPC = "{HasDefaultVpc}";
         public const string REPLACE_TOKEN_HAS_NOT_VPCS = "{HasNotVpcs}";
         public const string REPLACE_TOKEN_DEFAULT_CONTAINER_PORT = "{DefaultContainerPort}";
+        public const string REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE = "{DefaultEnvironmentArchitecture}";
 
         /// <summary>
         /// Id for the 'dotnet publish --configuration' recipe option
@@ -37,6 +38,11 @@ namespace AWS.Deploy.Constants
         /// Id for the 'dotnet build --self-contained' recipe option
         /// </summary>
         public const string DotnetPublishSelfContainedBuildOptionId = "SelfContainedBuild";
+
+        /// <summary>
+        /// Id for the environment architecture recipe option
+        /// </summary>
+        public const string EnvironmentArchitectureOptionId = "EnvironmentArchitecture";
 
         public const string TARGET_SERVICE_ELASTIC_BEANSTALK = "AWS Elastic Beanstalk";
     }

--- a/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
+++ b/src/AWS.Deploy.Orchestration/OptionSettingHandler.cs
@@ -144,6 +144,9 @@ namespace AWS.Deploy.Orchestration
                 case Constants.RecipeIdentifier.DotnetPublishSelfContainedBuildOptionId:
                     recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = Convert.ToBoolean(value);
                     break;
+                case Constants.RecipeIdentifier.EnvironmentArchitectureOptionId:
+                    recommendation.DeploymentBundle.EnvironmentArchitecture = Enum.Parse<SupportedArchitecture>(value.ToString() ?? string.Empty);
+                    break;
                 default:
                     return;
             }

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -244,6 +244,13 @@ namespace AWS.Deploy.Orchestration
                 recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_CONTAINER_PORT, defaultPort);
                 recommendation.DeploymentBundle.DockerfileHttpPort = defaultPort;
             }
+            if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE))
+            {
+                if (_dockerEngine == null)
+                    throw new InvalidOperationException($"{nameof(_dockerEngine)} is null as part of the Orchestrator object");
+
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, SupportedArchitecture.X86_64.ToString());
+            }
         }
 
         public async Task DeployRecommendation(CloudApplication cloudApplication, Recommendation recommendation)

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -246,9 +246,6 @@ namespace AWS.Deploy.Orchestration
             }
             if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE))
             {
-                if (_dockerEngine == null)
-                    throw new InvalidOperationException($"{nameof(_dockerEngine)} is null as part of the Orchestrator object");
-
                 recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, SupportedArchitecture.X86_64.ToString());
             }
         }

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -246,7 +246,7 @@ namespace AWS.Deploy.Orchestration
             }
             if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE))
             {
-                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, SupportedArchitecture.X86_64.ToString());
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, Constants.Recipe.DefaultSupportedArchitecture);
             }
         }
 

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/Container.deploymentbundle
@@ -2,6 +2,16 @@
     "Type": "Container",
     "Parameters": [
         {
+            "Id": "EnvironmentArchitecture",
+            "Name": "Environment Architecture",
+            "Description": "The CPU architecture of the environment to create.",
+            "TypeHint": "EnvironmentArchitecture",
+            "Type": "String",
+            "DefaultValue": "{DefaultEnvironmentArchitecture}",
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
             "Id": "DockerBuildArgs",
             "Name": "Docker Build Args",
             "Description": "The list of additional options to append to the `docker build` command.",

--- a/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/DotnetPublishZipFile.deploymentbundle
+++ b/src/AWS.Deploy.Recipes/DeploymentBundleDefinitions/DotnetPublishZipFile.deploymentbundle
@@ -2,6 +2,16 @@
     "Type": "DotnetPublishZipFile",
     "Parameters": [
         {
+            "Id": "EnvironmentArchitecture",
+            "Name": "Environment Architecture",
+            "Description": "The CPU architecture of the environment to create.",
+            "TypeHint": "EnvironmentArchitecture",
+            "Type": "String",
+            "DefaultValue": "{DefaultEnvironmentArchitecture}",
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
             "Id": "DotnetBuildConfiguration",
             "Name": "Dotnet Build Configuration",
             "Description": "The build configuration to use for the dotnet build",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppAppRunner",
-    "Version": "1.0.2",
+    "Version": "1.0.3",
     "Name": "ASP.NET Core App to AWS App Runner",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -11,6 +11,7 @@
     "Description": "This ASP.NET Core application will be built as a container image on Linux and deployed to AWS App Runner, a fully managed service for web applications and APIs. If your project does not contain a Dockerfile, it will be automatically generated, otherwise an existing Dockerfile will be used. Recommended if you want to deploy your web application as a Linux container image on a fully managed environment.",
     "TargetService": "AWS App Runner",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppEcsFargate",
-    "Version": "1.1.1",
+    "Version": "1.1.2",
     "Name": "ASP.NET Core App to Amazon ECS using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -11,6 +11,7 @@
     "Description": "This ASP.NET Core application will be deployed to Amazon Elastic Container Service (Amazon ECS) with compute power managed by AWS Fargate compute engine. If your project does not contain a Dockerfile, it will be automatically generated, otherwise an existing Dockerfile will be used. Recommended if you want to deploy your application as a container image on Linux.",
     "TargetService": "Amazon Elastic Container Service",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppElasticBeanstalkLinux",
-    "Version": "1.0.2",
+    "Version": "1.0.3",
     "Name": "ASP.NET Core App to AWS Elastic Beanstalk on Linux",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "DotnetPublishZipFile",
@@ -11,6 +11,7 @@
     "Description": "This ASP.NET Core application will be built and deployed to AWS Elastic Beanstalk on Linux. Recommended if you want to deploy your application directly to EC2 hosts, not as a container image.",
     "TargetService": "AWS Elastic Beanstalk",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppElasticBeanstalkWindows",
-    "Version": "1.0.2",
+    "Version": "1.0.3",
     "Name": "ASP.NET Core App to AWS Elastic Beanstalk on Windows",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "DotnetPublishZipFile",
@@ -11,6 +11,7 @@
     "ShortDescription": "ASP.NET Core application deployed to AWS Elastic Beanstalk on Windows.",
     "TargetService": "AWS Elastic Beanstalk",
     "TargetPlatform": "Windows",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppExistingBeanstalkEnvironment",
-    "Version": "1.0.1",
+    "Version": "1.0.2",
     "Name": "ASP.NET Core App to Existing AWS Elastic Beanstalk Environment",
     "DisableNewDeployments": true,
     "DeploymentType": "BeanstalkEnvironment",
@@ -10,6 +10,7 @@
     "Description": "This ASP.NET Core application will be built and deployed to an existing AWS Elastic Beanstalk environment. Recommended if you want to deploy your application directly to EC2 hosts, not as a container image.",
     "TargetService": "AWS Elastic Beanstalk",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "RecipePriority": 0,
     "RecommendationRules": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "AspNetAppExistingBeanstalkWindowsEnvironment",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Name": "ASP.NET Core App to Existing AWS Elastic Beanstalk Windows Environment",
     "DisableNewDeployments": true,
     "DeploymentType": "BeanstalkEnvironment",
@@ -10,6 +10,7 @@
     "Description": "This ASP.NET Core application will be built and deployed to an existing AWS Elastic Beanstalk Windows environment. Recommended if you want to deploy your application directly to EC2 hosts, not as a container image.",
     "TargetService": "AWS Elastic Beanstalk",
     "TargetPlatform": "Windows",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "RecipePriority": 0,
     "RecommendationRules": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/BlazorWasm.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "BlazorWasm",
-    "Version": "1.0.1",
+    "Version": "1.0.2",
     "Name": "Blazor WebAssembly App",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "DotnetPublishZipFile",
@@ -11,6 +11,7 @@
     "Description": "This Blazor WebAssembly application will be built and hosted in a new Amazon Simple Storage Service (Amazon S3) bucket. The Blazor application will be exposed publicly through a CloudFront distribution using the Amazon S3 bucket as the origin.",
     "TargetService": "Amazon S3",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "ConsoleAppEcsFargateScheduleTask",
-    "Version": "1.0.2",
+    "Version": "1.0.3",
     "Name": "Scheduled Task on Amazon Elastic Container Service (ECS) using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -11,6 +11,7 @@
     "ShortDescription": "Deploys a scheduled task as a Linux container image to a fully managed container orchestration service. Dockerfile will be automatically generated if needed.",
     "TargetService": "Amazon Elastic Container Service",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "ConsoleAppEcsFargateService",
-    "Version": "1.0.2",
+    "Version": "1.0.3",
     "Name": "Service on Amazon Elastic Container Service (ECS) using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -11,6 +11,7 @@
     "ShortDescription": "Deploys a service as a Linux container image to a fully managed container orchestration service. Dockerfile will be automatically generated if needed.",
     "TargetService": "Amazon Elastic Container Service",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/PushContainerImageECR.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/PushContainerImageECR.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "PushContainerImageEcr",
-    "Version": "1.0.1",
+    "Version": "1.0.2",
     "Name": "Container Image to Amazon Elastic Container Registry (ECR)",
     "DeploymentType": "ElasticContainerRegistryImage",
     "DeploymentBundle": "Container",
@@ -9,6 +9,7 @@
     "ShortDescription": "Pushes container image to a fully managed container registry.",
     "TargetService": "Amazon Elastic Container Service",
     "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "x86_64" ],
 
     "RecipePriority": 0,
     "RecommendationRules": [

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -17,6 +17,7 @@
         "ShortDescription",
         "TargetService",
         "TargetPlatform",
+        "SupportedArchitectures",
         "RecipePriority",
         "RecommendationRules",
         "OptionSettings"
@@ -102,6 +103,15 @@
             "description": "The environment platform the recipe deploys to. This is used to publish a self-contained .NET application for that platform.",
             "minLength": 1,
             "enum": [ "Linux", "Windows" ]
+        },
+        "SupportedArchitectures": {
+            "type": "array",
+            "title": "Supported Architectures",
+            "description": "The CPU architecture that is supported by the recipe.",
+            "items": {
+                "type": "string",
+                "enum": [ "x86_64", "arm64" ]
+            }
         },
         "DeploymentConfirmation": {
             "$ref": "#/definitions/DeploymentConfirmation"

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -34,6 +34,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
         private const string STACK_NAME_TOKEN = "{StackName}";
         private const string DEFAULT_VPC_ID_TOKEN = "{DefaultVpcId}";
         private const string DEFAULT_CONTAINER_PORT_TOKEN = "{DefaultContainerPort}";
+        private const string DEFAULT_ENVIRONMENT_ARCHITECTURE = "{DefaultEnvironmentArchitecture}";
 
         public DeploymentSettingsHandlerTests()
         {
@@ -163,6 +164,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             selectedRecommendation.AddReplacementToken(BEANSTALK_PLATFORM_ARN_TOKEN, "Latest-ARN");
             selectedRecommendation.AddReplacementToken(STACK_NAME_TOKEN, "MyAppStack");
             selectedRecommendation.AddReplacementToken(DEFAULT_VPC_ID_TOKEN, "vpc-12345678");
+            selectedRecommendation.AddReplacementToken(DEFAULT_ENVIRONMENT_ARCHITECTURE, "X86_64");
 
             // ARRANGE - Modify option setting items
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "BeanstalkApplication", "MyBeanstalkApplication");
@@ -202,6 +204,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             selectedRecommendation.AddReplacementToken(STACK_NAME_TOKEN, "MyAppStack");
             selectedRecommendation.AddReplacementToken(DEFAULT_VPC_ID_TOKEN, "vpc-12345678");
             selectedRecommendation.AddReplacementToken(DEFAULT_CONTAINER_PORT_TOKEN, 80);
+            selectedRecommendation.AddReplacementToken(DEFAULT_ENVIRONMENT_ARCHITECTURE, "X86_64");
 
             // ARRANGE - Modify option setting items
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ServiceName", "MyAppRunnerService");
@@ -234,6 +237,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             // ARRANGE - Modify option setting items
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ImageTag", "123456789");
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "ECRRepositoryName", "my-ecr-repository");
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "EnvironmentArchitecture", "X86_64");
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DockerfilePath", Path.Combine("DockerAssets", "Dockerfile")); // relative path
             await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "DockerExecutionDirectory", Path.Combine(_projectPath, "DockerAssets")); // absolute path
 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_Container.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_Container.json
@@ -26,6 +26,7 @@
       "UseVPCConnector": false
     },
     "AppRunnerEnvironmentVariables": "",
+    "EnvironmentArchitecture": "X86_64",
     "DockerBuildArgs": "",
     "DockerfilePath": "DockerAssets/Dockerfile",
     "DockerExecutionDirectory": "DockerAssets",

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
@@ -40,6 +40,7 @@
     "VPC": {
       "UseVPC": false
     },
+    "EnvironmentArchitecture": "X86_64",
     "DotnetBuildConfiguration": "Release",
     "DotnetPublishArgs": "",
     "SelfContainedBuild": false

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_PushImageECR.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_PushImageECR.json
@@ -4,6 +4,7 @@
   "RecipeId": "PushContainerImageEcr",
   "Settings": {
     "ImageTag": 123456789,
+    "EnvironmentArchitecture": "X86_64",
     "DockerBuildArgs": "",
     "DockerfilePath": "DockerAssets/Dockerfile",
     "DockerExecutionDirectory": "DockerAssets",

--- a/test/AWS.Deploy.Orchestration.UnitTests/OrchestratorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/OrchestratorTests.cs
@@ -66,6 +66,8 @@ public class OrchestratorTests
         recommendation.ReplacementTokens.Clear();
         recommendation.ReplacementTokens.Add(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, true);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await orchestrator.ApplyAllReplacementTokens(recommendation, "WebAppNoDockerFile"));
+        await orchestrator.ApplyAllReplacementTokens(recommendation, "WebAppNoDockerFile");
+
+        Assert.Equal(Constants.Recipe.DefaultSupportedArchitecture, recommendation.ReplacementTokens[Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE]);
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/OrchestratorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/OrchestratorTests.cs
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.DeploymentManifest;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration.UnitTests.Utilities;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.Orchestration.UnitTests;
+
+public class OrchestratorTests
+{
+    private readonly IRecipeHandler _recipeHandler;
+    private OrchestratorSession _session;
+    private readonly IDeploymentManifestEngine _deploymentManifestEngine;
+    private readonly Mock<IOrchestratorInteractiveService> _orchestratorInteractiveService;
+    private readonly IDirectoryManager _directoryManager;
+    private readonly IFileManager _fileManager;
+
+    public OrchestratorTests()
+    {
+        _directoryManager = new DirectoryManager();
+        _fileManager = new FileManager();
+        _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
+        _orchestratorInteractiveService = new Mock<IOrchestratorInteractiveService>();
+        var serviceProvider = new Mock<IServiceProvider>();
+        var validatorFactory = new ValidatorFactory(serviceProvider.Object);
+        var optionSettingHandler = new OptionSettingHandler(validatorFactory);
+        _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService.Object, _directoryManager, _fileManager, optionSettingHandler, validatorFactory);
+    }
+
+    private async Task<RecommendationEngine.RecommendationEngine> BuildRecommendationEngine(string testProjectName)
+    {
+        var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
+
+        var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+        var awsCredentials = new Mock<AWSCredentials>();
+        _session = new OrchestratorSession(
+            await parser.Parse(fullPath),
+            awsCredentials.Object,
+            "us-west-2",
+            "123456789012")
+        {
+            AWSProfileName = "default"
+        };
+
+        return new RecommendationEngine.RecommendationEngine(_session, _recipeHandler);
+    }
+
+    [Fact]
+    public async Task ApplyAllReplacementTokensTest()
+    {
+        var engine = await BuildRecommendationEngine("WebAppNoDockerFile");
+        var recommendations = await engine.ComputeRecommendations();
+        var recommendation = recommendations.First(r => r.Recipe.Id.Equals("AspNetAppElasticBeanstalkLinux"));
+        var orchestrator = new Orchestrator(_session, _recipeHandler);
+
+        recommendation.ReplacementTokens.Clear();
+        recommendation.ReplacementTokens.Add(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, true);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await orchestrator.ApplyAllReplacementTokens(recommendation, "WebAppNoDockerFile"));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5124

*Description of changes:*
* Added a new `SupportedArchitectures` property to recipes which has 2 allowed values: `X86_64` and `Arm64`. I have set all our recipes to `X86_64` while we work on adding `Arm64` for the ones that support it.
* Added a new option setting item `EnvironmentArchitecture` which is part of the Deployment Bundle Settings. This option setting has a type hint that checks the `SupportedArchitectures` property on the recipe and prompts the user to chose one of them. By default, the architecture is `X86_64`.

![image](https://github.com/user-attachments/assets/e26bba8c-d18a-4085-bf3e-c20763f731e7)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
