### PR TITLE
feat: add validator for beanstalk when switching architecture on redeployment

### DIFF
--- a/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
@@ -166,6 +166,12 @@ namespace AWS.Deploy.CLI.ServerMode.Services
         }
 
         /// <inheritdoc/>
+        public async Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName)
+        {
+            return (await GetAndCache(async () => await _awsResourceQueryer.DescribeElasticBeanstalkConfigurationSettings(applicationName, environmentName), new object[] { applicationName, environmentName }))!;
+        }
+
+        /// <inheritdoc/>
         public async Task<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn)
         {
             return (await GetAndCache(async () => await _awsResourceQueryer.DescribeElasticLoadBalancer(loadBalancerArn), new object[] { loadBalancerArn }))!;

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -55,8 +55,22 @@ namespace AWS.Deploy.Common.Data
 
         Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
         Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
+
+        /// <summary>
+        /// Describes the compute environment of an Elastic Beanstalk application
+        /// </summary>
+        /// <param name="environmentName">Environment name</param>
+        /// <returns>The Elastic Beanstalk environment</returns>
         Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentName);
+
+        /// <summary>
+        /// Describes the configuration settings of an Elastic Beanstalk environment
+        /// </summary>
+        /// <param name="applicationName">Application name</param>
+        /// <param name="environmentName">Environment name</param>
+        /// <returns>The configuration settings of an Elastic Beanstalk environment</returns>
         Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName);
+
         Task<LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn);
         Task<List<Listener>> DescribeElasticLoadBalancerListeners(string loadBalancerArn);
         Task<DescribeRuleResponse> DescribeCloudWatchRule(string ruleName);

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -56,6 +56,7 @@ namespace AWS.Deploy.Common.Data
         Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
         Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
         Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentName);
+        Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName);
         Task<LoadBalancer> DescribeElasticLoadBalancer(string loadBalancerArn);
         Task<List<Listener>> DescribeElasticLoadBalancerListeners(string loadBalancerArn);
         Task<DescribeRuleResponse> DescribeCloudWatchRule(string ruleName);

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidatorList.cs
@@ -13,6 +13,11 @@ namespace AWS.Deploy.Common.Recipes.Validation
         /// <summary>
         /// Must be paired with <see cref="DockerfilePathValidator"/>
         /// </summary>
-        ValidDockerfilePath
+        ValidDockerfilePath,
+
+        /// <summary>
+        /// Must be paired with <see cref="BeanstalkInstanceTypeValidator"/>
+        /// </summary>
+        BeanstalkInstanceType
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/BeanstalkInstanceTypeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/BeanstalkInstanceTypeValidator.cs
@@ -10,11 +10,18 @@ using AWS.Deploy.Common.Data;
 
 namespace AWS.Deploy.Common.Recipes.Validation;
 
+/// <summary>
+/// Validates that the chosen Elastic Beanstalk instance type(s) support
+/// the target environment architecture in a deployment recommendation.
+/// </summary>
 public class BeanstalkInstanceTypeValidator : IRecipeValidator
 {
     private readonly IOptionSettingHandler _optionSettingHandler;
     private readonly IAWSResourceQueryer _awsResourceQueryer;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BeanstalkInstanceTypeValidator"/> class.
+    /// </summary>
     public BeanstalkInstanceTypeValidator(IAWSResourceQueryer awsResourceQueryer, IOptionSettingHandler optionSettingHandler)
     {
         _awsResourceQueryer = awsResourceQueryer;
@@ -25,10 +32,13 @@ public class BeanstalkInstanceTypeValidator : IRecipeValidator
     public string ApplicationNameOptionSettingsId { get; set; } = "BeanstalkApplication.ApplicationName";
     public string EnvironmentNameOptionSettingsId { get; set; } = "BeanstalkEnvironment.EnvironmentName";
 
+    /// <summary>
+    /// Validates that the instance type(s) configured for an Elastic Beanstalk
+    /// deployment recommendation support the deployment bundle’s environment architecture.
+    /// </summary>
     public async Task<ValidationResult> Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
     {
         string? instanceType;
-
         try
         {
             instanceType = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, InstanceTypeOptionSettingsId));
@@ -39,19 +49,29 @@ public class BeanstalkInstanceTypeValidator : IRecipeValidator
                 "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
         }
 
-        if (!recommendation.IsExistingCloudApplication)
-            return await ValidationResult.ValidAsync();
-
-
+        // If the instance type is null and this is a new deployment, CDK & Beanstalk will automatically set the appropriate instance type
+        // based on the defined environment architecture. However, on a redeployment, if the user changes the environment architecture
+        // but does not explicitly update the instance type, then CDK & Beanstalk do not automatically update the instance type
+        // which would cause a failed deployment. In this case, we need to let the user know that the instance type needs to be updated.
         if (string.IsNullOrEmpty(instanceType))
         {
+            // If this is a new deployment, CDK & Beanstalk will set up the proper instance type and we do not need to perform validation
+            if (!recommendation.IsExistingCloudApplication)
+                return await ValidationResult.ValidAsync();
+
             string? applicationName;
             string? environmentName;
 
             try
             {
                 applicationName = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, ApplicationNameOptionSettingsId));
+                if (string.IsNullOrEmpty(applicationName))
+                    return await ValidationResult.FailedAsync("Could not find a valid value for Application Name " +
+                    "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
                 environmentName = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, EnvironmentNameOptionSettingsId));
