### PR TITLE
Add support for .NET 9 and support for disabling IMDS v1

### DIFF
--- a/.autover/changes/07AEC2AC-0C7B-4C60-9EAF-C92E6A805559.json
+++ b/.autover/changes/07AEC2AC-0C7B-4C60-9EAF-C92E6A805559.json
@@ -1,0 +1,13 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added support for .NET 9 in deployment recipes.",
+		"Added ability to configure EC2 IMDSv1 access for the Windows and Linux Elastic Beanstalk recipes.",
+		"Support Elastic Beanstalk's transition to using EC2 Launch Templates from the deprecated Launch Configuration."
+      ]
+    }
+  ]
+}

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Linux.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Linux.md
@@ -34,6 +34,10 @@
     * ID: InstanceType
     * Description: The EC2 instance type of the EC2 instances created for the environment.
     * Type: String
+* **Access to IMDS v1**
+    * ID: IMDSv1Access
+    * Description: Access to IMDS v1; Default means new deployments will disable IMDSv1, redeployments leave the setting at its current value.
+    * Type: String
 * **Environment Type**
     * ID: EnvironmentType
     * Description: The type of environment to create; for example, a single instance for development work or load balanced for production.

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Windows.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to AWS Elastic Beanstalk on Windows.md
@@ -29,6 +29,10 @@
     * ID: InstanceType
     * Description: The EC2 instance type of the EC2 instances created for the environment.
     * Type: String
+* **Access to IMDS v1**
+    * ID: IMDSv1Access
+    * Description: Access to IMDS v1; Default means new deployments will disable IMDSv1, redeployments leave the setting at its current value.
+    * Type: String
 * **Environment Type**
     * ID: EnvironmentType
     * Description: The type of environment to create; for example, a single instance for development work or load balanced for production.

