### PR TITLE
chore: revert Microsoft.AspNetCore.SignalR.Client to 8.0.0

### DIFF
--- a/.autover/changes/cf3c8ee9-f2ea-472b-9b87-5c060fb09a5f.json
+++ b/.autover/changes/cf3c8ee9-f2ea-472b-9b87-5c060fb09a5f.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.ServerMode.Client",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Revert Microsoft.AspNetCore.SignalR.Client to 8.0.0 down from 8.0.15 to maintain support for older Visual Studio versions. Visual Studio 17.13 and older support up to 8.0.0."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
+++ b/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
@@ -17,7 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="4.0.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
+    <!-- We are pining Microsoft.AspNetCore.SignalR.Client to 8.0.0 to support VS versions prior to 17.14.
+    Currently, versions above 8.0.0 are only supported in VS 17.14 -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     <!-- We are pining Newtonsoft.Json to 13.0.1 to maintain compatibility with the VS Toolkit.
     https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/AWS.Deploy.CLI.Common.UnitTests.csproj
@@ -25,12 +25,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
 
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
+++ b/test/AWS.Deploy.CLI.UnitTests/AWS.Deploy.CLI.UnitTests.csproj
@@ -27,12 +27,12 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
 
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/AWS.Deploy.DocGenerator.UnitTests/AWS.Deploy.DocGenerator.UnitTests.csproj
+++ b/test/AWS.Deploy.DocGenerator.UnitTests/AWS.Deploy.DocGenerator.UnitTests.csproj
@@ -28,12 +28,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
+++ b/test/AWS.Deploy.Orchestration.UnitTests/AWS.Deploy.Orchestration.UnitTests.csproj
@@ -15,12 +15,12 @@
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
       <PackageReference Include="Moq" Version="4.16.1" />
 
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PackageReference Include="coverlet.collector" Version="6.0.4">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
 
-      <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PackageReference Include="coverlet.msbuild" Version="6.0.4">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
+++ b/test/AWS.Deploy.ServerMode.Client.UnitTests/AWS.Deploy.ServerMode.Client.UnitTests.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
 
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/testapps/WebAppNet8WithCustomDockerFile/WebAppNet8WithCustomDockerFile.csproj
+++ b/testapps/WebAppNet8WithCustomDockerFile/WebAppNet8WithCustomDockerFile.csproj
@@ -8,8 +8,4 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
-  </ItemGroup>
-
 </Project>

--- a/testapps/WebAppWithDockerFile/WebAppWithDockerFile.csproj
+++ b/testapps/WebAppWithDockerFile/WebAppWithDockerFile.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Update="AppRunnerConfigFile.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/testapps/docker/ConsoleSdkType/ConsoleSdkType.csproj
+++ b/testapps/docker/ConsoleSdkType/ConsoleSdkType.csproj
@@ -7,8 +7,4 @@
     <DockerfileContext>.</DockerfileContext>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
 </Project>

--- a/testapps/docker/WebAppDifferentAssemblyName/WebAppDifferentAssemblyName.csproj
+++ b/testapps/docker/WebAppDifferentAssemblyName/WebAppDifferentAssemblyName.csproj
@@ -8,8 +8,4 @@
     <DockerfileContext>.</DockerfileContext>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
 </Project>

--- a/testapps/docker/WebAppNoSolution/WebAppNoSolution.csproj
+++ b/testapps/docker/WebAppNoSolution/WebAppNoSolution.csproj
@@ -7,8 +7,4 @@
     <DockerfileContext>.</DockerfileContext>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
 </Project>

--- a/testapps/docker/WebAppProjectDependencies/WebAppProjectDependencies/WebAppProjectDependencies.csproj
+++ b/testapps/docker/WebAppProjectDependencies/WebAppProjectDependencies/WebAppProjectDependencies.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\WebAppProjectDependenciesLibrary\WebAppProjectDependenciesLibrary.csproj" />
   </ItemGroup>
 

--- a/testapps/docker/WebAppProjectDependenciesAboveSolution/WebAppProjectDependencies/WebAppProjectDependencies.csproj
+++ b/testapps/docker/WebAppProjectDependenciesAboveSolution/WebAppProjectDependencies/WebAppProjectDependencies.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\WebAppProjectDependenciesLibrary\WebAppProjectDependenciesLibrary.csproj" />
   </ItemGroup>
 

--- a/testapps/docker/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel.csproj
+++ b/testapps/docker/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel/WebAppWithSolutionParentLevel.csproj
@@ -6,8 +6,4 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
 </Project>

--- a/testapps/docker/WebAppWithSolutionSameLevel/WebAppWithSolutionSameLevel.csproj
+++ b/testapps/docker/WebAppWithSolutionSameLevel/WebAppWithSolutionSameLevel.csproj
@@ -7,8 +7,4 @@
     <DockerfileContext>.</DockerfileContext>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
*Description of changes:*
* Revert `Microsoft.AspNetCore.SignalR.Client` to 8.0.0 down from 8.0.15 to maintain support for older Visual Studio versions. Visual Studio 17.13 and older support up to 8.0.0.
* Update `coverlet.collector` to the latest version since the one we are using has a vulnerability.
* Remove `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` from Test Apps since it is not used and it has a vulnerability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