+                if (string.IsNullOrEmpty(environmentName))
+                    return await ValidationResult.FailedAsync("Could not find a valid value for Environment Name " +
+                    "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
             }
             catch (OptionSettingItemDoesNotExistException)
             {
@@ -59,13 +79,8 @@ public class BeanstalkInstanceTypeValidator : IRecipeValidator
                     "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
             }
 
-            if (string.IsNullOrEmpty(applicationName))
-                return await ValidationResult.FailedAsync("Could not find a valid value for Application Name " +
-                "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
-            if (string.IsNullOrEmpty(environmentName))
-                return await ValidationResult.FailedAsync("Could not find a valid value for Environment Name " +
-                "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
-
+            // In order to retrieve the Instance Type from Elastic Beanstalk, we need to list the Option Settings of the configuration settings and look for the option
+            // with the namespace 'aws:autoscaling:launchconfiguration' and name 'InstanceType'.
             var environmentSettings = await _awsResourceQueryer.DescribeElasticBeanstalkConfigurationSettings(applicationName, environmentName);
             var environmentInstanceTypes = new HashSet<string>();
             foreach (var environmentSetting in environmentSettings)
@@ -80,6 +95,7 @@ public class BeanstalkInstanceTypeValidator : IRecipeValidator
                 }
             }
 
+            // Once we have the instance types, we need to retrieve the supported architecture for those instance types.
             var environmentArchitectures = new HashSet<string>();
             foreach (var environmentInstanceType in environmentInstanceTypes)
             {
@@ -87,6 +103,7 @@ public class BeanstalkInstanceTypeValidator : IRecipeValidator
                 describeInstanceTypeResponse?.ProcessorInfo.SupportedArchitectures.ForEach((x) => environmentArchitectures.Add(x));
             }
 
