### PR TITLE
feat: upgrade deploy tool to net8.0

### DIFF
--- a/site/content/contributing.md
+++ b/site/content/contributing.md
@@ -176,7 +176,7 @@ To support IDEs using the AWS .NET Deploy tool the CLI can be launched in server
 ```json
 {
    "DeployServer":{
-      "AlternateCliPath":"C:\\code\\aws-dotnet-deploy\\src\\AWS.Deploy.CLI\\bin\\Release\\net6.0\\AWS.Deploy.CLI.exe",
+      "AlternateCliPath":"C:\\code\\aws-dotnet-deploy\\src\\AWS.Deploy.CLI\\bin\\Release\\net8.0\\AWS.Deploy.CLI.exe",
       "PortRange":{
          "Start":10000,
          "End":10100

--- a/site/content/docs/commands/deploy.md
+++ b/site/content/docs/commands/deploy.md
@@ -19,7 +19,7 @@ Inspects the project and recommends AWS compute that is most suited to the type 
 Deploying HelloWorld
 
 ```
-dotnet new web -n HelloWorld -f net6.0
+dotnet new web -n HelloWorld -f net8.0
 cd HelloWorld
 dotnet aws deploy
 ```

--- a/site/content/docs/deployment-projects/recipe-file.md
+++ b/site/content/docs/deployment-projects/recipe-file.md
@@ -60,8 +60,8 @@ The deploy tool supports a collection of tests that can be run against the .NET 
     "Condition": {
         "PropertyName": "TargetFramework",
         "AllowedValues": [
-            "netcoreapp3.1",
-            "net6.0"
+            "net8.0",
+            "net9.0"
         ]
     }
 }
@@ -103,8 +103,8 @@ Here is an example of a rule that checks if the project is a web project and tar
         "Condition": {
           "PropertyName": "TargetFramework",
           "AllowedValues": [
-            "netcoreapp3.1",
-            "net6.0"
+            "net8.0",
+            "net9.0"
           ]
         }
       }

--- a/site/content/docs/getting-started/run-tool.md
+++ b/site/content/docs/getting-started/run-tool.md
@@ -12,7 +12,7 @@ dotnet-aws ...
 #### Step 1: Create the ASP.NET Web application
 
 ```
-dotnet new web -n HelloWorld -f net6.0
+dotnet new web -n HelloWorld -f net8.0
 ```
 
 #### Step 2: cd to the project folder

--- a/site/content/troubleshooting-guide/index.md
+++ b/site/content/troubleshooting-guide/index.md
@@ -30,7 +30,7 @@ For example:
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
+		<TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
 		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/site/content/tutorials/custom-project.md
+++ b/site/content/tutorials/custom-project.md
@@ -20,7 +20,7 @@ Tasks we will accomplish:
 In your command prompt, run the following command to create your app:
 
 ```
-dotnet new webapp -o Acme.WebApp -f net6.0
+dotnet new webapp -o Acme.WebApp -f net8.0
 ```
 
 ### Step 2: Generate a deployment project

--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <ToolCommandName>dotnet-aws</ToolCommandName>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/src/AWS.Deploy.CLI/ServerMode/AwsCredentialsAuthenticationHandler.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/AwsCredentialsAuthenticationHandler.cs
@@ -62,9 +62,8 @@ namespace AWS.Deploy.CLI.ServerMode
             IOptionsMonitor<AwsCredentialsAuthenticationSchemeOptions> options,
             ILoggerFactory logger,
             UrlEncoder encoder,
-            ISystemClock clock,
             IEncryptionProvider encryptionProvider)
-            : base(options, logger, encoder, clock)
+            : base(options, logger, encoder)
         {
             _encryptionProvider = encryptionProvider;
         }

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <AssemblyName>AWS.Deploy.Common</AssemblyName>
     <RootNamespace>AWS.Deploy.Common</RootNamespace>

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <AssemblyName>AWS.Deploy.Orchestration</AssemblyName>
     <RootNamespace>AWS.Deploy.Orchestration</RootNamespace>
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\AWS.Deploy.Common\AWS.Deploy.Common.csproj" />
     <ProjectReference Include="..\AWS.Deploy.Recipes\AWS.Deploy.Recipes.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Remove="Properties\DockerFileConfig.json" />
     <None Remove="Templates\Dockerfile.template" />

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Product>AWS .NET deployment tool CDK Utilities</Product>
     <Description>Utility code used in CDK recipes used by the AWS .NET deployment tool. This package is not intended for direct usage.</Description>
     <PackageId>AWS.Deploy.Recipes.CDK.Common</PackageId>

--- a/src/AWS.Deploy.Recipes/AWS.Deploy.Recipes.csproj
+++ b/src/AWS.Deploy.Recipes/AWS.Deploy.Recipes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AWS.Deploy.Recipes</AssemblyName>
     <RootNamespace>AWS.Deploy.Recipes</RootNamespace>
   </PropertyGroup>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/AspNetAppEcsFargate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/Generated/Recipe.cs
@@ -76,7 +76,7 @@ namespace BlazorWasm
             {
                 DefaultBehavior = new BehaviorOptions
                 {
-                    Origin = new S3Origin(ContentS3Bucket, new S3OriginProps())
+                    Origin = S3BucketOrigin.WithOriginAccessControl(ContentS3Bucket)
                 },
                 DefaultRootObject = settings.IndexDocument,
                 EnableIpv6 = settings.EnableIpv6,

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <Nullable>enable</Nullable>
     <AWSProjectType>DeploymentProject</AWSProjectType>

--- a/src/AWS.Deploy.ServerMode.ClientGenerator/AWS.Deploy.ServerMode.ClientGenerator.csproj
+++ b/src/AWS.Deploy.ServerMode.ClientGenerator/AWS.Deploy.ServerMode.ClientGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 

--- a/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>AWS.Deploy.CLI.UnitTests</AssemblyName>
     <RootNamespace>AWS.Deploy.CLI.UnitTests</RootNamespace>
@@ -16,7 +16,7 @@
     <Content Include="TestFiles\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>  
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    
+
   </ItemGroup>
 
   <ItemGroup>
@@ -43,5 +43,5 @@
     <ProjectReference Include="..\..\src\AWS.Deploy.ServerMode.Client\AWS.Deploy.ServerMode.Client.csproj" />
     <ProjectReference Include="..\AWS.Deploy.CLI.Common.UnitTests\AWS.Deploy.CLI.Common.UnitTests.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/AWS.Deploy.DockerImageUploader/AWS.Deploy.DockerImageUploader.csproj
+++ b/test/AWS.Deploy.DockerImageUploader/AWS.Deploy.DockerImageUploader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <LangVersion>Latest</LangVersion>

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    
+
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8095

*Description of changes:*
* Update all projects to net8.0
* Switch `S3Origin` to `S3BucketOrigin.WithOriginAccessControl` since `S3Origin` is now obsolete.
* Removed `ISystemClock clock` which is now obsolete

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