--- a/src/AWS.Deploy.DockerEngine/Properties/DockerFileConfig.json
+++ b/src/AWS.Deploy.DockerEngine/Properties/DockerFileConfig.json
@@ -3,10 +3,16 @@
         "SdkType": "Microsoft.NET.Sdk.Web",
         "ImageMapping": [
             {
+                "TargetFramework": "net9.0",
+                "BaseImage": "mcr.microsoft.com/dotnet/aspnet:9.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:9.0"
+            },
+            {
                 "TargetFramework": "net8.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/aspnet:8.0",
                 "BuildImage": "mcr.microsoft.com/dotnet/sdk:8.0"
-            },            {
+            },
+            {
                 "TargetFramework": "net7.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/aspnet:7.0",
                 "BuildImage": "mcr.microsoft.com/dotnet/sdk:7.0"
@@ -32,10 +38,15 @@
         "SdkType": "Microsoft.NET.Sdk",
         "ImageMapping": [
             {
+                "TargetFramework": "net9.0",
+                "BaseImage": "mcr.microsoft.com/dotnet/runtime:9.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:9.0"
+            },
+            {
                 "TargetFramework": "net8.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/runtime:8.0",
                 "BuildImage": "mcr.microsoft.com/dotnet/sdk:8.0"
-            },            
+            },
             {
                 "TargetFramework": "net7.0",
                 "BaseImage": "mcr.microsoft.com/dotnet/runtime:7.0",

--- a/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
+++ b/src/AWS.Deploy.Orchestration/CdkAppSettingsSerializer.cs
@@ -53,7 +53,8 @@ namespace AWS.Deploy.Orchestration
                 ECRRepositoryName = recommendation.DeploymentBundle.ECRRepositoryName ?? "",
                 ECRImageTag = recommendation.DeploymentBundle.ECRImageTag ?? "",
                 DotnetPublishZipPath = recommendation.DeploymentBundle.DotnetPublishZipPath ?? "",
-                DotnetPublishOutputDirectory = recommendation.DeploymentBundle.DotnetPublishOutputDirectory ?? ""
+                DotnetPublishOutputDirectory = recommendation.DeploymentBundle.DotnetPublishOutputDirectory ?? "",
+                NewDeployment = !recommendation.IsExistingCloudApplication
             };
 
             // Persist deployment bundle settings

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -133,9 +133,9 @@ namespace AWS.Deploy.Orchestration
                 if (string.IsNullOrEmpty(targetFramework))
                     return;
 
-                // Elastic Beanstalk doesn't currently have .NET 7 preinstalled.
-                var unavailableFramework = new List<string> { "net7.0" };
-                var frameworkNames = new Dictionary<string, string> { { "net7.0", ".NET 7" } };
+                // Elastic Beanstalk doesn't currently have .NET 7 and 9 preinstalled.
+                var unavailableFramework = new List<string> { "net7.0", "net9.0" };
+                var frameworkNames = new Dictionary<string, string> { { "net7.0", ".NET 7" }, { "net9.0", ".NET 9" } };
                 if (unavailableFramework.Contains(targetFramework))
                 {
                     _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have {frameworkNames[targetFramework]} preinstalled");

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Deploy.Recipes.CDK.Common/RecipeProps.cs
+++ b/src/AWS.Deploy.Recipes.CDK.Common/RecipeProps.cs
@@ -70,6 +70,11 @@ namespace AWS.Deploy.Recipes.CDK.Common
         /// The account ID used during deployment.
         /// </summary>
         string? AWSAccountId { get; set; }
+
+        /// <summary>
+        /// True if the recipe is doing a new deployment.
+        /// </summary>
+        bool NewDeployment { get; set; }
     }
 
     /// <summary>
@@ -137,6 +142,11 @@ namespace AWS.Deploy.Recipes.CDK.Common
         /// The account ID used during deployment.
         /// </summary>
         public string? AWSAccountId { get; set; }
+
+        /// <summary>
+        /// True if the recipe is doing a redeployment.
+        /// </summary>
+        public bool NewDeployment { get; set; } = false;
 
         /// A parameterless constructor is needed for <see cref="Microsoft.Extensions.Configuration.ConfigurationBuilder"/>
         /// or the classes will fail to initialize.

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/Generated/Configurations/Configuration.cs
@@ -44,6 +44,11 @@ namespace AspNetAppElasticBeanstalkLinux.Configurations
         public BeanstalkApplicationConfiguration BeanstalkApplication { get; set; }
 
         /// <summary>
+        /// Control of IMDS v1 accessibility.
+        /// </summary>
+        public string IMDSv1Access { get; set; } = Recipe.IMDS_V1_DEFAULT;
+
+        /// <summary>
         /// The name of an Elastic Beanstalk solution stack (platform version) to use with the environment.
         /// </summary>
         public string ElasticBeanstalkPlatformArn { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
 
     <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.42" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Configurations/Configuration.cs
@@ -44,6 +44,11 @@ namespace AspNetAppElasticBeanstalkWindows.Configurations
         public BeanstalkApplicationConfiguration BeanstalkApplication { get; set; }
 
         /// <summary>
+        /// Control of IMDS v1 accessibility.
+        /// </summary>
+        public string IMDSv1Access { get; set; } = Recipe.IMDS_V1_DEFAULT;
+
+        /// <summary>
         /// The name of an Elastic Beanstalk solution stack (platform version) to use with the environment.
         /// </summary>
         public string ElasticBeanstalkPlatformArn { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/Generated/Recipe.cs
@@ -33,6 +33,10 @@ namespace AspNetAppElasticBeanstalkWindows
         public const string LOADBALANCERTYPE_APPLICATION = "application";
         public const string LOADBALANCERSCHEME_PUBLIC = "public";
 
+        public const string IMDS_V1_DEFAULT = "Default";
+        public const string IMDS_V1_DISABLED = "Disabled";
+        public const string IMDS_V1_ENABLED = "Enabled";
+
         public const string REVERSEPROXY_NGINX = "nginx";
         
         public const string ENHANCED_HEALTH_REPORTING = "enhanced";
@@ -74,7 +78,7 @@ namespace AspNetAppElasticBeanstalkWindows
             ConfigureVpc(settings);
             ConfigureIAM(settings);
             var beanstalkApplicationName = ConfigureApplication(settings);
-            ConfigureBeanstalkEnvironment(settings, beanstalkApplicationName);
+            ConfigureBeanstalkEnvironment(props.NewDeployment, settings, beanstalkApplicationName);
         }
 
         private void ConfigureVpc(Configuration settings)
@@ -200,7 +204,7 @@ namespace AspNetAppElasticBeanstalkWindows
             return beanstalkApplicationName;
         }
 
-        private void ConfigureBeanstalkEnvironment(Configuration settings, string beanstalkApplicationName)
+        private void ConfigureBeanstalkEnvironment(bool newDeployment, Configuration settings, string beanstalkApplicationName)
         {
             if (Ec2InstanceProfile == null)
                 throw new InvalidOperationException($"{nameof(Ec2InstanceProfile)} has not been set. The {nameof(ConfigureIAM)} method should be called before {nameof(ConfigureBeanstalkEnvironment)}");
@@ -237,6 +241,18 @@ namespace AspNetAppElasticBeanstalkWindows
                         Value = settings.EnhancedHealthReporting
                    }
                 };
+
+            if (newDeployment ||
+                (!newDeployment && !string.Equals(settings.IMDSv1Access, IMDS_V1_DEFAULT, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                var computedDisableIMDSv1 = string.Equals(settings.IMDSv1Access, IMDS_V1_ENABLED, StringComparison.InvariantCultureIgnoreCase) ? "false" : "true";
+                optionSettingProperties.Add(new CfnEnvironment.OptionSettingProperty
+                {
+                    Namespace = "aws:autoscaling:launchconfiguration",
+                    OptionName = "DisableIMDSv1",
+                    Value = computedDisableIMDSv1
+                });
+            }
 
             if (!string.IsNullOrEmpty(settings.InstanceType))
             {

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.155.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppAppRunner.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -41,7 +41,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ],
@@ -262,6 +262,21 @@
                     "ValidatorType": "InstanceType"
                 }
             ]
+        },
+        {
+            "Id": "IMDSv1Access",
+            "Name": "Access to IMDS v1",
+            "Category": "Compute",
+            "Description": "Access to IMDS v1; Default means new deployments will disable IMDSv1, redeployments leave the setting at its current value.",
+            "Type": "String",
+            "DefaultValue": "Default",
+            "AllowedValues": [
+                "Default",
+                "Disabled",
+                "Enabled"
+            ],
+            "AdvancedSetting": false,
+            "Updatable": true
         },
         {
             "Id": "EnvironmentType",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkWindows.recipe
@@ -33,7 +33,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ],
@@ -250,6 +250,21 @@
                     "ValidatorType": "WindowsInstanceType"
                 }
             ]
