### PR TITLE
update node to 22

### DIFF
--- a/.autover/changes/1292d7ce-01b0-41d2-b0a5-58ae76457ced.json
+++ b/.autover/changes/1292d7ce-01b0-41d2-b0a5-58ae76457ced.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Deploy.CLI",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Update node version from 18 to 22"
+        "Update the default docker image node version from version 18 to 22"
       ]
     }
   ]

--- a/.autover/changes/1292d7ce-01b0-41d2-b0a5-58ae76457ced.json
+++ b/.autover/changes/1292d7ce-01b0-41d2-b0a5-58ae76457ced.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update node version from 18 to 22"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/DetectCDKBootstrapVersionChanges.yml
+++ b/.github/workflows/DetectCDKBootstrapVersionChanges.yml
@@ -33,11 +33,10 @@ jobs:
     - name: Save New CDK Bootstrap Template
       run: |
         cdk bootstrap --show-template > newTemplate.yml
+        cat ./newTemplate.yml
     - name: Get Latest CDK Bootstrap Version
       id: latestBootstrapVersion
       run: |
-        cat ./newTemplate.yml
-        cat ./newTemplate.yml | grep CdkBootstrapVersion
         echo "latest-version=$(yq '.Resources.CdkBootstrapVersion.Properties.Value' 'newTemplate.yml')" >> $GITHUB_OUTPUT
     - name: Get Current CDK Bootstrap Version
       id: currentBootstrapVersion

--- a/.github/workflows/DetectCDKBootstrapVersionChanges.yml
+++ b/.github/workflows/DetectCDKBootstrapVersionChanges.yml
@@ -12,6 +12,7 @@ jobs:
     - name: Install AWS CDK
       run: |
         npm install -g aws-cdk
+        cdk acknowledge 32775
     - name: Get Staging Bucket Update/Replace Policy
       id: stagingBucketUpdateReplacePolicy
       run: |
@@ -33,7 +34,6 @@ jobs:
     - name: Save New CDK Bootstrap Template
       run: |
         cdk bootstrap --show-template > newTemplate.yml
-        cat ./newTemplate.yml
     - name: Get Latest CDK Bootstrap Version
       id: latestBootstrapVersion
       run: |

--- a/.github/workflows/DetectCDKBootstrapVersionChanges.yml
+++ b/.github/workflows/DetectCDKBootstrapVersionChanges.yml
@@ -36,6 +36,8 @@ jobs:
     - name: Get Latest CDK Bootstrap Version
       id: latestBootstrapVersion
       run: |
+        cat ./newTemplate.yml
+        cat ./newTemplate.yml | grep CdkBootstrapVersion
         echo "latest-version=$(yq '.Resources.CdkBootstrapVersion.Properties.Value' 'newTemplate.yml')" >> $GITHUB_OUTPUT
     - name: Get Current CDK Bootstrap Version
       id: currentBootstrapVersion

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: 22
     commands:
       # install .NET SDK
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0

--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.Net6.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.Net6.template
@@ -15,7 +15,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "{project-name}" -c Release -o /app/publish

--- a/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
+++ b/src/AWS.Deploy.DockerEngine/Templates/Dockerfile.template
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "{project-name}" -c Release -o /app/publish -a $TARGETARCH

--- a/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
@@ -615,7 +615,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: /cdk-bootstrap/${Qualifier}/version
-      Value: "25"
+      Value: "26"
 Outputs:
   BucketName:
     Description: The name of the S3 bucket owned by the CDK toolkit stack

--- a/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
@@ -159,6 +159,8 @@ Resources:
                 Fn::Sub: ${FilePublishingRole.Arn}
             Resource: "*"
     Condition: CreateNewKey
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
   FileAssetsBucketEncryptionKeyAlias:
     Condition: CreateNewKey
     Type: AWS::KMS::Alias

--- a/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
@@ -271,6 +271,18 @@ Resources:
               StringLike:
                 aws:sourceArn:
                   Fn::Sub: arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*
