### PR TITLE
Update Microsoft.AspNetCore.SignalR.Client version to fix System.Text.Json vulnerability

### DIFF
--- a/.autover/changes/27d0ce13-f148-4129-a977-1ae2fa1b36e4.json
+++ b/.autover/changes/27d0ce13-f148-4129-a977-1ae2fa1b36e4.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.ServerMode.Client",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update Microsoft.AspNetCore.SignalR.Client version to fix System.Text.Json vulnerability"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
+++ b/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.303.20" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.22" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.36" />
     <!-- We are pining Newtonsoft.Json to 13.0.1 to maintain compatibility with the VS Toolkit.
     https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When building with .NET 9 we were getting 
```
Severity	Code	Description	Project	File	Line	Suppression State
Error (active)	NU1903	Warning As Error: Package 'System.Text.Json' 6.0.8 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4	AWS.Deploy.ServerMode.Client
```

The System.Text.Json dependency comes from `Microsoft.AspNetCore.SignalR.Client`

![image](https://github.com/user-attachments/assets/560022c7-3964-4f77-a51b-5ef2cf142186)

This change updates the `Microsoft.AspNetCore.SignalR.Client` version that includes the patched System.Text.Json version `(6.0.11)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
