### PR TITLE
feat: add min health percent to Fargate recipes

### DIFF
--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon ECS using AWS Fargate.md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon ECS using AWS Fargate.md
@@ -29,6 +29,10 @@
     * ID: DesiredCount
     * Description: The desired number of ECS tasks to run for the service.
     * Type: Int
+* **Minimum Healthy Percent**
+    * ID: MinHealthyPercent
+    * Description: The minimum number of tasks, specified as a percentage of the Amazon ECS service's 'Desired Task Count' value, that must continue to run and remain healthy during a deployment.
+    * Type: Int
 * **Container Port**
     * ID: Port
     * Description: The port the container is listening for requests on.

--- a/site/content/docs/cicd/recipes/Service on Amazon Elastic Container Service (ECS) using AWS Fargate.md
+++ b/site/content/docs/cicd/recipes/Service on Amazon Elastic Container Service (ECS) using AWS Fargate.md
@@ -29,6 +29,10 @@
     * ID: DesiredCount
     * Description: The desired number of ECS tasks to run for the service.
     * Type: Int
+* **Minimum Healthy Percent**
+    * ID: MinHealthyPercent
+    * Description: The minimum number of tasks, specified as a percentage of the Amazon ECS service's 'Desired Task Count' value, that must continue to run and remain healthy during a deployment.
+    * Type: Int
 * **Application IAM Role**
     * ID: ApplicationIAMRole
     * Description: The Identity and Access Management (IAM) role that provides AWS credentials to the application to access AWS services.

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Configurations/Configuration.cs
@@ -24,6 +24,12 @@ namespace AspNetAppEcsFargate.Configurations
         public double DesiredCount { get; set; }
 
         /// <summary>
+        /// The minimum number of tasks, specified as a percentage of the Amazon ECS service's <see cref="DesiredCount"/> value,
+        /// that must continue to run and remain healthy during a deployment.
+        /// </summary>
+        public double MinHealthyPercent { get; set; }
+
+        /// <summary>
         /// The name of the ECS service running in the cluster.
         /// </summary>
         public string ECSServiceName { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppEcsFargate/Generated/Recipe.cs
@@ -191,6 +191,7 @@ namespace AspNetAppEcsFargate
                 Cluster = EcsCluster,
                 TaskDefinition = AppTaskDefinition,
                 DesiredCount = settings.DesiredCount,
+                MinHealthyPercent = settings.MinHealthyPercent,
                 ServiceName = settings.ECSServiceName,
                 AssignPublicIp = settings.Vpc.IsDefault,
                 SecurityGroups = EcsServiceSecurityGroups.ToArray()

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Configurations/Configuration.cs
@@ -19,6 +19,12 @@ namespace ConsoleAppEcsFargateService.Configurations
         public double DesiredCount { get; set; }
 
         /// <summary>
+        /// The minimum number of tasks, specified as a percentage of the Amazon ECS service's <see cref="DesiredCount"/> value,
+        /// that must continue to run and remain healthy during a deployment.
+        /// </summary>
+        public double MinHealthyPercent { get; set; }
+
+        /// <summary>
         /// The Identity and Access Management Role that provides AWS credentials to the application to access AWS services.
         /// </summary>
         public IAMRoleConfiguration ApplicationIAMRole { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/Generated/Recipe.cs
@@ -181,7 +181,8 @@ namespace ConsoleAppEcsFargateService
                 Cluster = EcsCluster,
                 TaskDefinition = AppTaskDefinition,
                 AssignPublicIp = settings.Vpc.IsDefault,
-                DesiredCount = settings.DesiredCount
+                DesiredCount = settings.DesiredCount,
+                MinHealthyPercent = settings.MinHealthyPercent
             };
 
 

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppECSFargate.recipe
@@ -230,6 +230,25 @@
             ]
         },
         {
+            "Id": "MinHealthyPercent",
+            "Name": "Minimum Healthy Percent",
+            "Category": "Compute",
+            "Description": "The minimum number of tasks, specified as a percentage of the Amazon ECS service's 'Desired Task Count' value, that must continue to run and remain healthy during a deployment.",
+            "Type": "Int",
+            "DefaultValue": 100,
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "Range",
+                    "Configuration": {
+                        "Min": 0,
+                        "Max": 100
+                    }
+                }
+            ]
+        },
+        {
             "Id": "Port",
             "Name": "Container Port",
             "Category": "General",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ConsoleAppECSFargateService.recipe
@@ -282,6 +282,25 @@
             ]
         },
         {
+            "Id": "MinHealthyPercent",
+            "Name": "Minimum Healthy Percent",
+            "Category": "Compute",
+            "Description": "The minimum number of tasks, specified as a percentage of the Amazon ECS service's 'Desired Task Count' value, that must continue to run and remain healthy during a deployment.",
+            "Type": "Int",
+            "DefaultValue": 100,
+            "AdvancedSetting": true,
+            "Updatable": true,
+            "Validators": [
+                {
+                    "ValidatorType": "Range",
+                    "Configuration": {
+                        "Min": 0,
+                        "Max": 100
+                    }
+                }
+            ]
+        },
+        {
             "Id": "ApplicationIAMRole",
             "Name": "Application IAM Role",
             "Category": "Permissions",


### PR DESCRIPTION
*Description of changes:*
Add min health percent to Fargate recipes to address the CDK warning:
[Warning at /NET8Web1/Recipe/AppFargateService] minHealthyPercent has not been configured so the default value of 50% is used. The number of running tasks will decrease below the desired count during deployments etc. See https://github.com/aws/aws-cdk/issues/31705 [ack: @aws-cdk/aws-ecs:minHealthyPercent]

CDK defaults this value to 50, though CloudFormation defaults to 100 https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ecs-service-deploymentconfiguration.html#cfn-ecs-service-deploymentconfiguration-minimumhealthypercent.

I stuck with 100 as the default to provide users with the behavior they would expect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