+          - Sid: EmrServerlessImageRetrievalPolicy
+            Effect: Allow
+            Principal:
+              Service: emr-serverless.amazonaws.com
+            Action:
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+              - ecr:DescribeImages
+            Condition:
+              StringLike:
+                aws:sourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:emr-serverless:${AWS::Region}:${AWS::AccountId}:/applications/*
   FilePublishingRole:
     Type: AWS::IAM::Role
     Properties:
@@ -617,7 +629,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: /cdk-bootstrap/${Qualifier}/version
-      Value: "26"
+      Value: "27"
 Outputs:
   BucketName:
     Description: The name of the S3 bucket owned by the CDK toolkit stack

--- a/testapps/WebAppNet8WithCustomDockerFile/Dockerfile
+++ b/testapps/WebAppNet8WithCustomDockerFile/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNet8WithCustomDockerFile.csproj" -c Release -o /app/publish

--- a/testapps/docker/ConsoleSdkType/Dockerfile
+++ b/testapps/docker/ConsoleSdkType/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "ConsoleSdkType.csproj" -c Release -o /app/publish

--- a/testapps/docker/ConsoleSdkType/ReferenceDockerfile
+++ b/testapps/docker/ConsoleSdkType/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "ConsoleSdkType.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppDifferentAssemblyName/Dockerfile
+++ b/testapps/docker/WebAppDifferentAssemblyName/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppDifferentAssemblyName.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppDifferentAssemblyName/ReferenceDockerfile
+++ b/testapps/docker/WebAppDifferentAssemblyName/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppDifferentAssemblyName.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppDifferentTargetFramework/Dockerfile
+++ b/testapps/docker/WebAppDifferentTargetFramework/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppDifferentTargetFramework.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppDifferentTargetFramework/ReferenceDockerfile
+++ b/testapps/docker/WebAppDifferentTargetFramework/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppDifferentTargetFramework.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppNet7/Dockerfile
+++ b/testapps/docker/WebAppNet7/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNet7.csproj" -c Release -o /app/publish -a $TARGETARCH

--- a/testapps/docker/WebAppNet7/ReferenceDockerfile
+++ b/testapps/docker/WebAppNet7/ReferenceDockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNet7.csproj" -c Release -o /app/publish -a $TARGETARCH

--- a/testapps/docker/WebAppNet8/Dockerfile
+++ b/testapps/docker/WebAppNet8/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish -a $TARGETARCH

--- a/testapps/docker/WebAppNet8/ReferenceDockerfile
+++ b/testapps/docker/WebAppNet8/ReferenceDockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNet8.csproj" -c Release -o /app/publish -a $TARGETARCH

--- a/testapps/docker/WebAppNoSolution/Dockerfile
+++ b/testapps/docker/WebAppNoSolution/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNoSolution.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppNoSolution/ReferenceDockerfile
+++ b/testapps/docker/WebAppNoSolution/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppNoSolution.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppProjectDependencies/WebAppProjectDependencies/Dockerfile
+++ b/testapps/docker/WebAppProjectDependencies/WebAppProjectDependencies/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppProjectDependencies.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppProjectDependencies/WebAppProjectDependencies/ReferenceDockerfile
+++ b/testapps/docker/WebAppProjectDependencies/WebAppProjectDependencies/ReferenceDockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppProjectDependencies.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel/Dockerfile
+++ b/testapps/docker/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppWithSolutionParentLevel.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel/ReferenceDockerfile
+++ b/testapps/docker/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppWithSolutionParentLevel.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppWithSolutionSameLevel/Dockerfile
+++ b/testapps/docker/WebAppWithSolutionSameLevel/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppWithSolutionSameLevel.csproj" -c Release -o /app/publish

--- a/testapps/docker/WebAppWithSolutionSameLevel/ReferenceDockerfile
+++ b/testapps/docker/WebAppWithSolutionSameLevel/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WebAppWithSolutionSameLevel.csproj" -c Release -o /app/publish

--- a/testapps/docker/WorkerServiceExample/Dockerfile
+++ b/testapps/docker/WorkerServiceExample/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WorkerServiceExample.csproj" -c Release -o /app/publish

--- a/testapps/docker/WorkerServiceExample/ReferenceDockerfile
+++ b/testapps/docker/WorkerServiceExample/ReferenceDockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -yq \
     && apt-get install -yq ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
     && apt-get install nodejs -yq
 RUN dotnet publish "WorkerServiceExample.csproj" -c Release -o /app/publish


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7986

*Description of changes:*
1.  Update node to version 22 since 18 is end of life in april.
2. Add `cdk acknowledge`. This is needed because when doing cdk commands now an extra warning text appears the first time its being ran. This extra text breaks our logic because we pipe the output of the command to a file and parse it. So by adding cdk acknowledge it doesnt show the extra text anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
