### PR TITLE
chore: remove System.Text.Json dependency to not conflict user apps

### DIFF
--- a/.autover/changes/a341e9ce-1356-465d-b1b4-77743905d586.json
+++ b/.autover/changes/a341e9ce-1356-465d-b1b4-77743905d586.json
@@ -4,21 +4,21 @@
       "Name": "AWS.Deploy.CLI",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Bump System.Text.Json to 8.0.5 to address a known high severity vulnerability"
+        "Removed the System.Text.Json dependency from the deployment project templates"
       ]
     },
     {
       "Name": "AWS.Deploy.Recipes.CDK.Common",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Bump System.Text.Json to 8.0.5 to address a known high severity vulnerability"
+        "Removed the System.Text.Json dependency from the deployment project templates"
       ]
     },
     {
       "Name": "AWS.Deploy.ServerMode.Client",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Bump System.Text.Json to 8.0.5 to address a known high severity vulnerability"
+        "Removed the System.Text.Json dependency from the deployment project templates"
       ]
     }
   ]

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -26,7 +26,6 @@
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -26,7 +26,6 @@
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -28,7 +28,6 @@
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -28,7 +28,6 @@
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -26,7 +26,6 @@
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -26,7 +26,6 @@
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -26,7 +26,6 @@
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />


### PR DESCRIPTION
*Description of changes:*
While trying to deploy a web app, the deployment failed due to a conflict between the `System.Text.Json` in the CDK Templates and the one in my web app. In order to avoid these conflicts, we should remove the reference from the CDK templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
