### PR TITLE
fix: fix an issue causing container deployments to fail when run on an ARM-based system

### DIFF
--- a/.autover/changes/f3bdd1b8-155d-416d-b4ff-0d1bcf119e45.json
+++ b/.autover/changes/f3bdd1b8-155d-416d-b4ff-0d1bcf119e45.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Fix an issue causing container deployments to fail when run on an ARM-based system"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="System.Text.Json" Version="6.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.CLI/ServerMode/AwsCredentialsAuthenticationHandler.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/AwsCredentialsAuthenticationHandler.cs
@@ -76,7 +76,7 @@ namespace AWS.Deploy.CLI.ServerMode
                 return Task.FromResult(AuthenticateResult.Fail("Missing Authorization header"));
             }
 
-            return Task.FromResult(ProcessAuthorizationHeader(value, _encryptionProvider));
+            return Task.FromResult(ProcessAuthorizationHeader(value.ToString(), _encryptionProvider));
         }
 
         public static AuthenticateResult ProcessAuthorizationHeader(string authorizationHeaderValue, IEncryptionProvider encryptionProvider)

--- a/src/AWS.Deploy.DockerEngine/AWS.Deploy.DockerEngine.csproj
+++ b/src/AWS.Deploy.DockerEngine/AWS.Deploy.DockerEngine.csproj
@@ -9,10 +9,12 @@
   <ItemGroup>
     <None Remove="Properties\DockerFileConfig.json" />
     <None Remove="Templates\Dockerfile.template" />
+    <None Remove="Templates\Dockerfile.Net6.template" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Properties\DockerFileConfig.json" />
+    <EmbeddedResource Include="Templates\Dockerfile.Net6.template" />
     <EmbeddedResource Include="Templates\Dockerfile.template" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.DockerEngine/DockerEngine.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerEngine.cs
@@ -81,7 +81,7 @@ namespace AWS.Deploy.DockerEngine
                 DetermineHTTPPortEnvironmentVariable(recommendation, recommendation.DeploymentBundle.DockerfileHttpPort));
             var projectDirectory = Path.GetDirectoryName(_projectPath) ?? "";
             var projectList = GetProjectList();