+        },
+        {
+            "Id": "IMDSv1Access",
+            "Name": "Access to IMDS v1",
+            "Category": "Compute",
+            "Description": "Access to IMDS v1; Default means new deployments will disable IMDSv1, redeployments leave the setting at its current value.",
+            "Type": "String",
+            "DefaultValue": "Default",
+            "AllowedValues": [
+                "Default",
+                "Disabled",
+                "Enabled"
+            ],
+            "AdvancedSetting": false,
+            "Updatable": true
         },
         {
             "Id": "EnvironmentType",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkEnvironment.recipe
@@ -25,7 +25,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppExistingBeanstalkWindowsEnvironment.recipe
@@ -25,7 +25,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ],

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateScheduleTask.recipe
@@ -41,7 +41,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 },
                 {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -36,7 +36,7 @@
                     "Type": "MSProperty",
                     "Condition": {
                         "PropertyName": "TargetFramework",
-                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0" ]
+                        "AllowedValues": [ "netcoreapp3.1", "net5.0", "net6.0", "net7.0", "net8.0", "net9.0" ]
                     }
                 }
             ],

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -174,6 +174,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
                 { "key1", "value1" },
                 { "key2", "value2" }
             });
+            await _optionSettingHandler.SetOptionSettingValue(selectedRecommendation, "IMDSv1Access", "Disabled");
 
             // ACT
             await _deploymentSettingsHandler.SaveSettings(new SaveSettingsConfiguration(saveSettingsType, actualSnapshotFilePath), selectedRecommendation, cloudApplication, _orchestratorSession);

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer.json
@@ -9,6 +9,7 @@
       "EnvironmentName": "MyBeanstalkEnvironment"
     },
     "InstanceType": "",
+    "IMDSv1Access": "Disabled",
     "EnvironmentType": "LoadBalanced",
     "LoadBalancerType": "application",
     "LoadBalancerScheme": "public",

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer_ModifiedOnly.json
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/TestFiles/SettingsSnapshot_NonContainer_ModifiedOnly.json
@@ -7,6 +7,7 @@
     "BeanstalkEnvironment": {
       "EnvironmentName": "MyBeanstalkEnvironment"
     },
+    "IMDSv1Access": "Disabled",
     "EnvironmentType": "LoadBalanced",
     "XRayTracingSupportEnabled": true,
     "ElasticBeanstalkEnvironmentVariables": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-deploy/issues/877

*Description of changes:*
EC2 made a change that new accounts created after Oct 1 2024. This means today if an account created after Oct 1st tries to deploy to Beanstalk using our tooling it will fail because it can't create a LaunchConfiguration.

To force Beanstalk you need to set one of the following 4 settings.
* RootVolumeType
* BlockDeviceMappings
* DisableIMDSv1 -> `true`
* EnableSpot
(For reference the Beantalk Developer Guide: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-autoscaling-launch-templates.html)

None of these setting are currently settable in the tooling. Ideally we should add support for now I added `DisableIMDSv1`. The other settings require more settings to be set when enabled and there isn't an obvious default.

The  `DisableIMDSv1` is a boolean property but we have to be careful not to automatically set this to `true` on existing environments when users do a redeployment. That could break environments. The compromise I did was modeled the property as 3 state value: Enabled, Disabled and Default. 

The `Default` value is the the default for the new setting in the recipe. Using `Default` means in the CDK project to set `DisableIMDSv1` for new deployments but for redeployments leave the setting alone. That way existing users when they upgrade to the new version of the tooling no change will be made to their environments when they redeploy. This required adding metadata being passed into the CDK project whether it was being run for a new deployment or not.

I decided to make the changes to add .NET 9 support while I was waiting for test deployments to finish. The change was just to add the .NET 9 target in the recipe rules files and update the docker manifest.

### Testing

I have run all of the unit and integ tests. Before making any changes I created a new AWS account and reproduced the failure situation. After making the changes I was able to do deployments and redeployments with both my old account and new account. I also ran through .NET 9 deployments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
