### PR TITLE
Read region value for non default profiles

### DIFF
--- a/.autover/changes/ebd7f49a-72cd-4c5b-83f4-2790a2560e94.json
+++ b/.autover/changes/ebd7f49a-72cd-4c5b-83f4-2790a2560e94.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Read region value for non default profiles"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.CLI/AWSCredentialsFactory.cs
+++ b/src/AWS.Deploy.CLI/AWSCredentialsFactory.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
+
+namespace AWS.Deploy.CLI
+{
+    /// <inheritdoc />
+    public class AWSCredentialsFactory : IAWSCredentialsFactory
+    {
+        /// <inheritdoc />
+        public AWSCredentials Create()
+        {
+            return FallbackCredentialsFactory.GetCredentials();
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/CommandFactory.cs
@@ -209,8 +209,8 @@ namespace AWS.Deploy.CLI.Commands
                         deploymentSettings = await _deploymentSettingsHandler.ReadSettings(applyPath);
                     }
 
-                    var awsCredentials = await _awsUtilities.ResolveAWSCredentials(input.Profile ?? deploymentSettings?.AWSProfile);
-                    var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region ?? deploymentSettings?.AWSRegion);
+                    var (awsCredentials, regionFromProfile) = await _awsUtilities.ResolveAWSCredentials(input.Profile ?? deploymentSettings?.AWSProfile);
+                    var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region ?? deploymentSettings?.AWSRegion ?? regionFromProfile);
 
                     _commandLineWrapper.RegisterAWSContext(awsCredentials, awsRegion);
                     _awsClientFactory.RegisterAWSContext(awsCredentials, awsRegion);
@@ -318,8 +318,8 @@ namespace AWS.Deploy.CLI.Commands
                     _toolInteractiveService.Diagnostics = input.Diagnostics;
                     _toolInteractiveService.DisableInteractive = input.Silent;
 
-                    var awsCredentials = await _awsUtilities.ResolveAWSCredentials(input.Profile);
-                    var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region);
+                    var (awsCredentials, regionFromProfile) = await _awsUtilities.ResolveAWSCredentials(input.Profile);
+                    var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region ?? regionFromProfile);
 
                     _awsClientFactory.ConfigureAWSOptions(awsOption =>
                     {
@@ -401,8 +401,8 @@ namespace AWS.Deploy.CLI.Commands
                 {
                     _toolInteractiveService.Diagnostics = input.Diagnostics;
 
-                    var awsCredentials = await _awsUtilities.ResolveAWSCredentials(input.Profile);
-                    var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region);
+                    var (awsCredentials, regionFromProfile) = await _awsUtilities.ResolveAWSCredentials(input.Profile);
+                    var awsRegion = _awsUtilities.ResolveAWSRegion(input.Region ?? regionFromProfile);
 
                     _awsClientFactory.ConfigureAWSOptions(awsOptions =>
                     {

--- a/src/AWS.Deploy.CLI/CredentialProfileStoreChainFactory.cs
+++ b/src/AWS.Deploy.CLI/CredentialProfileStoreChainFactory.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.CredentialManagement;
+
+namespace AWS.Deploy.CLI
+{
+    /// <inheritdoc />
+    public class CredentialProfileStoreChainFactory : ICredentialProfileStoreChainFactory
+    {
+        /// <inheritdoc />
+        public CredentialProfileStoreChain Create()
+        {
+            return new CredentialProfileStoreChain();
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -71,6 +71,9 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IEnvironmentVariableManager), typeof(EnvironmentVariableManager), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IDeployToolWorkspaceMetadata), typeof(DeployToolWorkspaceMetadata), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IDeploymentSettingsHandler), typeof(DeploymentSettingsHandler), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(ICredentialProfileStoreChainFactory), typeof(CredentialProfileStoreChainFactory), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(ISharedCredentialsFileFactory), typeof(SharedCredentialsFileFactory), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IAWSCredentialsFactory), typeof(AWSCredentialsFactory), lifetime));
 
             var packageJsonTemplate = typeof(PackageJsonGenerator).Assembly.ReadEmbeddedFile(PackageJsonGenerator.TemplateIdentifier);
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IPackageJsonGenerator), (serviceProvider) => new PackageJsonGenerator(packageJsonTemplate), lifetime));

--- a/src/AWS.Deploy.CLI/IAWSCredentialsFactory.cs
+++ b/src/AWS.Deploy.CLI/IAWSCredentialsFactory.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
+
+namespace AWS.Deploy.CLI
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="AWSCredentials">
+    /// </summary>
+    public interface IAWSCredentialsFactory
+    {
+        /// <summary>
+        /// Creates <see cref="AWSCredentials">
+        /// </summary>
+        AWSCredentials Create();
+    }
+}

--- a/src/AWS.Deploy.CLI/ICredentialProfileStoreChainFactory.cs
+++ b/src/AWS.Deploy.CLI/ICredentialProfileStoreChainFactory.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.CredentialManagement;
+
+namespace AWS.Deploy.CLI
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="CredentialProfileStoreChain">
+    /// </summary>
+    public interface ICredentialProfileStoreChainFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="CredentialProfileStoreChain">
+        /// </summary>
+        CredentialProfileStoreChain Create();
+    }
+}

