### PR TITLE
feat: update NodeJS minimum version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ To take advantage of this library you’ll need:
   * The local credential profile can be configured by a variety of tools. For example, the credential profile can be configured with the [AWS Toolkit for Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/credentials.html) or the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html), among others.
   * Note: You need to make sure to add the appropriate CloudFormation permissions to your credentials's profile / assumed role.
   * For SSO, please visit the [.NET SDK Reference Guide](https://docs.aws.amazon.com/sdkref/latest/guide/access-sso.html).
-* [.NET 6](https://dotnet.microsoft.com/download) or later
-* [Node.js 14](https://nodejs.org/en/download/) or later
+* [.NET 8](https://dotnet.microsoft.com/download) or later
+* [Node.js 18](https://nodejs.org/en/download/) or later
   * The [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) is used by this tool to create the AWS infrastructure to run applications. The CDK requires Node.js to function. This dependency is needed for deployments that are CDK based. If you will be using deployments that are not CDK based, you are not required to have this dependency.
-* (optional) [Docker](https://docs.docker.com/get-docker/)
+* (optional) [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/docs/installation)
   * Used when deploying to a container based service like Amazon Elastic Container Service (Amazon ECS)
 * (optional) The zip cli tool
    *   Mac / Linux only. Used when creating zip packages for deployment bundles. The zip cli is used to maintain Linux file permissions.

--- a/site/content/docs/getting-started/pre-requisites.md
+++ b/site/content/docs/getting-started/pre-requisites.md
@@ -9,12 +9,12 @@ To run the AWS Deploy Tool, you need the following pre-requisites set up in your
 
   > Note: You need to make sure to add the appropriate AWS permissions to your credentials’ profile / assumed role. See [Setting up Credentials](setup-creds.md)
 
-#### .NET 6 or later
+#### .NET 8 or later
 * .NET CLI - the deployment tool can be used from the .NET command-line interface (CLI) - a cross-platform toolchain for developing, building, running, and publishing .NET applications.
 
 * The .NET CLI is included with the [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/sdk). For information about how to install or update .NET, see [https://dotnet.microsoft.com/](https://dotnet.microsoft.com/).
 
-* The deployment tool requires .NET 6 or later to be installed. However, the deployment tool supports deploying applications built using .NET Core 3.1 or later (for example, .NET Core 3.1, .NET 5.0, .NET 6.0, .NET 7). To see what version you have, run the following on the command prompt or in a terminal:
+* The deployment tool requires .NET 8 or later to be installed. However, the deployment tool supports deploying applications built using .NET Core 3.1 or later (for example, .NET Core 3.1, .NET 5.0, .NET 6.0, .NET 7, and newer). To see what version you have, run the following on the command prompt or in a terminal:
 
 ```
 dotnet --version
@@ -22,7 +22,7 @@ dotnet --version
 
 #### Node.js
 
-* The deployment tool requires the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/), and the AWS CDK requires [Node.js](https://nodejs.org/en/download/). AWS CDK requires Node.js, versions 14.x, 16.x, 18.x (or later) - we recommend installing the latest LTS version.
+* The deployment tool requires the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/), and the AWS CDK requires [Node.js](https://nodejs.org/en/download/). AWS CDK requires Node.js, versions 18.x (or later) - we recommend installing the latest LTS version.
 
 * To install Node.js, go to  [Node.js downloads](https://nodejs.org/en/download/)
 

--- a/site/content/troubleshooting-guide/missing-dependencies.md
+++ b/site/content/troubleshooting-guide/missing-dependencies.md
@@ -6,7 +6,7 @@ This section of the troubleshooting guide explains how to determine, diagnose, a
 
 **Why is this happening**: AWS.Deploy.Tools relies on [AWS Cloud Development Kit](https://aws.amazon.com/cdk/) (CDK) to provision resources for your cloud application. AWS CDK requires Node.js to be installed in your machine. See the  [CDK's FAQs](https://aws.amazon.com/cdk/faqs/) for more information about how it uses Node.js.
 
-*Minimum required Node.js version >= 14.17.0*
+*Minimum required Node.js version >= 18.0.0*
 
 **Resolution**: See [here](https://nodejs.org/en/download/) to install Node.js on your system.
 

--- a/src/AWS.Deploy.Orchestration/SystemCapabilityEvaluator.cs
+++ b/src/AWS.Deploy.Orchestration/SystemCapabilityEvaluator.cs
@@ -33,7 +33,7 @@ namespace AWS.Deploy.Orchestration
         private const string PODMAN_DEPENDENCY_NAME = "Podman";
         private const string PODMAN_INSTALLATION_URL = "https://podman.io/docs/installation";
 
-        private static readonly Version MinimumNodeJSVersion = new Version(14,17,0);
+        private static readonly Version MinimumNodeJSVersion = new Version(18,0,0);
 
         /// <summary>
         /// How long to wait for the commands we run to determine if Node/Docker/etc. are installed to finish


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8095

*Description of changes:*
Update NodeJS minimum version to 18 since AWS CDK has dropped support for 14 and 16 https://aws.amazon.com/blogs/devops/announcing-the-end-of-support-for-node-js-14-x-and-16-x-in-aws-cdk/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
