### PR TITLE
Update platform query logic to support deprecated

### DIFF
--- a/.autover/changes/721a3463-3ad9-413d-b2b6-11efb7575fac.json
+++ b/.autover/changes/721a3463-3ad9-413d-b2b6-11efb7575fac.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update beanstalk platform resolution logic"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/721a3463-3ad9-413d-b2b6-11efb7575fac.json
+++ b/.autover/changes/721a3463-3ad9-413d-b2b6-11efb7575fac.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Deploy.CLI",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Update beanstalk platform resolution logic"
+        "Update beanstalk platform resolution logic to additionally use 'Deprecated' versions in order to continue supporting .NET 6."
       ]
     }
   ]

--- a/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
@@ -203,7 +203,11 @@ Resources:
           - Id: CleanupOldVersions
             Status: Enabled
             NoncurrentVersionExpiration:
-              NoncurrentDays: 365
+              NoncurrentDays: 30
+          - Id: AbortIncompleteMultipartUploads
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
   StagingBucketPolicy:
@@ -611,7 +615,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: /cdk-bootstrap/${Qualifier}/version
-      Value: "23"
+      Value: "25"
 Outputs:
   BucketName:
     Description: The name of the S3 bucket owned by the CDK toolkit stack

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -574,7 +574,7 @@ namespace AWS.Deploy.Orchestration.Data
                 if (string.IsNullOrEmpty(version.PlatformCategory) || string.IsNullOrEmpty(version.PlatformBranchLifecycleState))
                     continue;
 
-                if (!version.PlatformBranchLifecycleState.Equals("Supported"))
+                if (!(version.PlatformBranchLifecycleState.Equals("Supported") || version.PlatformBranchLifecycleState.Equals("Deprecated")))
                     continue;
 
                 platformVersions.Add(version);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
1. Update platform query logic to support deprecated beanstalk platforms. Why? .net 6 is was just marked as deprecated by beanstalk a couple days ago and now customers cannot deploy .net 6 to beanstalk with deploy tool. This change updates the logic so that .net 6 will work by allowing deprecated versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
