### PR TITLE
fix t2.nano usage

### DIFF
--- a/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/WebAppNoDockerFileTests.cs
@@ -214,7 +214,7 @@ namespace AWS.Deploy.CLI.IntegrationTests
                         interactiveService.StdInWriter.Write(Environment.NewLine); // Confirm selection and deploy
                         interactiveService.StdInWriter.WriteLine("more"); // Select "Environment Architecture"
                         interactiveService.StdInWriter.WriteLine("1"); // Select "EC2 Instance Type"
-                        interactiveService.StdInWriter.WriteLine("n"); // Don't select free tier which forces t3.micro to be used instead of t2.micro
+                        interactiveService.StdInWriter.WriteLine("y"); // select free tier which includes t3.micro
                         interactiveService.StdInWriter.WriteLine("1"); // Select "x86_64"
                         interactiveService.StdInWriter.WriteLine("1"); // Select "CPU Cores"
                         interactiveService.StdInWriter.WriteLine("1"); // Select "Instance Memory"


### PR DESCRIPTION
*Issue #, if available:* Update tests to use t3.micro free tier


it looks like there was a recent change where t3.micro is free tier now. so this updates the test to select "yes" for free tier so that t3.micro is used ( i couldnt find any news/docs on this change though so maybe im missing something)

below is query result i got when doing describe instances in us-west-2

```
InstanceType FreeTierEligible Architecture CPU Cores Memory (MiB)
------------ ---------------- ------------ --------- ------------
t2.2xlarge              False x86_64               8        32768
t3.xlarge               False x86_64               2        16384
t3.2xlarge              False x86_64               4        32768
t2.large                False x86_64               2         8192
t3.medium               False x86_64               1         4096
t3.large                False x86_64               1         8192
t2.micro                False i386, x86_64         1         1024
t3.micro                 True x86_64               1         1024
t3.nano                 False x86_64               1          512
t2.medium               False i386, x86_64         2         4096
t2.small                False i386, x86_64         1         2048
t3.small                 True x86_64               1         2048
t2.xlarge               False x86_64               4        16384
t2.nano                 False i386, x86_64         1          512
```

*Description of changes:*
1. use t3 micro.

* testing*
im not able to test in my personal isengard account because my account still shows t2.nano as free tier (idk why)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
