### PR TITLE
Fix intermittent IAM permission failures in delete-deployment command

### DIFF
--- a/.autover/changes/d5f415cd-080b-41e1-8256-8743f7a423d3.json
+++ b/.autover/changes/d5f415cd-080b-41e1-8256-8743f7a423d3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed intermittent IAM permission failures in delete-deployment command by ensuring CloudFormation client is created after AWS credentials are configured"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
@@ -243,6 +243,16 @@ namespace AWS.Deploy.CLI.ServerMode.Services
             return (await GetAndCache(async () => await _awsResourceQueryer.GetCloudFrontDistribution(distributionId), new object[] { distributionId }))!;
         }
 
+        public async Task<List<Stack>> DescribeStacks(string stackName)
+        {
+            return (await GetAndCache(async () => await _awsResourceQueryer.DescribeStacks(stackName), new object[] { stackName }))!;
+        }
+
+        public async Task<DeleteStackResponse> DeleteStack(string stackName)
+        {
+            return (await GetAndCache(async () => await _awsResourceQueryer.DeleteStack(stackName), new object[] { stackName }))!;
+        }
+
         /// <inheritdoc/>
         public async Task<Vpc?> GetDefaultVpc()
         {

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -36,6 +36,8 @@ namespace AWS.Deploy.Common.Data
     /// </remarks>
     public interface IAWSResourceQueryer
     {
+        Task<List<Stack>> DescribeStacks(string stackName);
+        Task<DeleteStackResponse> DeleteStack(string stackName);
         Task<Vpc?> GetDefaultVpc();
         Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier);
         Task<List<StackEvent>> GetCloudFormationStackEvents(string stackName);

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -51,6 +51,34 @@ namespace AWS.Deploy.Orchestration.Data
 {
     public class AWSResourceQueryer(IAWSClientFactory awsClientFactory) : IAWSResourceQueryer
     {
+        public async Task<List<Stack>> DescribeStacks(string stackName)
+        {
+            var cfClient = awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
+            var request = new DescribeStacksRequest
+            {
+                StackName = stackName
+            };
+
+            return await HandleException(async () => await cfClient.Paginators
+                    .DescribeStacks(request)
+                    .Stacks
+                    .ToListAsync(),
+                $"Error attempting to describe available CloudFormation stacks using stack name '{stackName}'");
+        }
+
+        public async Task<DeleteStackResponse> DeleteStack(string stackName)
+        {
+            var cfClient = awsClientFactory.GetAWSClient<IAmazonCloudFormation>();
+            var request = new DeleteStackRequest
+            {
+                StackName = stackName
+            };
+
+            return await HandleException(async () => await cfClient
+                    .DeleteStackAsync(request),
+                $"Error attempting to delete the CloudFormation stack '{stackName}'.");
+        }
+
         public async Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier)
         {
             var cloudControlApiClient = awsClientFactory.GetAWSClient<IAmazonCloudControlApi>();

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -69,6 +69,10 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string? vpcID = null) => throw new NotImplementedException();
         public Task<string?> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
         public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
+        public Task<List<Stack>> DescribeStacks(string stackName) => throw new NotImplementedException();
+
+        public Task<DeleteStackResponse> DeleteStack(string stackName) => throw new NotImplementedException();
+
         public Task<Vpc?> GetDefaultVpc() => throw new NotImplementedException();
         public Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName) => throw new NotImplementedException();
     }

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -94,6 +94,10 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
         public Task<List<SecurityGroup>> DescribeSecurityGroups(string? vpcID = null) => throw new NotImplementedException();
         public Task<string?> GetParameterStoreTextValue(string parameterName) => throw new NotImplementedException();
         public Task<ResourceDescription> GetCloudControlApiResource(string type, string identifier) => throw new NotImplementedException();
+        public Task<List<Stack>> DescribeStacks(string stackName) => throw new NotImplementedException();
+
+        public Task<DeleteStackResponse> DeleteStack(string stackName) => throw new NotImplementedException();
+
         public Task<Vpc?> GetDefaultVpc() => throw new NotImplementedException();
         public Task<List<ConfigurationSettingsDescription>> DescribeElasticBeanstalkConfigurationSettings(string applicationName, string environmentName) => throw new NotImplementedException();
     }


### PR DESCRIPTION
*Description of changes:*
Package Verifier Canary failed during SmokeTests execution (V1823700902)

*Description of changes:*

Fixed CloudFormation client initialization timing issue in DeleteDeploymentCommand

  - Client was being created with wrong AWS credentials during constructor execution

  - Removed the direct use of the CFN client and used the AWS Queryer service to query CFN



*Testing*
  - Built successfully with `dotnet build`
  - No existing unit tests directly instantiate DeleteDeploymentCommand
  - Fix addresses the cross-account permission errors seen in smoke test logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