-            dockerFile.WriteDockerFile(projectDirectory, projectList);
+            dockerFile.WriteDockerFile(projectDirectory, projectList, recommendation.ProjectDefinition.TargetFramework);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace AWS.Deploy.DockerEngine
             if (string.IsNullOrEmpty(recommendation.DeploymentBundle.DockerExecutionDirectory))
             {
                 var projectFilename = Path.GetFileName(recommendation.ProjectPath);
-                
+
                 if (DockerUtilities.TryGetAbsoluteDockerfile(recommendation, _fileManager, _directoryManager, out var dockerFilePath))
                 {
                     using (var stream = File.OpenRead(dockerFilePath))

--- a/src/AWS.Deploy.DockerEngine/DockerFile.cs
+++ b/src/AWS.Deploy.DockerEngine/DockerFile.cs
@@ -48,9 +48,9 @@ namespace AWS.Deploy.DockerEngine
         /// <summary>
         /// Writes a docker file based on project information
         /// </summary>
-        public void WriteDockerFile(string projectDirectory, List<string>? projectList)
+        public void WriteDockerFile(string projectDirectory, List<string>? projectList, string? targetFramework)
         {
-            var dockerFileTemplate = ProjectUtilities.ReadTemplate();
+            var dockerFileTemplate = ProjectUtilities.ReadTemplate(targetFramework);
             var projects = "";
             var projectPath = "";
             var projectFolder = "";
@@ -99,7 +99,7 @@ namespace AWS.Deploy.DockerEngine
                 dockerFile = dockerFile
                     .Replace("{http-port-env-variable}", string.Empty);
             }
-            // For all other ports, it is up to the user to expose the HTTPS port in the dockerfile. 
+            // For all other ports, it is up to the user to expose the HTTPS port in the dockerfile.
             else
             {
                 dockerFile = dockerFile
@@ -119,7 +119,7 @@ namespace AWS.Deploy.DockerEngine
                     .Replace("{non-root-user}", "\r\nUSER app");
             }
 
-            // ProjectDefinitionParser will have transformed projectDirectory to an absolute path, 
+            // ProjectDefinitionParser will have transformed projectDirectory to an absolute path,
             // and DockerFileName is static so traversal should not be possible here.
             // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
             File.WriteAllText(Path.Combine(projectDirectory, Constants.Docker.DefaultDockerfileName), dockerFile);

--- a/src/AWS.Deploy.DockerEngine/ProjectUtilities.cs
+++ b/src/AWS.Deploy.DockerEngine/ProjectUtilities.cs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.IO;
 using System.Reflection;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.Extensions;
@@ -12,6 +11,7 @@ namespace AWS.Deploy.DockerEngine
     {
         private const string DockerFileConfig = "AWS.Deploy.DockerEngine.Properties.DockerFileConfig.json";
         private const string DockerfileTemplate = "AWS.Deploy.DockerEngine.Templates.Dockerfile.template";
+        private const string DockerfileTemplate_Net6 = "AWS.Deploy.DockerEngine.Templates.Dockerfile.Net6.template";
 
         /// <summary>
         /// Retrieves the Docker File Config
@@ -31,9 +31,22 @@ namespace AWS.Deploy.DockerEngine
         /// <summary>
         /// Reads dockerfile template file
         /// </summary>
-        internal static string ReadTemplate()
+        internal static string ReadTemplate(string? targetFramework)
         {
-            var template = Assembly.GetExecutingAssembly().ReadEmbeddedFile(DockerfileTemplate);
+            string templateLocation;
+            switch (targetFramework)
+            {
+                case "net6.0":
+                case "net5.0":
+                case "netcoreapp3.1":
+                    templateLocation = DockerfileTemplate_Net6;
+                    break;
+
+                default:
+                    templateLocation = DockerfileTemplate;
+                    break;
+            }
+            var template = Assembly.GetExecutingAssembly().ReadEmbeddedFile(templateLocation);
 
             if (string.IsNullOrWhiteSpace(template))
             {

--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.Net6.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.Net6.template
@@ -1,17 +1,14 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER app
+FROM {docker-base-image} AS base{non-root-user}
 WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
+{exposed-ports}
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-ARG TARGETARCH
+FROM {docker-build-image} AS build
 WORKDIR /src
-COPY ["WebAppNet8.csproj", ""]
-RUN dotnet restore "WebAppNet8.csproj" -a $TARGETARCH
+{project-path-list}
+RUN dotnet restore "{project-path}"
 COPY . .
-WORKDIR "/src/"
-RUN dotnet build "WebAppNet8.csproj" -c Release -o /app/build -a $TARGETARCH
+WORKDIR "/src/{project-folder}"
+RUN dotnet build "{project-name}" -c Release -o /app/build
 
 FROM build AS publish
 RUN apt-get update -yq \
@@ -21,9 +18,9 @@ RUN apt-get update -yq \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
-RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish -a $TARGETARCH
+RUN dotnet publish "{project-name}" -c Release -o /app/publish
 
-FROM base AS final
+FROM base AS final{http-port-env-variable}
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "WebAppNet8.dll"]
+ENTRYPOINT ["dotnet", "{assembly-name}.dll"]

--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
@@ -2,13 +2,14 @@ FROM {docker-base-image} AS base{non-root-user}
 WORKDIR /app
 {exposed-ports}
 
-FROM {docker-build-image} AS build
+FROM --platform=$BUILDPLATFORM {docker-build-image} AS build
+ARG TARGETARCH
 WORKDIR /src
 {project-path-list}
-RUN dotnet restore "{project-path}"
+RUN dotnet restore "{project-path}" -a $TARGETARCH
 COPY . .
 WORKDIR "/src/{project-folder}"
-RUN dotnet build "{project-name}" -c Release -o /app/build
+RUN dotnet build "{project-name}" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
 RUN apt-get update -yq \
@@ -18,7 +19,7 @@ RUN apt-get update -yq \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
-RUN dotnet publish "{project-name}" -c Release -o /app/publish
+RUN dotnet publish "{project-name}" -c Release -o /app/publish -a $TARGETARCH
 
 FROM base AS final{http-port-env-variable}
 WORKDIR /app

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\AWS.Deploy.Recipes.CDK.Common\RecipeProps.cs" Link="RecipeProps.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="AWSSDK.CloudControlApi" Version="3.7.300.77" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.302.18" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.77" />
@@ -31,7 +27,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="5.0.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="5.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="13.4.0" />
   </ItemGroup>
@@ -39,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="..\AWS.Deploy.Recipes\AWS.Deploy.Recipes.csproj" />
     <ProjectReference Include="..\AWS.Deploy.DockerEngine\AWS.Deploy.DockerEngine.csproj" />
+    <ProjectReference Include="..\AWS.Deploy.Recipes.CDK.Common\AWS.Deploy.Recipes.CDK.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -74,6 +74,11 @@ namespace AWS.Deploy.Orchestration
             DockerUtilities.TryGetAbsoluteDockerfile(recommendation, _fileManager, _directoryManager, out var dockerFile);
 
             var dockerBuildCommand = $"docker build -t {imageTag} -f \"{dockerFile}\"{buildArgs} .";
+            if (RuntimeInformation.OSArchitecture != Architecture.X64)
+            {
+                dockerBuildCommand = $"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{dockerFile}\"{buildArgs} .";
+            }
+
             _interactiveService.LogInfoMessage($"Docker Execution Directory: {Path.GetFullPath(dockerExecutionDirectory)}");
             _interactiveService.LogInfoMessage($"Docker Build Command: {dockerBuildCommand}");
 

--- a/src/AWS.Deploy.Orchestration/TemplateEngine.cs
+++ b/src/AWS.Deploy.Orchestration/TemplateEngine.cs
@@ -41,7 +41,7 @@ namespace AWS.Deploy.Orchestration
             {
                 throw new InvalidOperationException($"{nameof(recommendation.Recipe.CdkProjectTemplateId)} cannot be null or an empty string");
             }
-                    
+
             //The location of the base template that will be installed into the templating engine
             var cdkProjectTemplateDirectory = Path.Combine(
                 Path.GetDirectoryName(recommendation.Recipe.RecipePath) ??
@@ -67,7 +67,7 @@ namespace AWS.Deploy.Orchestration
             var templateParameters = new Dictionary<string, string> {
                 // CDK Template projects can parameterize the version number of the AWS.Deploy.Recipes.CDK.Common package. This avoid
                 // projects having to be modified every time the package version is bumped.
-                { "AWSDeployRecipesCDKCommonVersion", FileVersionInfo.GetVersionInfo(typeof(Constants.CloudFormationIdentifier).Assembly.Location).ProductVersion
+                { "AWSDeployRecipesCDKCommonVersion", FileVersionInfo.GetVersionInfo(typeof(AWS.Deploy.Recipes.CDK.Common.CDKRecipeSetup).Assembly.Location).ProductVersion
                                                       ?? throw new InvalidAWSDeployRecipesCDKCommonVersionException(DeployToolErrorCode.InvalidAWSDeployRecipesCDKCommonVersion, "The version number of the AWS.Deploy.Recipes.CDK.Common package is invalid.") }
             };
 

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -91,8 +91,16 @@ namespace AWS.Deploy.CLI.UnitTests
             var expectedDockerFile = Path.GetFullPath(Path.Combine(".", "Dockerfile"), recommendation.GetProjectDirectory());
             var dockerExecutionDirectory = Directory.GetParent(Path.GetFullPath(recommendation.ProjectPath)).Parent.Parent;
 
-            Assert.Equal($"docker build -t {imageTag} -f \"{expectedDockerFile}\" .",
-                _commandLineWrapper.CommandsToExecute.First().Command);
+            if (RuntimeInformation.OSArchitecture.Equals(Architecture.X64))
+            {
+                Assert.Equal($"docker build -t {imageTag} -f \"{expectedDockerFile}\" .",
+                    _commandLineWrapper.CommandsToExecute.First().Command);
+            }
+            else
+            {
+                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{expectedDockerFile}\" .",
+                    _commandLineWrapper.CommandsToExecute.First().Command);
+            }
             Assert.Equal(dockerExecutionDirectory.FullName,
                 _commandLineWrapper.CommandsToExecute.First().WorkingDirectory);
         }
@@ -116,8 +124,16 @@ namespace AWS.Deploy.CLI.UnitTests
 
             var expectedDockerFile = Path.GetFullPath(Path.Combine(".", "Dockerfile"), recommendation.GetProjectDirectory());
 
-            Assert.Equal($"docker build -t {imageTag} -f \"{expectedDockerFile}\" .",
-                _commandLineWrapper.CommandsToExecute.First().Command);
+            if (RuntimeInformation.OSArchitecture.Equals(Architecture.X64))
+            {
+                Assert.Equal($"docker build -t {imageTag} -f \"{expectedDockerFile}\" .",
+                    _commandLineWrapper.CommandsToExecute.First().Command);
+            }
+            else
+            {
+                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{expectedDockerFile}\" .",
+                    _commandLineWrapper.CommandsToExecute.First().Command);
+            }
             Assert.Equal(projectPath,
                 _commandLineWrapper.CommandsToExecute.First().WorkingDirectory);
         }
@@ -144,9 +160,16 @@ namespace AWS.Deploy.CLI.UnitTests
             var cloudApplication = new CloudApplication("ConsoleAppTask", string.Empty, CloudApplicationResourceType.CloudFormationStack, recommendation.Recipe.Id);
             var imageTag = "imageTag";
             await _deploymentBundleHandler.BuildDockerImage(cloudApplication, recommendation, imageTag);
-
-            Assert.Equal($"docker build -t {imageTag} -f \"{dockerfilePath}\" .",
-                _commandLineWrapper.CommandsToExecute.First().Command);
+            if (RuntimeInformation.OSArchitecture.Equals(Architecture.X64))
+            {
+                Assert.Equal($"docker build -t {imageTag} -f \"{dockerfilePath}\" .",
+                    _commandLineWrapper.CommandsToExecute.First().Command);
+            }
+            else
+            {
+                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{dockerfilePath}\" .",
+                    _commandLineWrapper.CommandsToExecute.First().Command);
+            }
             Assert.Equal(expectedDockerExecutionDirectory.FullName,
                 _commandLineWrapper.CommandsToExecute.First().WorkingDirectory);
         }

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -64,10 +64,15 @@ namespace AWS.Deploy.CLI.UnitTests
             Assert.False(string.IsNullOrWhiteSpace(dockerFileConfig));
         }
 
