### PR TITLE
ci: add v4 release workflows

### DIFF
--- a/.github/workflows/create-release-pr-v4sdk.yml
+++ b/.github/workflows/create-release-pr-v4sdk.yml
@@ -1,0 +1,101 @@
+# This GitHub Workflow will create a new release branch that contains the updated C# project versions and changelog.
+# The workflow will also create a PR that targets `v4sdk-development` from the release branch.
+name: Create V4-SDK Release PR
+
+# This workflow is manually triggered when in preparation for a release. The workflow should be dispatched from the `v4sdk-development` branch.
+on:
+  workflow_dispatch:
+    inputs:
+      OVERRIDE_VERSION:
+        description: "Override Version"
+        type: string
+        required: false
+
+permissions:
+  id-token: write
+
+jobs:
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+
+    env:
+      INPUT_OVERRIDE_VERSION: ${{ github.event.inputs.OVERRIDE_VERSION }}
+      
+    steps:
+      # Assume an AWS Role that provides access to the Access Token
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
+        with:
+          role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
+          aws-region: us-west-2
+      # Retrieve the Access Token from Secrets Manager
+      - name: Retrieve secret from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
+          parse-json-secrets: true
+      # Checkout a full clone of the repo
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          token: ${{ env.AWS_SECRET_TOKEN }}
+      # Install .NET8 which is needed for AutoVer
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Install AutoVer to automate versioning and changelog creation
+      - name: Install AutoVer
+        run: dotnet tool install --global AutoVer --version 0.0.21
+      # Set up a git user to be able to run git commands later on
+      - name: Setup Git User
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+      # Create the release branch which will contain the version changes and updated changelog
+      - name: Create Release Branch
+        id: create-release-branch
+        run: |
+          branch=releases/next-release
+          git checkout -b $branch
+          echo "BRANCH=$branch" >> $GITHUB_OUTPUT
+      # Update the version of projects based on the change files
+      - name: Increment Version
+        run: autover version
+        if: env.INPUT_OVERRIDE_VERSION == ''
+      # Update the version of projects based on the override version
+      - name: Increment Version
+        run: autover version --use-version "$INPUT_OVERRIDE_VERSION"
+        if: env.INPUT_OVERRIDE_VERSION != ''
+      # Update the changelog based on the change files
+      - name: Update Changelog
+        run: autover changelog
+      # Push the release branch up as well as the created tag
+      - name: Push Changes
+        run: |
+          branch=${{ steps.create-release-branch.outputs.BRANCH }}
+          git push origin $branch
+          git push origin $branch --tags
+      # Get the release name that will be used to create a PR
+      - name: Read Release Name
+        id: read-release-name
+        run: |
+          version=$(autover changelog --release-name)
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+      # Get the changelog that will be used to create a PR
+      - name: Read Changelog
+        id: read-changelog
+        run: |
+          changelog=$(autover changelog --output-to-console)
+          echo "CHANGELOG<<EOF"$'\n'"$changelog"$'\n'EOF >> "$GITHUB_OUTPUT"
+      # Create the Release PR and label it
+      - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+        run: |
+          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base v4sdk-development --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
+          gh pr edit $pr_url --add-label "Release PR"

