### PR TITLE
Fix Beanstalk integ tests

### DIFF
--- a/test/AWS.Deploy.CLI.IntegrationTests/Helpers/IAMHelper.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Helpers/IAMHelper.cs
@@ -32,6 +32,19 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
             var role = existingRoles.FirstOrDefault(x => string.Equals(roleName, x.RoleName));
             if (role != null)
             {
+                var polices = (await _client.ListAttachedRolePoliciesAsync(new ListAttachedRolePoliciesRequest { RoleName = roleName })).AttachedPolicies;
+                if (polices != null)
+                {
+                    foreach(var policy in polices)
+                    {
+                        await _client.DetachRolePolicyAsync(new DetachRolePolicyRequest
+                        {
+                            RoleName = roleName,
+                            PolicyArn = policy.PolicyArn
+                        });
+                    }
+                }
+
                 await _client.RemoveRoleFromInstanceProfileAsync(new RemoveRoleFromInstanceProfileRequest
                 {
                     RoleName = roleName,
@@ -77,6 +90,12 @@ namespace AWS.Deploy.CLI.IntegrationTests.Helpers
                     RoleName = roleName,
                     AssumeRolePolicyDocument = assumeRolepolicyDocument.Replace("'", "\""),
                     MaxSessionDuration = 7200
+                });
+
+                await _client.AttachRolePolicyAsync(new AttachRolePolicyRequest
+                {
+                    RoleName = roleName,
+                    PolicyArn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier"
                 });
             }
 


### PR DESCRIPTION
*Description of changes:*
The beanstalk tests deploying from existing environments are failing because existing environments were being created without permissions to download the deployment bundle from S3. This PR adds the managed beanstalk policy to the role that being created as part of the test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