-        [Fact]
-        public void DockerfileTemplateExists()
+        [Theory]
+        [InlineData("net8.0")]
+        [InlineData("net7.0")]
+        [InlineData("net6.0")]
+        [InlineData("net5.0")]
+        [InlineData("netcoreapp3.1")]
+        public void DockerfileTemplateExists(string targetFramework)
         {
-            var dockerFileTemplate = ProjectUtilities.ReadTemplate();
+            var dockerFileTemplate = ProjectUtilities.ReadTemplate(targetFramework);
             Assert.False(string.IsNullOrWhiteSpace(dockerFileTemplate));
         }
 

--- a/testapps/docker/WebAppNet7/Dockerfile
+++ b/testapps/docker/WebAppNet7/Dockerfile
@@ -3,13 +3,14 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+ARG TARGETARCH
 WORKDIR /src
 COPY ["WebAppNet7.csproj", ""]
-RUN dotnet restore "WebAppNet7.csproj"
+RUN dotnet restore "WebAppNet7.csproj" -a $TARGETARCH
 COPY . .
 WORKDIR "/src/"
-RUN dotnet build "WebAppNet7.csproj" -c Release -o /app/build
+RUN dotnet build "WebAppNet7.csproj" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
 RUN apt-get update -yq \
@@ -19,7 +20,7 @@ RUN apt-get update -yq \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
-RUN dotnet publish "WebAppNet7.csproj" -c Release -o /app/publish
+RUN dotnet publish "WebAppNet7.csproj" -c Release -o /app/publish -a $TARGETARCH
 
 FROM base AS final
 WORKDIR /app

