### PR TITLE
chore: self-contain unsupported .net versions on beanstalk

### DIFF
--- a/.autover/changes/1c879063-ec4b-4330-80a2-3f2116812150.json
+++ b/.autover/changes/1c879063-ec4b-4330-80a2-3f2116812150.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Automatically deploy unsupported .NET versions using a self-contained build to Elastic Beanstalk"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/1c879063-ec4b-4330-80a2-3f2116812150.json
+++ b/.autover/changes/1c879063-ec4b-4330-80a2-3f2116812150.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "AWS.Deploy.CLI",
-      "Type": "Patch",
+      "Type": "Minor",
       "ChangelogMessages": [
         "Automatically deploy unsupported .NET versions using a self-contained build to Elastic Beanstalk"
       ]

--- a/AWS.Deploy.sln
+++ b/AWS.Deploy.sln
@@ -69,6 +69,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Deploy.DockerImageUploa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppArmDeployment", "testapps\WebAppArmDeployment\WebAppArmDeployment.csproj", "{303A0323-3FEF-4640-80C2-E33A8BC0F1FC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleAppArmDeployment", "testapps\ConsoleAppArmDeployment\ConsoleAppArmDeployment.csproj", "{BA7E7790-8E60-4133-B3BC-BDD50B1D7A76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -179,6 +181,10 @@ Global
 		{303A0323-3FEF-4640-80C2-E33A8BC0F1FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{303A0323-3FEF-4640-80C2-E33A8BC0F1FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{303A0323-3FEF-4640-80C2-E33A8BC0F1FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA7E7790-8E60-4133-B3BC-BDD50B1D7A76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA7E7790-8E60-4133-B3BC-BDD50B1D7A76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA7E7790-8E60-4133-B3BC-BDD50B1D7A76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA7E7790-8E60-4133-B3BC-BDD50B1D7A76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -211,6 +217,7 @@ Global
 		{7E661545-7DFD-4FE3-A5F9-767FAE30DFFE} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 		{49A1C020-F4C8-4B28-A6B2-6AD3C8452E69} = {BD466B5C-D8B0-4069-98A9-6DC8F01FA757}
 		{303A0323-3FEF-4640-80C2-E33A8BC0F1FC} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
+		{BA7E7790-8E60-4133-B3BC-BDD50B1D7A76} = {C3A0C716-BDEA-4393-B223-AF8F8531522A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A4B2863-1763-4496-B122-651A38A4F5D7}

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -12,7 +12,7 @@ phases:
   build:
     commands:
       - dotnet build AWS.Deploy.sln -c Release
-      - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover AWS.Deploy.sln -c Release --no-build --logger trx --results-directory ./testresults
+      - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover AWS.Deploy.sln -c Release --no-build --logger trx --logger "console;verbosity=detailed" --results-directory ./testresults
 
   post_build:
     steps:

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -143,7 +143,7 @@ namespace AWS.Deploy.Orchestration
                     if (retiredFrameworks.Contains(targetFramework))
                     {
                         _interactiveService.LogErrorMessage($"The version of .NET that you are targeting has reached its end-of-support and has been retired by Elastic Beanstalk");
-                        _interactiveService.LogInfoMessage($"Using self-contained publish to deploy your application on a newer Elastic Beanstalk platform with a supported version of .NET");
+                        _interactiveService.LogInfoMessage($"Using self-contained publish to include the out of support version of .NET used by this application with the deployment bundle");
                     }
                     else
                     {

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -135,12 +135,20 @@ namespace AWS.Deploy.Orchestration
                 if (string.IsNullOrEmpty(targetFramework))
                     return;
 
-                // Elastic Beanstalk doesn't currently have .NET 7 and 9 preinstalled.
-                var unavailableFramework = new List<string> { "net7.0", "net9.0" };
-                var frameworkNames = new Dictionary<string, string> { { "net7.0", ".NET 7" }, { "net9.0", ".NET 9" } };
-                if (unavailableFramework.Contains(targetFramework))
+                // Elastic Beanstalk currently has .NET 8 and 9 supported on their platforms.
+                var supportedFrameworks = new List<string> { "net8.0", "net9.0" };
+                var retiredFrameworks = new List<string> { "netcoreapp3.1", "net5.0", "net6.0", "net7.0" };
+                if (!supportedFrameworks.Contains(targetFramework))
                 {
-                    _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have {frameworkNames[targetFramework]} preinstalled");
+                    if (retiredFrameworks.Contains(targetFramework))
+                    {
+                        _interactiveService.LogErrorMessage($"The version of .NET that you are targeting has reached its end-of-support and has been retired by Elastic Beanstalk");
+                        _interactiveService.LogInfoMessage($"Using self-contained publish to deploy your application on a newer Elastic Beanstalk platform with a supported version of .NET");
+                    }
+                    else
+                    {
+                        _interactiveService.LogInfoMessage($"Using self-contained publish since AWS Elastic Beanstalk does not currently have {targetFramework} preinstalled");
+                    }
                     recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild = true;
                     return;
                 }

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -120,14 +120,13 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
         [Theory]
         [InlineData("testapps", "ConsoleAppService", "ConsoleAppService.csproj")]
-        [InlineData("testapps", "ConsoleAppTask", "ConsoleAppTask.csproj")]
         public async Task FargateArmDeployment(params string[] components)
         {
             _stackName = $"{components[1]}Arm{Guid.NewGuid().ToString().Split('-').Last()}";
 
             // Arrange input for deploy
             await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Select default recommendation
-            await _interactiveService.StdInWriter.WriteLineAsync("8"); // Select "Environment Architecture"
+            await _interactiveService.StdInWriter.WriteLineAsync("7"); // Select "Environment Architecture"
             await _interactiveService.StdInWriter.WriteLineAsync("2"); // Select "Arm64"
             await _interactiveService.StdInWriter.WriteAsync(Environment.NewLine); // Confirm selection and deploy
             await _interactiveService.StdInWriter.FlushAsync();

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConsoleAppTests.cs
@@ -119,7 +119,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
         }
 
         [Theory]
-        [InlineData("testapps", "ConsoleAppService", "ConsoleAppService.csproj")]
+        [InlineData("testapps", "ConsoleAppArmDeployment", "ConsoleAppArmDeployment.csproj")]
         public async Task FargateArmDeployment(params string[] components)
         {
             _stackName = $"{components[1]}Arm{Guid.NewGuid().ToString().Split('-').Last()}";

--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -199,6 +199,51 @@ namespace AWS.Deploy.CLI.IntegrationTests
             Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
         }
 
+        [Fact]
+        public async Task DeployRetiredDotnetVersion()
+        {
+            _stackName = $"RetiredDotnetBeanstalk{Guid.NewGuid().ToString().Split('-').Last()}";
+
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "WebApiNET6", "WebApiNET6.csproj"));
+            var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics", "--silent", "--apply", "ElasticBeanStalkConfigFile.json" };
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deployArgs));
+
+            // Verify application is deployed and running
+            Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+            var deployStdOut = _interactiveService.StdOutReader.ReadAllLines();
+
+            var tempCdkProjectLine = deployStdOut.First(line => line.StartsWith("Saving AWS CDK deployment project to: "));
+            var tempCdkProject = tempCdkProjectLine.Split(": ")[1].Trim();
+            Assert.False(Directory.Exists(tempCdkProject), $"{tempCdkProject} must not exist.");
+
+            // Example:     Endpoint: http://52.36.216.238/
+            var endpointLine = deployStdOut.First(line => line.Trim().StartsWith($"Endpoint"));
+            var applicationUrl = endpointLine.Substring(endpointLine.IndexOf(":", StringComparison.Ordinal) + 1).Trim();
+            Assert.True(Uri.IsWellFormedUriString(applicationUrl, UriKind.Absolute));
+
+            // URL could take few more minutes to come live, therefore, we want to wait and keep trying for a specified timeout
+            await _httpHelper.WaitUntilSuccessStatusCode(applicationUrl, TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
+
+            // list
+            var listArgs = new[] { "list-deployments", "--diagnostics" };
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(listArgs)); ;
+
+            // Verify stack exists in list of deployments
+            var listStdOut = _interactiveService.StdOutReader.ReadAllLines().Select(x => x.Split()[0]).ToList();
+            Assert.Contains(listStdOut, (deployment) => _stackName.Equals(deployment));
+
+            // Arrange input for delete
+            // Use --silent flag to delete without user prompts
+            var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics", "--silent" };
+
+            // Delete
+            Assert.Equal(CommandReturnCodes.SUCCESS, await _app.Run(deleteArgs)); ;
+
+            // Verify application is deleted
+            Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -400,37 +400,6 @@ namespace AWS.Deploy.CLI.UnitTests
         }
 
         [Theory]
-        [InlineData("arn:aws:elasticbeanstalk:us-west-2::platform/.NET 8 running on 64bit Amazon Linux 2023")]
-        [InlineData("arn:aws:elasticbeanstalk:us-west-2::platform/.NET 8 running on 64bit Amazon Linux 2023/invalidversion")]
-        public async Task CreateDotnetPublishZip_InvalidPlatformArn(string platformArn)
-        {
-            var projectPath = SystemIOUtilities.ResolvePath(Path.Combine("ConsoleAppTask"));
-            var project = await _projectDefinitionParser.Parse(projectPath);
-            _recipeDefinition.TargetService = RecipeIdentifier.TARGET_SERVICE_ELASTIC_BEANSTALK;
-            _recipeDefinition.OptionSettings.Add(
-                new OptionSettingItem(
-                    "ElasticBeanstalkPlatformArn",
-                    "ElasticBeanstalkPlatformArn",
-                    "Beanstalk Platform",
-                    "The name of the Elastic Beanstalk platform to use with the environment.")
-                {
-                    DefaultValue = platformArn
-                });
-            var recommendation = new Recommendation(_recipeDefinition, project, 100, new Dictionary<string, object>());
-
-            await _deploymentBundleHandler.CreateDotnetPublishZip(recommendation);
-
-            Assert.False(recommendation.DeploymentBundle.DotnetPublishSelfContainedBuild);
-
-            var expectedCommand =
-                $"dotnet publish \"{project.ProjectPath}\"" +
-                $" -o \"{_directoryManager.CreatedDirectories.First()}\"" +
-                " -c Release  ";
-
-            Assert.Equal(expectedCommand, _commandLineWrapper.CommandsToExecute.First().Command);
-        }
-
-        [Theory]
         [InlineData("arn:aws:elasticbeanstalk:us-west-2::platform/.NET Core running on 64bit Amazon Linux 2/2.7.3")]
         [InlineData("arn:aws:elasticbeanstalk:us-west-2::platform/.NET 6 running on 64bit Amazon Linux 2023/3.1.3")]
         public async Task CreateDotnetPublishZip_PlatformDoesntSupportNet8(string platformArn)

--- a/testapps/ConsoleAppArmDeployment/ConsoleAppArmDeployment.csproj
+++ b/testapps/ConsoleAppArmDeployment/ConsoleAppArmDeployment.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/testapps/ConsoleAppArmDeployment/Dockerfile
+++ b/testapps/ConsoleAppArmDeployment/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+USER app
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG TARGETARCH
+WORKDIR /src
+COPY ["ConsoleAppArmDeployment.csproj", "ConsoleAppArmDeployment/"]
+RUN dotnet restore "ConsoleAppArmDeployment/ConsoleAppArmDeployment.csproj" -a $TARGETARCH
+COPY . "ConsoleAppArmDeployment/"
+
+WORKDIR "/src/ConsoleAppArmDeployment"
+RUN dotnet build "ConsoleAppArmDeployment.csproj" -c Release -o /app/build -a $TARGETARCH
+
+FROM build AS publish
+RUN dotnet publish "ConsoleAppArmDeployment.csproj" -c Release -o /app/publish -a $TARGETARCH
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "ConsoleAppArmDeployment.dll"]

--- a/testapps/ConsoleAppArmDeployment/Program.cs
+++ b/testapps/ConsoleAppArmDeployment/Program.cs
@@ -1,0 +1,7 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+while (true)
+{
+    Console.WriteLine("Hello World!");
+    await Task.Delay(500);
+}

--- a/testapps/WebApiNET6/ElasticBeanStalkConfigFile.json
+++ b/testapps/WebApiNET6/ElasticBeanStalkConfigFile.json
@@ -1,0 +1,6 @@
+{
+    "RecipeId": "AspNetAppElasticBeanstalkLinux",
+    "Settings": {
+
+    }
+}

--- a/testapps/WebApiNET6/WebApiNET6.csproj
+++ b/testapps/WebApiNET6/WebApiNET6.csproj
@@ -6,4 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Update="ElasticBeanStalkConfigFile.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8094

*Description of changes:*
* Instead of tracking the unsupported dotnet versions, we are now tracking the supported ones and everything else will be deployed as self-contained.
* We are also tracking the retired .net versions to provide the user messaging informing them that they are using an out of support version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
