### PR TITLE
Add AWSSDK.Signin dependency to resolve 'aws login' credentials

### DIFF
--- a/.autover/changes/820ce536-653c-4f85-ba25-38489fd67ff2.json
+++ b/.autover/changes/820ce536-653c-4f85-ba25-38489fd67ff2.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added AWSSDK.Signin dependency to resolve AWS credentials when authenticated using the AWS CLI v2 'aws login' SSO flow"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/86fe5d64-aa64-4878-8325-76885b519fe8.json
+++ b/.autover/changes/86fe5d64-aa64-4878-8325-76885b519fe8.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update CDK Bootstrap template to version 32"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
+++ b/src/AWS.Deploy.CLI/AWS.Deploy.CLI.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.10" />
     <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.11" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
+    <PackageReference Include="AWSSDK.Signin" Version="4.0.1.1" />
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.16" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.17" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
+++ b/src/AWS.Deploy.Orchestration/CDK/CDKBootstrapTemplate.yaml
@@ -593,14 +593,11 @@ Resources:
       Policies:
         - PolicyDocument:
             Statement:
-              - Sid: CloudFormationPermissions
+              - Sid: DeployPermissions
                 Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
-                  - cloudformation:DescribeChangeSet
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeEvents
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:CreateStack
                   - cloudformation:UpdateStack
@@ -640,13 +637,9 @@ Resources:
                 Effect: Allow
               - Sid: CliPermissions
                 Action:
-                  - cloudformation:DescribeStackEvents
-                  - cloudformation:GetTemplate
                   - cloudformation:DeleteStack
                   - cloudformation:UpdateTerminationProtection
                   - sts:GetCallerIdentity
-                  - cloudformation:GetTemplateSummary
-                  - cloudformation:GetHookResult
                 Resource: "*"
                 Effect: Allow
               - Sid: CliStagingBucket
@@ -669,14 +662,12 @@ Resources:
                 Effect: Allow
                 Action:
                   - cloudformation:CreateStackRefactor
-                  - cloudformation:DescribeStackRefactor
                   - cloudformation:ExecuteStackRefactor
-                  - cloudformation:ListStackRefactorActions
-                  - cloudformation:ListStackRefactors
-                  - cloudformation:ListStacks
                 Resource: "*"
             Version: "2012-10-17"
           PolicyName: default
+      ManagedPolicyArns:
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AWSCloudFormationReadOnlyAccess
       RoleName:
         Fn::Sub: cdk-${Qualifier}-deploy-role-${AWS::AccountId}-${AWS::Region}
       Tags:
@@ -756,7 +747,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: /cdk-bootstrap/${Qualifier}/version
-      Value: "31"
+      Value: "32"
 Outputs:
   BucketName:
     Description: The name of the S3 bucket owned by the CDK toolkit stack
@@ -782,4 +773,4 @@ Outputs:
       Fn::Sub: ${ContainerAssetsRepository}
   BootstrapVersion:
     Description: The version of the bootstrap resources that are currently mastered in this stack
-    Value: "31"
+    Value: "32"

--- a/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ConfigFileDeployment/ElasticBeanStalkDeploymentTest.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ConfigFileDeployment
 {
+    [Collection(nameof(ElasticBeanstalkTestCollection))]
     public class ElasticBeanStalkDeploymentTest : IDisposable
     {
         private readonly IServiceCollection _serviceCollection;

--- a/test/AWS.Deploy.CLI.IntegrationTests/ElasticBeanstalkTestCollection.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ElasticBeanstalkTestCollection.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace AWS.Deploy.CLI.IntegrationTests
+{
+    // Serializes web app deploy/session tests so parallel runs don't throttle Elastic Beanstalk APIs.
+    [CollectionDefinition(nameof(ElasticBeanstalkTestCollection), DisableParallelization = true)]
+    public class ElasticBeanstalkTestCollection
+    {
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/DependencyValidationOptionSettings.cs
@@ -22,6 +22,7 @@ using Xunit;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 {
+    [Collection(nameof(ElasticBeanstalkTestCollection))]
     public class DependencyValidationOptionSettings : IDisposable
     {
         private bool _isDisposed;

--- a/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/ServerMode/GetApplyOptionSettings.cs
@@ -30,6 +30,7 @@ using AWS.Deploy.ServerMode.Client.Utilities;
 
 namespace AWS.Deploy.CLI.IntegrationTests.ServerMode
 {
+    [Collection(nameof(ElasticBeanstalkTestCollection))]
     public class GetApplyOptionSettings : IDisposable
     {
         private bool _isDisposed;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-dotnet-deploy/issues/1010

*Description of changes:* Adds the `AWSSDK.Signin` package so that the deploy tool can resolve credentials created via `aws login`. Approach here is similar to https://github.com/aws/aws-lambda-dotnet/pull/2391 but I only included the one package (I wasn't sure if other projects such as `AWS.Deploy.Common` and `AWS.Deploy.Orchestration` needed to be changed too)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
