### PR TITLE
fix: add .NET 10 to the doc builder workflow

### DIFF
--- a/.github/workflows/doc-builder.yml
+++ b/.github/workflows/doc-builder.yml
@@ -26,10 +26,10 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: 3.x
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 #v4.3.1
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - run: pip install mkdocs-material==8.2.9
       - run: pip install mkdocs-awesome-pages-plugin==2.8.0
       - name: Restore dependencies


### PR DESCRIPTION
*Description of changes:*
Add .NET 10 to the doc builder workflow since it has been failing ever since we added .NET 10 to the deploy tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