--- a/testapps/docker/WebAppNet7/ReferenceDockerfile
+++ b/testapps/docker/WebAppNet7/ReferenceDockerfile
@@ -3,13 +3,14 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+ARG TARGETARCH
 WORKDIR /src
 COPY ["WebAppNet7.csproj", ""]
-RUN dotnet restore "WebAppNet7.csproj"
+RUN dotnet restore "WebAppNet7.csproj" -a $TARGETARCH
 COPY . .
 WORKDIR "/src/"
-RUN dotnet build "WebAppNet7.csproj" -c Release -o /app/build
+RUN dotnet build "WebAppNet7.csproj" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
 RUN apt-get update -yq \
@@ -19,7 +20,7 @@ RUN apt-get update -yq \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
-RUN dotnet publish "WebAppNet7.csproj" -c Release -o /app/publish
+RUN dotnet publish "WebAppNet7.csproj" -c Release -o /app/publish -a $TARGETARCH
 
 FROM base AS final
 WORKDIR /app

--- a/testapps/docker/WebAppNet8/Dockerfile
+++ b/testapps/docker/WebAppNet8/Dockerfile
@@ -4,13 +4,14 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG TARGETARCH
 WORKDIR /src
 COPY ["WebAppNet8.csproj", ""]
-RUN dotnet restore "WebAppNet8.csproj"
+RUN dotnet restore "WebAppNet8.csproj" -a $TARGETARCH
 COPY . .
 WORKDIR "/src/"
-RUN dotnet build "WebAppNet8.csproj" -c Release -o /app/build
+RUN dotnet build "WebAppNet8.csproj" -c Release -o /app/build -a $TARGETARCH
 
 FROM build AS publish
 RUN apt-get update -yq \
@@ -20,7 +21,7 @@ RUN apt-get update -yq \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
-RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish
+RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish -a $TARGETARCH
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7715

*Description of changes:*
* Updated the default `Dockerfile` template to include a fix for the hanging `dotnet restore` in docker build. This follows the following Microsoft blog https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/. This fix only applies to .NET7 and newer since the `-a` argument was added in .NET7.
* Added a 2nd `Dockerfile` template which maintains the current behavior for .NET6 and older.
* Fixed an issue where the correct version of `AWS.Deploy.Recipes.CDK.Common` is not used in the CDK projects which was broken after we dropped `Nerdback.GitVersioning`. This issue does not currently exist in production. It is localized to the `dev` branch.
* This update will change the behavior of existing customers with generated dockerfiles. If they used the deploy tool to generate a dockerfile, if they try to build that image on an ARM-based system, the docker build will hang. As opposed to the previous behavior where the docker build succeeds but the deployment fails. This change does not break an existing use case, but changes where the issue occurs. The fix is to simply delete the dockerfile and let the deploy tool generate a new one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
