### PR TITLE
Bump AWSSDK.Core from 4.0.0.26 to 4.0.3.3

### DIFF
--- a/.autover/changes/61a3e8e4-f338-451b-ac86-61f1bb2c9c46.json
+++ b/.autover/changes/61a3e8e4-f338-451b-ac86-61f1bb2c9c46.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.ServerMode.Client",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Bumped AWSSDK.Core version to 4.0.3.3"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
+++ b/src/AWS.Deploy.ServerMode.Client/AWS.Deploy.ServerMode.Client.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="4.0.0.2" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.3" />
     <!-- We are pining Microsoft.AspNetCore.SignalR.Client to 8.0.0 to support VS versions prior to 17.14.
     Currently, versions above 8.0.0 are only supported in VS 17.14 -->
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />


### PR DESCRIPTION
Bumping `AWSSDK.Core` from 4.0.0.26 to 4.0.3.3. 
Recreated this PR as it had unwanted commits - https://github.com/aws/aws-dotnet-deploy/pull/994
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