--- a/.github/workflows/sync-v4sdk-release-v4sdk-development.yml
+++ b/.github/workflows/sync-v4sdk-release-v4sdk-development.yml
@@ -1,0 +1,137 @@
+# This GitHub Workflow is designed to run automatically after the Release PR, which was created by the `Create Release PR` workflow, is closed.
+# This workflow has 2 jobs. One will run if the `Release PR` is successfully merged, indicating that a release should go out.
+# The other will run if the `Release PR` was closed and a release is not intended to go out.
+name: Sync 'v4sdk-development' and 'v4sdk-release'
+
+# The workflow will automatically be triggered when any PR is closed.
+on:
+  pull_request:
+    types: [closed]
+
+permissions: 
+  contents: write
+  id-token: write
+
+jobs:
+  # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `v4sdk-development`. 
+  # This indicates that the merged PR was the `Release PR`. 
+  # This job will synchronize `v4sdk-development` and `v4sdk-release`, create a GitHub Release and delete the `releases/next-release` branch.
+  sync-dev-and-main:
+    name: Sync v4sdk-development and v4sdk-release
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'releases/next-release' &&
+      github.event.pull_request.base.ref == 'v4sdk-development'
+    runs-on: ubuntu-latest
+    steps:
+      # Assume an AWS Role that provides access to the Access Token
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
+        with:
+          role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
+          aws-region: us-west-2
+      # Retrieve the Access Token from Secrets Manager
+      - name: Retrieve secret from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
+          parse-json-secrets: true
+      # Checkout a full clone of the repo
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v4sdk-development
+          fetch-depth: 0
+          token: ${{ env.AWS_SECRET_TOKEN }}
+      # Install .NET8 which is needed for AutoVer
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Install AutoVer which is needed to retrieve information about the current release.
+      - name: Install AutoVer
+        run: dotnet tool install --global AutoVer --version 0.0.21
+      # Set up a git user to be able to run git commands later on
+      - name: Setup Git User
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+      # Retrieve the release name which is needed for the GitHub Release
+      - name: Read Release Name
+        id: read-release-name
+        run: |
+          version=$(autover changelog --release-name)
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+      # Retrieve the tag name which is needed for the GitHub Release
+      - name: Read Tag Name
+        id: read-tag-name
+        run: |
+          tag=$(autover changelog --tag-name)
+          echo "TAG=$tag" >> $GITHUB_OUTPUT
+      # Retrieve the changelog which is needed for the GitHub Release
+      - name: Read Changelog
+        id: read-changelog
+        run: |
+          changelog=$(autover changelog --output-to-console)
+          echo "CHANGELOG<<EOF"$'\n'"$changelog"$'\n'EOF >> "$GITHUB_OUTPUT"
+      # Merge v4sdk-development into v4sdk-release in order to synchronize the 2 branches
+      - name: Merge v4sdk-development to v4sdk-release
+        run: |
+          git fetch origin
+          git checkout v4sdk-release
+          git merge v4sdk-development
+          git push origin v4sdk-release
+      # Create the GitHub Release
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+        run: |
+          gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
+      # Delete the `releases/next-release` branch
+      - name: Clean up
+        run: |
+          git fetch origin
+          git push origin --delete releases/next-release
+  # This job will check if the PR was closed, it's source branch is `releases/next-release` and target branch is `v4sdk-development`. 
+  # This indicates that the closed PR was the `Release PR`.
+  # This job will delete the tag created by AutoVer and the release branch.
+  clean-up-closed-release:
+    name: Clean up closed release
+    if: |
+      github.event.pull_request.merged == false &&
+      github.event.pull_request.head.ref == 'releases/next-release' &&
+      github.event.pull_request.base.ref == 'v4sdk-development'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout a full clone of the repo
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: releases/next-release
+          fetch-depth: 0
+      # Install .NET8 which is needed for AutoVer
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Install AutoVer which is needed to retrieve information about the current release.
+      - name: Install AutoVer
+        run: dotnet tool install --global AutoVer --version 0.0.21
+      # Set up a git user to be able to run git commands later on
+      - name: Setup Git User
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+      # Retrieve the tag name to be deleted
+      - name: Read Tag Name
+        id: read-tag-name
+        run: |
+          tag=$(autover changelog --tag-name)
+          echo "TAG=$tag" >> $GITHUB_OUTPUT
+      # Delete the tag created by AutoVer and the release branch
+      - name: Clean up
+        run: |
+          git fetch origin
+          git push --delete origin ${{ steps.read-tag-name.outputs.TAG }}
+          git push origin --delete releases/next-release


### PR DESCRIPTION
*Description of changes:*
Duplicates existing `create-release-pr` and `sync-main-dev` workflows into V4 versions that target the V4 branches `v4sdk-release` and `v4sdk-development`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
