### PR TITLE
chore: upgrade templating engine to net8

### DIFF
--- a/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/GenerateDeploymentProjectCommand.cs
@@ -101,7 +101,7 @@ public class GenerateDeploymentProjectCommand(
             }
         }
 
-        cdkProjectHandler.CreateCdkProject(selectedRecommendation, session, saveDirectory);
+        await cdkProjectHandler.CreateCdkProject(selectedRecommendation, session, saveDirectory);
         await GenerateDeploymentRecipeSnapShot(selectedRecommendation, saveDirectory, projectDisplayName, targetApplicationFullPath);
 
         var saveCdkDirectoryFullPath = directoryManager.GetDirectoryInfo(saveDirectory).FullName;

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -26,9 +26,9 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.0.1" />
     <PackageReference Include="AWSSDK.AppRunner" Version="4.0.0.1" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="4.0.1.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="5.0.1" />
-    <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="8.0.408" />
+    <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="8.0.408" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="13.4.0" />

--- a/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
+++ b/src/AWS.Deploy.Orchestration/CdkProjectHandler.cs
@@ -16,7 +16,7 @@ namespace AWS.Deploy.Orchestration
     public interface ICdkProjectHandler
     {
         Task<string> ConfigureCdkProject(OrchestratorSession session, CloudApplication cloudApplication, Recommendation recommendation);
-        string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
+        Task<string> CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveDirectoryPath = null);
         Task DeployCdkProject(OrchestratorSession session, CloudApplication cloudApplication, string cdkProjectPath, Recommendation recommendation);
         void DeleteTemporaryCdkProject(string cdkProjectPath);
         Task<string> PerformCdkDiff(string cdkProjectPath, CloudApplication cloudApplication);
@@ -71,7 +71,7 @@ namespace AWS.Deploy.Orchestration
             {
                 // Create a new temporary CDK project for a new deployment
                 _interactiveService.LogInfoMessage("Generating AWS Cloud Development Kit (AWS CDK) deployment project");
-                cdkProjectPath = CreateCdkProject(recommendation, session);
+                cdkProjectPath = await CreateCdkProject(recommendation, session);
             }
 
             // Write required configuration in appsettings.json
@@ -255,7 +255,7 @@ namespace AWS.Deploy.Orchestration
             }
         }
 
-        public string CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)
+        public async Task<string> CreateCdkProject(Recommendation recommendation, OrchestratorSession session, string? saveCdkDirectoryPath = null)
         {
             string? assemblyName;
             if (string.IsNullOrEmpty(saveCdkDirectoryPath))
@@ -278,7 +278,7 @@ namespace AWS.Deploy.Orchestration
             _directoryManager.CreateDirectory(saveCdkDirectoryPath);
 
             var templateEngine = new TemplateEngine();
-            templateEngine.GenerateCDKProjectFromTemplate(recommendation, session, saveCdkDirectoryPath, assemblyName);
+            await templateEngine.GenerateCdkProjectFromTemplateAsync(recommendation, session, saveCdkDirectoryPath, assemblyName);
 
             _interactiveService.LogDebugMessage($"Saving AWS CDK deployment project to: {saveCdkDirectoryPath}");
             return saveCdkDirectoryPath;

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "AWS",
     "classifications": [
         "AWS",


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8095

*Description of changes:*
* Upgrade templating engine from .NET5 to .NET8 since a lot of changes have happened to their public interfaces

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
