### PR TITLE
fix: add --load flag to docker buildx build

### DIFF
--- a/.autover/changes/aeb80c58-0a88-4bcb-9fc4-c23c4045e6ec.json
+++ b/.autover/changes/aeb80c58-0a88-4bcb-9fc4-c23c4045e6ec.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add the --load flag in docker buildx build because, unlike the standard docker build command, buildx doesn't automatically load the resulting image into the local Docker image store. When using buildx with certain docker drivers (like docker-container), the build process happens in a container, and the resulting image needs to be explicitly loaded into the local image store using --load."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
+++ b/src/AWS.Deploy.Orchestration/DeploymentBundleHandler.cs
@@ -66,7 +66,7 @@ namespace AWS.Deploy.Orchestration
             if (currentArchitecture != recommendation.DeploymentBundle.EnvironmentArchitecture)
             {
                 var platform = recommendation.DeploymentBundle.EnvironmentArchitecture == SupportedArchitecture.Arm64 ? "linux/arm64" : "linux/amd64";
-                buildCommand = $"{commandName} buildx build --platform {platform} -t {imageTag} -f \"{dockerFile}\"{buildArgs} .";
+                buildCommand = $"{commandName} buildx build --load --platform {platform} -t {imageTag} -f \"{dockerFile}\"{buildArgs} .";
             }
 
             interactiveService.LogInfoMessage($"Container Execution Directory: {Path.GetFullPath(containerExecutionDirectory)}");

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -98,7 +98,7 @@ namespace AWS.Deploy.CLI.UnitTests
             }
             else
             {
-                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{dockerFilePath}\" .",
+                Assert.Equal($"docker buildx build --load --platform linux/amd64 -t {imageTag} -f \"{dockerFilePath}\" .",
                     _commandLineWrapper.CommandsToExecute.First().Command);
             }
         }
@@ -129,7 +129,7 @@ namespace AWS.Deploy.CLI.UnitTests
             else
             {
                 var dockerPlatform = recommendation.DeploymentBundle.EnvironmentArchitecture == SupportedArchitecture.Arm64 ? "linux/arm64" : "linux/amd64";
-                Assert.Equal($"docker buildx build --platform {dockerPlatform} -t {imageTag} -f \"{dockerFilePath}\" .",
+                Assert.Equal($"docker buildx build --load --platform {dockerPlatform} -t {imageTag} -f \"{dockerFilePath}\" .",
                     _commandLineWrapper.CommandsToExecute.First().Command);
             }
         }
@@ -159,7 +159,7 @@ namespace AWS.Deploy.CLI.UnitTests
             }
             else
             {
-                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{expectedDockerFile}\" .",
+                Assert.Equal($"docker buildx build --load --platform linux/amd64 -t {imageTag} -f \"{expectedDockerFile}\" .",
                     _commandLineWrapper.CommandsToExecute.First().Command);
             }
             Assert.Equal(dockerExecutionDirectory.FullName,
@@ -192,7 +192,7 @@ namespace AWS.Deploy.CLI.UnitTests
             }
             else
             {
-                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{expectedDockerFile}\" .",
+                Assert.Equal($"docker buildx build --load --platform linux/amd64 -t {imageTag} -f \"{expectedDockerFile}\" .",
                     _commandLineWrapper.CommandsToExecute.First().Command);
             }
             Assert.Equal(projectPath,
@@ -228,7 +228,7 @@ namespace AWS.Deploy.CLI.UnitTests
             }
             else
             {
-                Assert.Equal($"docker buildx build --platform linux/amd64 -t {imageTag} -f \"{dockerfilePath}\" .",
+                Assert.Equal($"docker buildx build --load --platform linux/amd64 -t {imageTag} -f \"{dockerfilePath}\" .",
                     _commandLineWrapper.CommandsToExecute.First().Command);
             }
             Assert.Equal(expectedDockerExecutionDirectory.FullName,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-toolkit-visual-studio/issues/521

*Description of changes:*
Add the `--load` flag in `docker buildx build` because, unlike the standard `docker build` command, `buildx` doesn't automatically load the resulting image into the local Docker image store. When using `buildx` with certain docker drivers (like `docker-container`), the build process happens in a container, and the resulting image needs to be explicitly loaded into the local image store using `--load`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
