### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -2,6 +2,9 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
+permissions:
+  issues: write
+
 jobs:
     auto_comment:
         runs-on: ubuntu-latest

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '23 20 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     name: Scan

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -5,6 +5,10 @@ on:
   schedule:
   - cron: "0 0/3 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   cleanup:
     name: Stale issue job


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.