+            // We check if the selected instance types support the architecture we are trying to deploy to.
             if (!environmentArchitectures.Contains(recommendation.DeploymentBundle.EnvironmentArchitecture.ToString(), StringComparer.InvariantCultureIgnoreCase))
             {
                 return await ValidationResult.FailedAsync(
@@ -97,8 +114,10 @@ public class BeanstalkInstanceTypeValidator : IRecipeValidator
         }
         else
         {
+            // We need to retrieve the supported architecture for the selected instance type.
             var describeInstanceTypeResponse = await _awsResourceQueryer.DescribeInstanceType(instanceType);
             var environmentArchitectures = describeInstanceTypeResponse?.ProcessorInfo.SupportedArchitectures ?? new List<string>();
+            // We check if the selected instance types support the architecture we are trying to deploy to.
             if (!environmentArchitectures.Contains(recommendation.DeploymentBundle.EnvironmentArchitecture.ToString(), StringComparer.InvariantCultureIgnoreCase))
             {
                 return await ValidationResult.FailedAsync(

--- a/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/BeanstalkInstanceTypeValidator.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/RecipeValidators/BeanstalkInstanceTypeValidator.cs
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
+
+namespace AWS.Deploy.Common.Recipes.Validation;
+
+public class BeanstalkInstanceTypeValidator : IRecipeValidator
+{
+    private readonly IOptionSettingHandler _optionSettingHandler;
+    private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+    public BeanstalkInstanceTypeValidator(IAWSResourceQueryer awsResourceQueryer, IOptionSettingHandler optionSettingHandler)
+    {
+        _awsResourceQueryer = awsResourceQueryer;
+        _optionSettingHandler = optionSettingHandler;
+    }
+
+    public string InstanceTypeOptionSettingsId { get; set; } = "InstanceType";
+    public string ApplicationNameOptionSettingsId { get; set; } = "BeanstalkApplication.ApplicationName";
+    public string EnvironmentNameOptionSettingsId { get; set; } = "BeanstalkEnvironment.EnvironmentName";
+
+    public async Task<ValidationResult> Validate(Recommendation recommendation, IDeployToolValidationContext deployValidationContext)
+    {
+        string? instanceType;
+
+        try
+        {
+            instanceType = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, InstanceTypeOptionSettingsId));
+        }
+        catch (OptionSettingItemDoesNotExistException)
+        {
+            return await ValidationResult.FailedAsync("Could not find a valid value for Instance Type " +
+                "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
+        }
+
+        if (!recommendation.IsExistingCloudApplication)
+            return await ValidationResult.ValidAsync();
+
+
+        if (string.IsNullOrEmpty(instanceType))
+        {
+            string? applicationName;
+            string? environmentName;
+
+            try
+            {
+                applicationName = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, ApplicationNameOptionSettingsId));
+                environmentName = _optionSettingHandler.GetOptionSettingValue<string>(recommendation, _optionSettingHandler.GetOptionSetting(recommendation, EnvironmentNameOptionSettingsId));
+            }
+            catch (OptionSettingItemDoesNotExistException)
+            {
+                return await ValidationResult.FailedAsync("Could not find a valid value for Environment Name " +
+                    "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
+            }
+
+            if (string.IsNullOrEmpty(applicationName))
+                return await ValidationResult.FailedAsync("Could not find a valid value for Application Name " +
+                "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
+            if (string.IsNullOrEmpty(environmentName))
+                return await ValidationResult.FailedAsync("Could not find a valid value for Environment Name " +
+                "as part of of the Elastic Beanstalk deployment configuration. Please provide a valid value and try again.");
+
+            var environmentSettings = await _awsResourceQueryer.DescribeElasticBeanstalkConfigurationSettings(applicationName, environmentName);
+            var environmentInstanceTypes = new HashSet<string>();
+            foreach (var environmentSetting in environmentSettings)
+            {
+                foreach (var optionSetting in environmentSetting.OptionSettings)
+                {
+                    if (optionSetting.Namespace.Equals("aws:autoscaling:launchconfiguration") &&
+                        optionSetting.OptionName.Equals("InstanceType"))
+                    {
+                        environmentInstanceTypes.Add(optionSetting.Value);
+                    }
+                }
+            }
+
+            var environmentArchitectures = new HashSet<string>();
+            foreach (var environmentInstanceType in environmentInstanceTypes)
+            {
+                var describeInstanceTypeResponse = await _awsResourceQueryer.DescribeInstanceType(environmentInstanceType);
+                describeInstanceTypeResponse?.ProcessorInfo.SupportedArchitectures.ForEach((x) => environmentArchitectures.Add(x));
+            }
+
+            if (!environmentArchitectures.Contains(recommendation.DeploymentBundle.EnvironmentArchitecture.ToString(), StringComparer.InvariantCultureIgnoreCase))
+            {
+                return await ValidationResult.FailedAsync(
+                    $"The Elastic Beanstalk application is currently using the Instance Types '{string.Join(",", environmentInstanceTypes)}' " +
+                    $"which do not support the currently selected Environment Architecture '{recommendation.DeploymentBundle.EnvironmentArchitecture}'. " +
+                    "Please select an Instance Type that supports the currently selected Environment Architecture.");
+            }
+        }
+        else
+        {
+            var describeInstanceTypeResponse = await _awsResourceQueryer.DescribeInstanceType(instanceType);
+            var environmentArchitectures = describeInstanceTypeResponse?.ProcessorInfo.SupportedArchitectures ?? new List<string>();
+            if (!environmentArchitectures.Contains(recommendation.DeploymentBundle.EnvironmentArchitecture.ToString(), StringComparer.InvariantCultureIgnoreCase))
+            {
+                return await ValidationResult.FailedAsync(
+                    $"The Elastic Beanstalk application is currently using the Instance Type '{string.Join(",", instanceType)}' " +
+                    $"which do not support the currently selected Environment Architecture '{recommendation.DeploymentBundle.EnvironmentArchitecture}'. " +
+                    "Please select an Instance Type that supports the currently selected Environment Architecture.");
+            }
+        }
+
+        return await ValidationResult.ValidAsync();
+    }
+}

--- a/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
+++ b/src/AWS.Deploy.Common/Recipes/Validation/ValidatorFactory.cs
@@ -68,7 +68,8 @@ namespace AWS.Deploy.Common.Recipes.Validation
         private static readonly Dictionary<RecipeValidatorList, Type> _recipeValidatorTypeMapping = new()
         {
             { RecipeValidatorList.FargateTaskSizeCpuMemoryLimits, typeof(FargateTaskCpuMemorySizeValidator) },
-            { RecipeValidatorList.ValidDockerfilePath, typeof(DockerfilePathValidator) }
+            { RecipeValidatorList.ValidDockerfilePath, typeof(DockerfilePathValidator) },
+            { RecipeValidatorList.BeanstalkInstanceType, typeof(BeanstalkInstanceTypeValidator) }
         };
 
         public IOptionSettingItemValidator[] BuildValidators(OptionSettingItem optionSettingItem, Func<OptionSettingItemValidatorConfig, bool>? filter = null)

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -233,6 +233,7 @@ namespace AWS.Deploy.Orchestration.Data
             $"Error attempting to describe CloudFormation resources of '{stackName}'");
         }
 
+        /// <inheritdoc />
         public async Task<EnvironmentDescription> DescribeElasticBeanstalkEnvironment(string environmentName)
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
@@ -253,6 +254,7 @@ namespace AWS.Deploy.Orchestration.Data
             $"Error attempting to describe Elastic Beanstalk environment '{environmentName}'");
         }
 
