### PR TITLE
feat: add support for deploying ARM console apps to ECS Fargate

### DIFF
--- a/.autover/changes/a2dd7cca-b2c5-47e1-8bce-34eb5239a047.json
+++ b/.autover/changes/a2dd7cca-b2c5-47e1-8bce-34eb5239a047.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support for deploying ARM console apps to ECS Fargate"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/Generated/Recipe.cs
@@ -110,7 +110,11 @@ namespace ConsoleAppECSFargateScheduleTask
             {
                 TaskRole = AppIAMTaskRole,
                 Cpu = settings.TaskCpu,
-                MemoryLimitMiB = settings.TaskMemory
+                MemoryLimitMiB = settings.TaskMemory,
+                RuntimePlatform = new RuntimePlatform
+                {
+                    CpuArchitecture = CpuArchitecture.Of(props.EnvironmentArchitecture ?? string.Empty)
+                }
             }));
 
             AppLogging = new AwsLogDriver(InvokeCustomizeCDKPropsEvent(nameof(AppLogging), this, new AwsLogDriverProps

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Recipe.cs
@@ -117,7 +117,11 @@ namespace ConsoleAppEcsFargateService
             {
                 TaskRole = AppIAMTaskRole,
                 Cpu = settings.TaskCpu,
-                MemoryLimitMiB = settings.TaskMemory
+                MemoryLimitMiB = settings.TaskMemory,
+                RuntimePlatform = new RuntimePlatform
+                {
+                    CpuArchitecture = CpuArchitecture.Of(props.EnvironmentArchitecture ?? string.Empty)
+                }
             }));
 
             AppLogging = new AwsLogDriver(InvokeCustomizeCDKPropsEvent(nameof(AppLogging), this, new AwsLogDriverProps

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "ConsoleAppEcsFargateScheduleTask",
-    "Version": "1.0.3",
+    "Version": "1.1.0",
     "Name": "Scheduled Task on Amazon Elastic Container Service (ECS) using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -11,7 +11,7 @@
     "ShortDescription": "Deploys a scheduled task as a Linux container image to a fully managed container orchestration service. Dockerfile will be automatically generated if needed.",
     "TargetService": "Amazon Elastic Container Service",
     "TargetPlatform": "Linux",
-    "SupportedArchitectures": [ "x86_64" ],
+    "SupportedArchitectures": [ "x86_64", "arm64" ],
 
     "DisplayedResources": [
         {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -1,7 +1,7 @@
 {
     "$schema": "./aws-deploy-recipe-schema.json",
     "Id": "ConsoleAppEcsFargateService",
-    "Version": "1.0.3",
+    "Version": "1.1.0",
     "Name": "Service on Amazon Elastic Container Service (ECS) using AWS Fargate",
     "DeploymentType": "CdkProject",
     "DeploymentBundle": "Container",
@@ -11,7 +11,7 @@
     "ShortDescription": "Deploys a service as a Linux container image to a fully managed container orchestration service. Dockerfile will be automatically generated if needed.",
     "TargetService": "Amazon Elastic Container Service",
     "TargetPlatform": "Linux",
-    "SupportedArchitectures": [ "x86_64" ],
+    "SupportedArchitectures": [ "x86_64", "arm64" ],
 
     "DisplayedResources": [
         {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-5124

*Description of changes:*
* Updated `ConsoleAppEcsFargateService` and `ConsoleAppEcsFargateScheduleTask` recipes and CDK templates to support ARM deployments.
* Added an integration test to deploy an ARM console app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
