### PR TITLE
ci: add ability to version all projects the same

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -14,6 +14,7 @@
     }
   ],
   "UseCommitsForChangelog": false,
+  "UseSameVersionForAllProjects": true,
   "DefaultIncrementType": "Patch",
   "ChangeFilesDetermineIncrementType": true
 }

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -49,7 +49,7 @@ jobs:
           dotnet-version: 8.0.x
       # Install AutoVer to automate versioning and changelog creation
       - name: Install AutoVer
-        run: dotnet tool install --global AutoVer --version 0.0.21
+        run: dotnet tool install --global AutoVer --version 0.0.22
       # Set up a git user to be able to run git commands later on
       - name: Setup Git User
         run: |

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -51,7 +51,7 @@ jobs:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
       - name: Install AutoVer
-        run: dotnet tool install --global AutoVer --version 0.0.21
+        run: dotnet tool install --global AutoVer --version 0.0.22
       # Set up a git user to be able to run git commands later on
       - name: Setup Git User
         run: |
@@ -117,7 +117,7 @@ jobs:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
       - name: Install AutoVer
-        run: dotnet tool install --global AutoVer --version 0.0.21
+        run: dotnet tool install --global AutoVer --version 0.0.22
       # Set up a git user to be able to run git commands later on
       - name: Setup Git User
         run: |


### PR DESCRIPTION
*Description of changes:*
This change updates `AutoVer` to version 0.0.22 to add support for versioning all projects using the same version number. Moving forward, whether a project has changes or not, its version will be updated using the same version as the projects that have changes.
As an example, if we have the following versions:
* Project 1 (1.20.0)
* Project 2 (1.25.0)
* Project 3 (1.30.0)

The version 1.30.0 will be used for future versioning. Depending on what increment type you are using, all projects will have the following version:

* Patch: 1.30.1
* Minor: 1.31.0
* Major: 2.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
