### PR TITLE
Improve error display when there are invalid command line parameters

### DIFF
--- a/.autover/changes/36545244-0ca6-4153-ae65-68ff655b5caf.json
+++ b/.autover/changes/36545244-0ca6-4153-ae65-68ff655b5caf.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Improve error display when there are invalid command line parameters"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.CLI/App.cs
+++ b/src/AWS.Deploy.CLI/App.cs
@@ -61,6 +61,11 @@ public class App
                     // bail out with an non-zero return code.
                     return CommandReturnCodes.USER_ERROR;
                 }
+                else if (exception is CommandParseException parseException)
+                {
+                    toolInteractiveService.WriteErrorLine(parseException.Message);
+                    return CommandReturnCodes.USER_ERROR;
+                }
                 else
                 {
                     // This is a bug


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-deploy/issues/1001

*Description of changes:*
Improve the error output to avoid dumping a stacktrace if there is a user error of an invalid command line parameter.

Before
```
> dotnet run -- help
Using launch settings from C:\codebase\aws-dotnet-deploy\src\AWS.Deploy.CLI\Properties\launchSettings.json...
AWS .NET deployment tool for deploying .NET Core applications to AWS.
Project Home: https://github.com/aws/aws-dotnet-deploy

Unhandled exception.  This is a bug.  Please copy the stack trace below and file a bug at https://github.com/aws/aws-dotnet-deploy.
Unknown command 'help'.
   at Spectre.Console.Cli.CommandTreeParser.ParseString(CommandTreeParserContext context, CommandTreeTokenStream stream, CommandTree node) in /_/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs:line 209
   at Spectre.Console.Cli.CommandTreeParser.ParseCommandParameters(CommandTreeParserContext context, CommandInfo command, CommandTree parent, CommandTreeTokenStream stream) in /_/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs:line 157
   at Spectre.Console.Cli.CommandTreeParser.Parse(CommandTreeParserContext context, CommandTreeTokenizerResult tokenizerResult) in /_/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs:line 82
   at Spectre.Console.Cli.CommandExecutor.InternalParseCommandLineArguments(CommandModel model, CommandAppSettings settings, IReadOnlyList`1 args) in /_/src/Spectre.Console.Cli/Internal/CommandExecutor.cs:line 213
   at Spectre.Console.Cli.CommandExecutor.ParseCommandLineArguments(CommandModel model, CommandAppSettings settings, IReadOnlyList`1 args) in /_/src/Spectre.Console.Cli/Internal/CommandExecutor.cs:line 133
   at Spectre.Console.Cli.CommandExecutor.Execute(IConfiguration configuration, IEnumerable`1 args) in /_/src/Spectre.Console.Cli/Internal/CommandExecutor.cs:line 74
   at Spectre.Console.Cli.CommandApp.RunAsync(IEnumerable`1 args) in /_/src/Spectre.Console.Cli/CommandApp.cs:line 87

```

After
```
> dotnet run -- help
Using launch settings from C:\codebase\aws-dotnet-deploy\src\AWS.Deploy.CLI\Properties\launchSettings.json...
AWS .NET deployment tool for deploying .NET Core applications to AWS.
Project Home: https://github.com/aws/aws-dotnet-deploy

Unknown command 'help'.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