--- a/src/AWS.Deploy.CLI/ISharedCredentialsFileFactory.cs
+++ b/src/AWS.Deploy.CLI/ISharedCredentialsFileFactory.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.CredentialManagement;
+
+namespace AWS.Deploy.CLI
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="SharedCredentialsFile">
+    /// </summary>
+    public interface ISharedCredentialsFileFactory
+    {
+        /// <summary>
+        /// Creates <see cref="SharedCredentialsFile">
+        /// </summary>
+        SharedCredentialsFile Create();
+    }
+}

--- a/src/AWS.Deploy.CLI/SharedCredentialsFileFactory.cs
+++ b/src/AWS.Deploy.CLI/SharedCredentialsFileFactory.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.CredentialManagement;
+
+namespace AWS.Deploy.CLI
+{
+    /// <inheritdoc />
+    public class SharedCredentialsFileFactory : ISharedCredentialsFileFactory
+    {
+        /// <inheritdoc />
+        public SharedCredentialsFile Create()
+        {
+            return new SharedCredentialsFile();
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/AWSCredentialsFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/AWSCredentialsFactoryTests.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class AWSCredentialsFactoryTests
+    {
+        [Fact]
+        public void Create_ReturnsAWSCredentialsInstance()
+        {
+            // Arrange
+            var factory = new AWSCredentialsFactory();
+
+            // Act
+            var result = factory.Create();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<AWSCredentials>(result);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/AWSUtilitiesTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/AWSUtilitiesTests.cs
@@ -1,0 +1,277 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class AWSUtilitiesTests : IDisposable
+    {
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly Mock<IToolInteractiveService> _mockToolInteractiveService;
+        private readonly Mock<IConsoleUtilities> _mockConsoleUtilities;
+        private readonly Mock<IServiceProvider> _mockServiceProvider;
+        private readonly Mock<ICredentialProfileStoreChainFactory> _mockCredentialChainFactory;
+        private readonly Mock<ISharedCredentialsFileFactory> _mockSharedCredentialsFileFactory;
+        private readonly Mock<IAWSCredentialsFactory> _mockAWSCredentialsFactory;
+        private CredentialProfileStoreChain _credentialProfileStoreChain;
+
+        private readonly string _tempCredentialsFile;
+        private SharedCredentialsFile _sharedCredentialsFile;
+
+        public AWSUtilitiesTests()
+        {
+            _directoryManager = new TestDirectoryManager();
+            _mockToolInteractiveService = new Mock<IToolInteractiveService>();
+            _mockConsoleUtilities = new Mock<IConsoleUtilities>();
+            _mockServiceProvider = new Mock<IServiceProvider>();
+            _optionSettingHandler = new Mock<IOptionSettingHandler>().Object;
+            _mockCredentialChainFactory = new Mock<ICredentialProfileStoreChainFactory>();
+            _mockSharedCredentialsFileFactory = new Mock<ISharedCredentialsFileFactory>();
+            _mockAWSCredentialsFactory = new Mock<IAWSCredentialsFactory>();
+
+            _credentialProfileStoreChain = new CredentialProfileStoreChain();
+
+            _mockCredentialChainFactory
+                .Setup(f => f.Create())
+                .Returns(_credentialProfileStoreChain);
+
+            // Create a temporary credentials file
+            _tempCredentialsFile = Path.GetTempFileName();
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", _tempCredentialsFile);
+
+            // Create a real SharedCredentialsFile instance
+            _sharedCredentialsFile = new SharedCredentialsFile(_tempCredentialsFile);
+
+            _mockSharedCredentialsFileFactory
+                .Setup(f => f.Create())
+                .Returns(_sharedCredentialsFile);
+        }
+
+        private AWSUtilities CreateAWSUtilities()
+        {
+            return new AWSUtilities(
+                _mockServiceProvider.Object,
+                _mockToolInteractiveService.Object,
+                _mockConsoleUtilities.Object,
+                _directoryManager,
+                _optionSettingHandler,
+                _mockCredentialChainFactory.Object,
+                _mockSharedCredentialsFileFactory.Object,
+                _mockAWSCredentialsFactory.Object
+            );
+        }
+
+        public void Dispose()
+        {
+            // Clean up the temporary file
+            if (File.Exists(_tempCredentialsFile))
+            {
+                File.Delete(_tempCredentialsFile);
+            }
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", null);
+        }
+
+        private void SetupCredentialsFile(params string[] profileNames)
+        {
+            var contents = new StringBuilder();
+            foreach (var profileName in profileNames)
+            {
+                contents.AppendLine($"[{profileName}]");
+                contents.AppendLine("aws_access_key_id = 123");
+                contents.AppendLine("aws_secret_access_key = abc");
+                contents.AppendLine();
+            }
+            File.WriteAllText(_tempCredentialsFile, contents.ToString());
+
+            // Re-create SharedCredentialsFile to pick up the changes
+            _sharedCredentialsFile = new SharedCredentialsFile(_tempCredentialsFile);
+            _mockSharedCredentialsFileFactory
+                .Setup(f => f.Create())
+                .Returns(_sharedCredentialsFile);
+        }
+
+
+        [Fact]
+        public async Task ResolveAWSCredentials_WithValidProfileName_ReturnsCredentials()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+            var profileName = "valid-profile";
+            var options = new CredentialProfileOptions
+            {
+                AccessKey = "abc",
+                SecretKey = "123"
+            };
+            var mockProfile = new CredentialProfile(profileName, options)
+            {
+                Region = RegionEndpoint.USEast1
+            };
+
+            var store = new CredentialProfileStoreChain();
+            store.RegisterProfile(mockProfile);
+            _credentialProfileStoreChain = store;
+
+            _mockCredentialChainFactory
+                .Setup(f => f.Create())
+                .Returns(_credentialProfileStoreChain);
+
+            // Act
+            var result = await awsUtilities.ResolveAWSCredentials(profileName);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Item1);
+            Assert.Equal("us-east-1", result.Item2);
+        }
+
+        [Fact]
+        public async Task ResolveAWSCredentials_WithValidProfileNameAndNullRegion_ReturnsCredentialsAndNullRegion()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+            var profileName = "valid-profile-no-region";
+            var options = new CredentialProfileOptions
+            {
+                AccessKey = "123",
+                SecretKey = "abc"
+            };
+            var mockProfile = new CredentialProfile(profileName, options)
+            {
+                Region = null
+            };
+
+            var store = new CredentialProfileStoreChain();
+            store.RegisterProfile(mockProfile);
+            _credentialProfileStoreChain = store;
+
+            _mockCredentialChainFactory
+                .Setup(f => f.Create())
+                .Returns(_credentialProfileStoreChain);
+
+            // Act
+            var result = await awsUtilities.ResolveAWSCredentials(profileName);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Item1);
+            Assert.Null(result.Item2);
+        }
+
+        [Fact]
+        public async Task ResolveAWSCredentials_WithInvalidProfileName_ThrowsException()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+            var profileName = "invalid-profile";
+
+            var store = new CredentialProfileStoreChain();
+            _credentialProfileStoreChain = store;
+
+            _mockCredentialChainFactory
+                .Setup(f => f.Create())
+                .Returns(_credentialProfileStoreChain);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<FailedToGetCredentialsForProfile>(() => awsUtilities.ResolveAWSCredentials(profileName));
+        }
+
+        [Fact]
+        public async Task ResolveAWSCredentials_WithNullProfileName_UsesFallbackCredentials()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+            var mockAWSCredentials = new Mock<AWSCredentials>().Object;
+
+            _mockAWSCredentialsFactory
+                .Setup(f => f.Create())
+                .Returns(mockAWSCredentials);
+
+            // Act
+            var result = await awsUtilities.ResolveAWSCredentials(null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(mockAWSCredentials, result.Item1);
+            Assert.Null(result.Item2);
+        }
+
+        [Fact]
+        public async Task ResolveAWSCredentials_WithNullProfileNameAndFallbackException_PromptsUserToChooseProfile()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+            var profileNames = new List<string> { "profile1", "profile2" };
+            var selectedProfileName = "profile1";
+
+            SetupCredentialsFile(profileNames.ToArray());
+
+            _mockAWSCredentialsFactory
+                .Setup(f => f.Create())
+                .Throws(new AmazonServiceException("No credentials found"));
+
+            _mockConsoleUtilities
+                .Setup(c => c.AskUserToChoose(It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(selectedProfileName);
+
+            var store = new CredentialProfileStoreChain(_tempCredentialsFile);
+            _credentialProfileStoreChain = store;
+
+            _mockCredentialChainFactory
+                .Setup(f => f.Create())
+                .Returns(_credentialProfileStoreChain);
+
+            // Act
+            var result = await awsUtilities.ResolveAWSCredentials(null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Item1);
+            Assert.Null(result.Item2);  // Region will be null as we didn't set it in the file
+            _mockConsoleUtilities.Verify(c => c.AskUserToChoose(It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ResolveAWSCredentials_WithNoProfiles_ThrowsNoAWSCredentialsFoundException()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+
+            SetupCredentialsFile();  // Empty file, no profiles
+
+            _mockAWSCredentialsFactory
+                .Setup(f => f.Create())
+                .Throws(new AmazonServiceException("No credentials found"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NoAWSCredentialsFoundException>(() => awsUtilities.ResolveAWSCredentials(null));
+        }
+
+        [Fact]
+        public void ResolveAWSRegion_WithNonNullRegion_ReturnsRegion()
+        {
+            // Arrange
+            var awsUtilities = CreateAWSUtilities();
+            var region = "us-west-2";
+
+            // Act
+            var result = awsUtilities.ResolveAWSRegion(region);
+
+            // Assert
+            Assert.Equal(region, result);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Commands/CommandFactoryTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Commands/CommandFactoryTest.cs
@@ -1,0 +1,576 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Linq;
+using Amazon.Runtime;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.Commands;
+using AWS.Deploy.CLI.Commands.CommandHandlerInput;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.CLI.Utilities;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.DeploymentManifest;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.CDK;
+using AWS.Deploy.Orchestration.DisplayedResources;
+using AWS.Deploy.Orchestration.LocalUserSettings;
+using AWS.Deploy.Orchestration.ServiceHandlers;
+using AWS.Deploy.Orchestration.Utilities;
+using Moq;
+using Xunit;
+using Amazon.SecurityToken.Model;
+using System.Collections.Generic;
+using Amazon.Extensions.NETCore.Setup;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class CommandFactoryTests
+    {
+        private readonly Mock<IServiceProvider> _mockServiceProvider;
+        private readonly Mock<IToolInteractiveService> _mockToolInteractiveService;
+        private readonly Mock<IOrchestratorInteractiveService> _mockOrchestratorInteractiveService;
+        private readonly Mock<ICDKManager> _mockCdkManager;
+        private readonly Mock<ISystemCapabilityEvaluator> _mockSystemCapabilityEvaluator;
+        private readonly Mock<ICloudApplicationNameGenerator> _mockCloudApplicationNameGenerator;
+        private readonly Mock<IAWSUtilities> _mockAwsUtilities;
+        private readonly Mock<IAWSClientFactory> _mockAwsClientFactory;
+        private readonly Mock<IAWSResourceQueryer> _mockAwsResourceQueryer;
+        private readonly Mock<IProjectParserUtility> _mockProjectParserUtility;
+        private readonly Mock<ICommandLineWrapper> _mockCommandLineWrapper;
+        private readonly Mock<ICdkProjectHandler> _mockCdkProjectHandler;
+        private readonly Mock<IDeploymentBundleHandler> _mockDeploymentBundleHandler;
+        private readonly Mock<ICloudFormationTemplateReader> _mockCloudFormationTemplateReader;
+        private readonly Mock<IDeployedApplicationQueryer> _mockDeployedApplicationQueryer;
+        private readonly Mock<ITypeHintCommandFactory> _mockTypeHintCommandFactory;
+        private readonly Mock<IDisplayedResourcesHandler> _mockDisplayedResourceHandler;
+        private readonly Mock<IConsoleUtilities> _mockConsoleUtilities;
+        private readonly Mock<IDirectoryManager> _mockDirectoryManager;
+        private readonly Mock<IFileManager> _mockFileManager;
+        private readonly Mock<IDeploymentManifestEngine> _mockDeploymentManifestEngine;
+        private readonly Mock<ILocalUserSettingsEngine> _mockLocalUserSettingsEngine;
+        private readonly Mock<ICDKVersionDetector> _mockCdkVersionDetector;
+        private readonly Mock<IAWSServiceHandler> _mockAwsServiceHandler;
+        private readonly Mock<IOptionSettingHandler> _mockOptionSettingHandler;
+        private readonly Mock<IValidatorFactory> _mockValidatorFactory;
+        private readonly Mock<IRecipeHandler> _mockRecipeHandler;
+        private readonly Mock<IDeployToolWorkspaceMetadata> _mockDeployToolWorkspaceMetadata;
+        private readonly Mock<IDeploymentSettingsHandler> _mockDeploymentSettingsHandler;
+
+        public CommandFactoryTests()
+        {
+            _mockServiceProvider = new Mock<IServiceProvider>();
+            _mockToolInteractiveService = new Mock<IToolInteractiveService>();
+            _mockOrchestratorInteractiveService = new Mock<IOrchestratorInteractiveService>();
+            _mockCdkManager = new Mock<ICDKManager>();
+            _mockSystemCapabilityEvaluator = new Mock<ISystemCapabilityEvaluator>();
+            _mockCloudApplicationNameGenerator = new Mock<ICloudApplicationNameGenerator>();
+            _mockAwsUtilities = new Mock<IAWSUtilities>();
+            _mockAwsClientFactory = new Mock<IAWSClientFactory>();
+            _mockAwsResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _mockProjectParserUtility = new Mock<IProjectParserUtility>();
+            _mockCommandLineWrapper = new Mock<ICommandLineWrapper>();
+            _mockCdkProjectHandler = new Mock<ICdkProjectHandler>();
+            _mockDeploymentBundleHandler = new Mock<IDeploymentBundleHandler>();
+            _mockCloudFormationTemplateReader = new Mock<ICloudFormationTemplateReader>();
+            _mockDeployedApplicationQueryer = new Mock<IDeployedApplicationQueryer>();
+            _mockTypeHintCommandFactory = new Mock<ITypeHintCommandFactory>();
+            _mockDisplayedResourceHandler = new Mock<IDisplayedResourcesHandler>();
+            _mockConsoleUtilities = new Mock<IConsoleUtilities>();
+            _mockDirectoryManager = new Mock<IDirectoryManager>();
+            _mockFileManager = new Mock<IFileManager>();
+            _mockDeploymentManifestEngine = new Mock<IDeploymentManifestEngine>();
+            _mockLocalUserSettingsEngine = new Mock<ILocalUserSettingsEngine>();
+            _mockCdkVersionDetector = new Mock<ICDKVersionDetector>();
+            _mockAwsServiceHandler = new Mock<IAWSServiceHandler>();
+            _mockOptionSettingHandler = new Mock<IOptionSettingHandler>();
+            _mockValidatorFactory = new Mock<IValidatorFactory>();
+            _mockRecipeHandler = new Mock<IRecipeHandler>();
+            _mockDeployToolWorkspaceMetadata = new Mock<IDeployToolWorkspaceMetadata>();
+            _mockDeploymentSettingsHandler = new Mock<IDeploymentSettingsHandler>();
+        }
+
+        private CommandFactory CreateCommandFactory()
+        {
+            return new CommandFactory(
+                _mockServiceProvider.Object,
+                _mockToolInteractiveService.Object,
+                _mockOrchestratorInteractiveService.Object,
+                _mockCdkManager.Object,
+                _mockSystemCapabilityEvaluator.Object,
+                _mockCloudApplicationNameGenerator.Object,
+                _mockAwsUtilities.Object,
+                _mockAwsClientFactory.Object,
+                _mockAwsResourceQueryer.Object,
+                _mockProjectParserUtility.Object,
+                _mockCommandLineWrapper.Object,
+                _mockCdkProjectHandler.Object,
+                _mockDeploymentBundleHandler.Object,
+                _mockCloudFormationTemplateReader.Object,
+                _mockDeployedApplicationQueryer.Object,
+                _mockTypeHintCommandFactory.Object,
+                _mockDisplayedResourceHandler.Object,
+                _mockConsoleUtilities.Object,
+                _mockDirectoryManager.Object,
+                _mockFileManager.Object,
+                _mockDeploymentManifestEngine.Object,
+                _mockLocalUserSettingsEngine.Object,
+                _mockCdkVersionDetector.Object,
+                _mockAwsServiceHandler.Object,
+                _mockOptionSettingHandler.Object,
+                _mockValidatorFactory.Object,
+                _mockRecipeHandler.Object,
+                _mockDeployToolWorkspaceMetadata.Object,
+                _mockDeploymentSettingsHandler.Object
+            );
+        }
+
+        [Fact]
+        public void BuildRootCommand_ReturnsRootCommandWithExpectedSubcommands()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+
+            // Act
+            var rootCommand = commandFactory.BuildRootCommand();
+
+            // Assert
+            Assert.NotNull(rootCommand);
+            Assert.Equal("dotnet-aws", rootCommand.Name);
+            Assert.Contains(rootCommand.Options, o => o.Name == "version");
+            Assert.Contains(rootCommand.Children, c => c.Name == "deploy");
+            Assert.Contains(rootCommand.Children, c => c.Name == "list-deployments");
+            Assert.Contains(rootCommand.Children, c => c.Name == "delete-deployment");
+            Assert.Contains(rootCommand.Children, c => c.Name == "deployment-project");
+            Assert.Contains(rootCommand.Children, c => c.Name == "server-mode");
+        }
+
+        [Fact]
+        public void BuildRootCommand_DeployCommandHasExpectedOptions()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+
+            // Act
+            var rootCommand = commandFactory.BuildRootCommand();
+            var deployCommand = rootCommand.Children.First(c => c.Name == "deploy") as Command;
+
+            // Assert
+            Assert.NotNull(deployCommand);
+            Assert.Contains(deployCommand.Options, o => o.Name == "profile");
+            Assert.Contains(deployCommand.Options, o => o.Name == "region");
+            Assert.Contains(deployCommand.Options, o => o.Name == "project-path");
+            Assert.Contains(deployCommand.Options, o => o.Name == "application-name");
+            Assert.Contains(deployCommand.Options, o => o.Name == "apply");
+            Assert.Contains(deployCommand.Options, o => o.Name == "diagnostics");
+            Assert.Contains(deployCommand.Options, o => o.Name == "silent");
+            Assert.Contains(deployCommand.Options, o => o.Name == "deployment-project");
+            Assert.Contains(deployCommand.Options, o => o.Name == "save-settings");
+            Assert.Contains(deployCommand.Options, o => o.Name == "save-all-settings");
+        }
+
+        // Add more tests for other commands and their options...
+
+        [Fact]
+        public void BuildRootCommand_ServerModeCommandHasExpectedOptions()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+
+            // Act
+            var rootCommand = commandFactory.BuildRootCommand();
+            var serverModeCommand = rootCommand.Children.First(c => c.Name == "server-mode") as Command;
+
+            // Assert
+            Assert.NotNull(serverModeCommand);
+            Assert.Contains(serverModeCommand.Options, o => o.Name == "port");
+            Assert.Contains(serverModeCommand.Options, o => o.Name == "parent-pid");
+            Assert.Contains(serverModeCommand.Options, o => o.Name == "unsecure-mode");
+            Assert.Contains(serverModeCommand.Options, o => o.Name == "diagnostics");
+        }
+
+        [Fact]
+        public async Task DeployCommand_UsesRegionFromCLIWhenProvided()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+            var mockCredentials = new Mock<AWSCredentials>();
+            var testProfile = "test-profile";
+            var regionFromCLI = "us-west-2";
+            var regionFromProfile = "us-east-1";
+            var testProjectPath = "/path/to/project";
+
+            // Mock ProjectDefinition
+            var mockProjectDefinition = new ProjectDefinition(
+                new System.Xml.XmlDocument(),
+                testProjectPath,
+                testProjectPath,
+                "123");
+
+            _mockProjectParserUtility
+                .Setup(x => x.Parse(It.IsAny<string>()))
+                .ReturnsAsync(mockProjectDefinition);
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSCredentials(It.IsAny<string>()))
+                .Returns(Task.FromResult((Tuple.Create(mockCredentials.Object, regionFromProfile))));
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSRegion(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(regionFromCLI);
+
+            // Create a mock DeploymentSettings
+            var mockDeploymentSettings = new DeploymentSettings
+            {
+                AWSProfile = "deployment-profile",
+                AWSRegion = "deployment-region"
+            };
+
+            _mockDeploymentSettingsHandler
+                .Setup(x => x.ReadSettings(It.IsAny<string>()))
+                .ReturnsAsync(mockDeploymentSettings);
+
+            _mockAwsResourceQueryer
+                .Setup(x => x.GetCallerIdentity(It.IsAny<string>()))
+                .ReturnsAsync(new GetCallerIdentityResponse { Account = "123456789012" });
+
+
+            // Act
+            var result = await InvokeDeployCommandHandler(new DeployCommandHandlerInput
+            {
+                Profile = testProfile,
+                Region = regionFromCLI,
+                Apply = "some-settings-file.json",
+                ProjectPath = testProjectPath
+            });
+
+            // Assert
+            _mockProjectParserUtility.Verify(x => x.Parse(testProjectPath), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSCredentials(testProfile), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSRegion(regionFromCLI, null), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeployCommand_UsesRegionFromProfileWhenCLIRegionNotProvided()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+            var mockCredentials = new Mock<AWSCredentials>();
+            var testProfile = "test-profile";
+            var regionFromProfile = "us-east-1";
+            var testProjectPath = "/path/to/project";
+
+            // Mock ProjectDefinition
+            var mockProjectDefinition = new ProjectDefinition(
+                new System.Xml.XmlDocument(),
+                testProjectPath,
+                testProjectPath,
+                "123");
+
+            _mockProjectParserUtility
+                .Setup(x => x.Parse(It.IsAny<string>()))
+                .ReturnsAsync(mockProjectDefinition);
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSCredentials(It.IsAny<string>()))
+                .Returns(Task.FromResult((Tuple.Create(mockCredentials.Object, regionFromProfile))));
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSRegion(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string r, string f) => r);
+
+            // Create a mock DeploymentSettings
+            var mockDeploymentSettings = new DeploymentSettings
+            {
+                AWSProfile = "deployment-profile",
+                AWSRegion = null  // Ensure this is null to test our scenario
+            };
+
+            _mockDeploymentSettingsHandler
+                .Setup(x => x.ReadSettings(It.IsAny<string>()))
+                .ReturnsAsync(mockDeploymentSettings);
+
+            _mockAwsResourceQueryer
+                .Setup(x => x.GetCallerIdentity(It.IsAny<string>()))
+                .ReturnsAsync(new GetCallerIdentityResponse { Account = "123456789012" });
+
+            // Act
+            var result = await InvokeDeployCommandHandler(new DeployCommandHandlerInput
+            {
+                Profile = testProfile,
+                Region = null,  // Not providing a region via CLI
+                Apply = "some-settings-file.json",
+                ProjectPath = testProjectPath
+            });
+
+            // Assert
+            _mockProjectParserUtility.Verify(x => x.Parse(testProjectPath), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSCredentials(testProfile), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSRegion(regionFromProfile, null), Times.Once);
+
+            // Verify that the region from the profile is used
+            _mockAwsResourceQueryer.Verify(x => x.GetCallerIdentity(regionFromProfile), Times.Once);
+        }
+
+        [Fact]
+        public void BuildRootCommand_DeleteCommandHasExpectedOptions()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+
+            // Act
+            var rootCommand = commandFactory.BuildRootCommand();
+            var deleteCommand = rootCommand.Children.First(c => c.Name == "delete-deployment") as Command;
+
+            // Assert
+            Assert.NotNull(deleteCommand);
+            Assert.Contains(deleteCommand.Options, o => o.Name == "profile");
+            Assert.Contains(deleteCommand.Options, o => o.Name == "region");
+            Assert.Contains(deleteCommand.Options, o => o.Name == "project-path");
+            Assert.Contains(deleteCommand.Options, o => o.Name == "diagnostics");
+            Assert.Contains(deleteCommand.Options, o => o.Name == "silent");
+
+            // Verify that the delete command has a deployment-name argument
+            Assert.Contains(deleteCommand.Arguments, a => a.Name == "deployment-name");
+        }
+
+        [Fact]
+        public void BuildRootCommand_ListCommandHasExpectedOptions()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+
+            // Act
+            var rootCommand = commandFactory.BuildRootCommand();
+            var listCommand = rootCommand.Children.First(c => c.Name == "list-deployments") as Command;
+
+            // Assert
+            Assert.NotNull(listCommand);
+            Assert.Contains(listCommand.Options, o => o.Name == "profile");
+            Assert.Contains(listCommand.Options, o => o.Name == "region");
+            Assert.Contains(listCommand.Options, o => o.Name == "diagnostics");
+        }
+
+        [Fact]
+        public async Task DeleteCommand_UsesRegionFromCLIWhenProvided()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+            var mockCredentials = new Mock<AWSCredentials>();
+            var testProfile = "test-profile";
+            var regionFromCLI = "us-west-2";
+            var regionFromProfile = "us-east-1";
+            var deploymentName = "test-deployment";
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSCredentials(It.IsAny<string>()))
+                .Returns(Task.FromResult((Tuple.Create(mockCredentials.Object, regionFromProfile))));
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSRegion(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(regionFromCLI);
+
+            _mockAwsClientFactory
+                .Setup(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()))
+                .Callback<Action<AWSOptions>>(action =>
+                {
+                    var options = new AWSOptions();
+                    action(options);
+                    Assert.Equal(regionFromCLI, options.Region.SystemName);
+                });
+
+            // Act
+            var result = await InvokeDeleteCommandHandler(new DeleteCommandHandlerInput
+            {
+                Profile = testProfile,
+                Region = regionFromCLI,
+                DeploymentName = deploymentName
+            });
+
+            // Assert
+            _mockAwsUtilities.Verify(x => x.ResolveAWSCredentials(testProfile), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSRegion(regionFromCLI, null), Times.Once);
+            _mockAwsClientFactory.Verify(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteCommand_UsesRegionFromProfileWhenCLIRegionNotProvided()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+            var mockCredentials = new Mock<AWSCredentials>();
+            var testProfile = "test-profile";
+            var regionFromProfile = "us-east-1";
+            var deploymentName = "test-deployment";
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSCredentials(It.IsAny<string>()))
+                .Returns(Task.FromResult((Tuple.Create(mockCredentials.Object, regionFromProfile))));
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSRegion(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string r, string f) => f);
+
+            _mockAwsClientFactory
+                .Setup(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()))
+                .Callback<Action<AWSOptions>>(action =>
+                {
+                    var options = new AWSOptions();
+                    action(options);
+                    Assert.Equal(regionFromProfile, options.Region.SystemName);
+                });
+
+            // Act
+            var result = await InvokeDeleteCommandHandler(new DeleteCommandHandlerInput
+            {
+                Profile = testProfile,
+                Region = null,  // Not providing a region via CLI
+                DeploymentName = deploymentName
+            });
+
+            // Assert
+            _mockAwsUtilities.Verify(x => x.ResolveAWSCredentials(testProfile), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSRegion(regionFromProfile, null), Times.Once);
+            _mockAwsClientFactory.Verify(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ListCommand_UsesRegionFromCLIWhenProvided()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+            var mockCredentials = new Mock<AWSCredentials>();
+            var testProfile = "test-profile";
+            var regionFromCLI = "us-west-2";
+            var regionFromProfile = "us-east-1";
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSCredentials(It.IsAny<string>()))
+                .Returns(Task.FromResult((Tuple.Create(mockCredentials.Object, regionFromProfile))));
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSRegion(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(regionFromCLI);
+
+            _mockAwsClientFactory
+                .Setup(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()))
+                .Callback<Action<AWSOptions>>(action =>
+                {
+                    var options = new AWSOptions();
+                    action(options);
+                    Assert.Equal(regionFromCLI, options.Region.SystemName);
+                });
+
+            // Act
+            var result = await InvokeListCommandHandler(new ListCommandHandlerInput
+            {
+                Profile = testProfile,
+                Region = regionFromCLI
+            });
+
+            // Assert
+            _mockAwsUtilities.Verify(x => x.ResolveAWSCredentials(testProfile), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSRegion(regionFromCLI, null), Times.Once);
+            _mockAwsClientFactory.Verify(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ListCommand_UsesRegionFromProfileWhenCLIRegionNotProvided()
+        {
+            // Arrange
+            var commandFactory = CreateCommandFactory();
+            var mockCredentials = new Mock<AWSCredentials>();
+            var testProfile = "test-profile";
+            var regionFromProfile = "us-east-1";
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSCredentials(It.IsAny<string>()))
+                .Returns(Task.FromResult((Tuple.Create(mockCredentials.Object, regionFromProfile))));
+
+            _mockAwsUtilities
+                .Setup(x => x.ResolveAWSRegion(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string r, string f) => f);
+
+            _mockAwsClientFactory
+                .Setup(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()))
+                .Callback<Action<AWSOptions>>(action =>
+                {
+                    var options = new AWSOptions();
+                    action(options);
+                    Assert.Equal(regionFromProfile, options.Region.SystemName);
+                });
+
+            // Act
+            var result = await InvokeListCommandHandler(new ListCommandHandlerInput
+            {
+                Profile = testProfile,
+                Region = null  // Not providing a region via CLI
+            });
+
+            // Assert
+            _mockAwsUtilities.Verify(x => x.ResolveAWSCredentials(testProfile), Times.Once);
+            _mockAwsUtilities.Verify(x => x.ResolveAWSRegion(regionFromProfile, null), Times.Once);
+            _mockAwsClientFactory.Verify(x => x.ConfigureAWSOptions(It.IsAny<Action<AWSOptions>>()), Times.Once);
+        }
+
+        private async Task<int> InvokeDeployCommandHandler(DeployCommandHandlerInput input)
+        {
+            var args = new List<string> { "deploy" };
+
+            if (!string.IsNullOrEmpty(input.Profile))
+                args.AddRange(new[] { "--profile", input.Profile });
+
+            if (!string.IsNullOrEmpty(input.Region))
+                args.AddRange(new[] { "--region", input.Region });
+
+            if (!string.IsNullOrEmpty(input.Apply))
+                args.AddRange(new[] { "--apply", input.Apply });
+
+            if (!string.IsNullOrEmpty(input.ProjectPath))
+                args.AddRange(new[] { "--project-path", input.ProjectPath });
+
+            var rootCommand = CreateCommandFactory().BuildRootCommand();
+            return await rootCommand.InvokeAsync(args.ToArray());
+        }
+
+
+        private async Task<int> InvokeDeleteCommandHandler(DeleteCommandHandlerInput input)
+        {
+            var args = new List<string> { "delete-deployment" };
+
+            if (!string.IsNullOrEmpty(input.Profile))
+                args.AddRange(new[] { "--profile", input.Profile });
+
+            if (!string.IsNullOrEmpty(input.Region))
+                args.AddRange(new[] { "--region", input.Region });
+
+            if (!string.IsNullOrEmpty(input.DeploymentName))
+                args.Add(input.DeploymentName);
+
+            var rootCommand = CreateCommandFactory().BuildRootCommand();
+            return await rootCommand.InvokeAsync(args.ToArray());
+        }
+
+        private async Task<int> InvokeListCommandHandler(ListCommandHandlerInput input)
+        {
+            var args = new List<string> { "list-deployments" };
+
+            if (!string.IsNullOrEmpty(input.Profile))
+                args.AddRange(new[] { "--profile", input.Profile });
+
+            if (!string.IsNullOrEmpty(input.Region))
+                args.AddRange(new[] { "--region", input.Region });
+
+            var rootCommand = CreateCommandFactory().BuildRootCommand();
+            return await rootCommand.InvokeAsync(args.ToArray());
+        }
+
+
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/CredentialProfileStoreChainFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/CredentialProfileStoreChainFactoryTests.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.CredentialManagement;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class CredentialProfileStoreChainFactoryTests
+    {
+        [Fact]
+        public void Create_ReturnsCredentialProfileStoreChainInstance()
+        {
+            // Arrange
+            var factory = new CredentialProfileStoreChainFactory();
+
+            // Act
+            var result = factory.Create();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsType<CredentialProfileStoreChain>(result);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/SharedCredentialsFileFactoryTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SharedCredentialsFileFactoryTests.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.CredentialManagement;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class SharedCredentialsFileFactoryTests
+    {
+        [Fact]
+        public void Create_ReturnsSharedCredentialsFileInstance()
+        {
+            // Arrange
+            var factory = new SharedCredentialsFileFactory();
+
+            // Act
+            var result = factory.Create();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsType<SharedCredentialsFile>(result);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
### Why is this change being made?

The problem we are trying to solve is that the dotnet tool does not take into account the AWS region when a non default profile is being used. It will use the region set on the default profile (if available) instead.

Also, this change also updates the cdk bootstrap version

For example consider the following profile setups.
Scenario 1
```
[test]
access-key=xyz
secret-key=abc
region=us-west-2

[default]
access-key=xyz
secret-key=abc
region=us-east-1
```
Running the program with

`AWS.Deploy.CLI.exe deploy --profile test`

will result in region `us-east-1`  being used rather than `us-west-2`

As a workaround, we let the user know to provide the --region parameter when a non default profile is being used

`AWS.Deploy.CLI.exe deploy --profile test --region us-west-2`

Scenario 2: There is also another scenario that can occur with the following profiles setup (no default profile/default profile doesn't have a region)

```
[test]
access-key=xyz
secret-key=abc
region=us-west-2
```

When running with
`AWS.Deploy.CLI.exe deploy --profile test`

this will prompt the user to enter a region as input

```
Select AWS Region
-----------------
1 : af-south-1 (Africa (Cape Town))
2 : ap-east-1 (Asia Pacific (Hong Kong))
Choose option:
```

Both of these scenarios are not ideal because we are requiring the user to manually select the region each time (either by providing --region flag as input or by doing as input in command line)

### What is this change being made?

1. This change updates `ResolveAWSCredentials` function to read the profile's region and return it from the function.  This allows the next function (`ResolveAWSRegion` to use the returned profile's region as input.
2. This change also refactors some of  `AWSUtilities` so that some of the credential chain logic is injected so that unit tests can be written for this class.


### How is this change tested?
1. I tested the two scenarios described above.

Scenario 1
```
[test]
access-key=xyz
secret-key=abc
region=us-west-2

[default]
access-key=xyz
secret-key=abc
region=us-east-1
```
Running the program with

`AWS.Deploy.CLI.exe deploy --profile test`

I validated that the program auto detected `us-west-2` rather than `us-east-`

Scenario 2: There is also another scenario that can occur with the following profiles setup (no default profile/default profile doesn't have a region)

```
[test]
access-key=xyz
secret-key=abc
region=us-west-2
```

When running with
`AWS.Deploy.CLI.exe deploy --profile test`

I validated that i am not prompted anymore for a region, and `us-west-2` is auto detected.

I also validated that the existing functionality of explicitly specifying a region still works. For example, even with this profile
```
[test]
access-key=xyz
secret-key=abc
region=us-east-2
```
i ran `AWS.Deploy.CLI.exe deploy --profile test --region us-west-1 ` and validated `us-west-1` was chosen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