+        /// <inheritdoc />
         public async Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName)
         {
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -238,7 +238,8 @@ namespace AWS.Deploy.Orchestration.Data
             var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
             return await HandleException(async () =>
             {
-                var environment = await beanstalkClient.DescribeEnvironmentsAsync(new DescribeEnvironmentsRequest {
+                var environment = await beanstalkClient.DescribeEnvironmentsAsync(new DescribeEnvironmentsRequest
+                {
                     EnvironmentNames = new List<string> { environmentName }
                 });
 
@@ -248,6 +249,22 @@ namespace AWS.Deploy.Orchestration.Data
                 }
 
                 return environment.Environments.First();
+            },
+            $"Error attempting to describe Elastic Beanstalk environment '{environmentName}'");
+        }
+
+        public async Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName)
+        {
+            var beanstalkClient = _awsClientFactory.GetAWSClient<IAmazonElasticBeanstalk>();
+            return await HandleException(async () =>
+            {
+                var environment = await beanstalkClient.DescribeConfigurationSettingsAsync(new DescribeConfigurationSettingsRequest
+                {
+                    ApplicationName = applicationName,
+                    EnvironmentName = environmentName
+                });
+
+                return environment.ConfigurationSettings;
             },
             $"Error attempting to describe Elastic Beanstalk environment '{environmentName}'");
         }

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppElasticBeanstalkLinux.recipe
@@ -75,6 +75,11 @@
             }
         }
     ],
+    "Validators": [
+        {
+            "ValidatorType": "BeanstalkInstanceType"
+        }
+    ],
     "Categories": [
         {
             "Id": "General",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
@@ -393,7 +393,8 @@
                         "type": "string",
                         "enum": [
                             "FargateTaskSizeCpuMemoryLimits",
-                            "ValidDockerfilePath"
+                            "ValidDockerfilePath",
+                            "BeanstalkInstanceType"
                         ]
                     }
                 },

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/ExistingWindowsEnvironment/WindowsTestContextFixture.cs
@@ -122,7 +122,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests.E
 
             await EBHelper.CreateApplicationAsync(ApplicationName);
             await EBHelper.CreateApplicationVersionAsync(ApplicationName, VersionLabel, zipFilePath);
-            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, "net6.0", VersionLabel, BeanstalkPlatformType.Windows, RoleName);
+            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, "net8.0", VersionLabel, BeanstalkPlatformType.Windows, RoleName);
             Assert.True(success);
 
             var environmentDescription = await AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/BeanstalkBackwardsCompatibilityTests/TestContextFixture.cs
@@ -114,7 +114,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.BeanstalkBackwardsCompatibilityTests
 
             await EBHelper.CreateApplicationAsync(ApplicationName);
             await EBHelper.CreateApplicationVersionAsync(ApplicationName, VersionLabel, zipFilePath);
-            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, "net6.0", VersionLabel, BeanstalkPlatformType.Linux, RoleName);
+            var success = await EBHelper.CreateEnvironmentAsync(ApplicationName, EnvironmentName, "net8.0", VersionLabel, BeanstalkPlatformType.Linux, RoleName);
             Assert.True(success);
 
             var environmentDescription = await AWSResourceQueryer.DescribeElasticBeanstalkEnvironment(EnvironmentName);

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -70,5 +70,6 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
         public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
         public Task<Vpc> GetDefaultVpc() => throw new NotImplementedException();
+        public Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName) => throw new NotImplementedException();
     }
 }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -95,5 +95,6 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<string> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
         public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
         public Task<Vpc> GetDefaultVpc() => throw new NotImplementedException();
+        public Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName) => throw new NotImplementedException();
     }
 }

--- a/testapps/WebAppNoDockerFile/WebAppNoDockerFile.csproj
+++ b/testapps/WebAppNoDockerFile/WebAppNoDockerFile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8065

*Description of changes:*
* Add a recipe validator for the Beanstalk recipe which checks if the `Environment Architecture` is compatible with the selected `Instance Type`. If no `Instance Type` is selected and CDK is selecting the instance, I am querying Beanstalk to fetch the Instance Type in order to check the architecture.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
