### PR TITLE
Fix intermittent IAM permission failures in delete-deployment command

### DIFF
--- a/.autover/changes/d5f415cd-080b-41e1-8256-8743f7a423d3.json
+++ b/.autover/changes/d5f415cd-080b-41e1-8256-8743f7a423d3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed intermittent IAM permission failures in delete-deployment command by ensuring CloudFormation client is created after AWS credentials are configured"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*
Package Verifier Canary failed during SmokeTests execution (V1823703386)
Package Verifier Canary failed during SmokeTests execution (V1823700902)

*Description of changes:*

Fixed CloudFormation client initialization timing issue in DeleteDeploymentCommand

  - Client was being created with wrong AWS credentials during constructor execution

  - Moved client creation to ExecuteAsync after credentials are properly configured



*Testing*
  - Built successfully with `dotnet build`
  - No existing unit tests directly instantiate DeleteDeploymentCommand
  - Fix addresses the cross-account permission errors seen in smoke test logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
