### PR TITLE
feat: deploy to AgentCore Runtime

### DIFF
--- a/.autover/changes/209b8aef-fe24-4a69-a360-aa93a58a5173.json
+++ b/.autover/changes/209b8aef-fe24-4a69-a360-aa93a58a5173.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "AWS.Deploy.CLI",
-      "Type": "Patch",
+      "Type": "Minor",
       "ChangelogMessages": [
         "Add support for deploying .NET AI Agents built with AWS.AgentCore.Hosting to Amazon Bedrock AgentCore runtime"
       ]

--- a/.autover/changes/209b8aef-fe24-4a69-a360-aa93a58a5173.json
+++ b/.autover/changes/209b8aef-fe24-4a69-a360-aa93a58a5173.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add support for deploying .NET AI Agents built with AWS.AgentCore.Hosting to Amazon Bedrock AgentCore runtime"
+      ]
+    }
+  ]
+}

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -21,7 +21,7 @@
 ** AWSSDK.ElasticLoadBalancingV2; version 3.7.302.33 -- https://www.nuget.org/packages/AWSSDK.ElasticLoadBalancingV2/
 ** AWSSDK.Core; version 3.7.303.20 -- https://www.nuget.org/packages/AWSSDK.Core
 ** AWSSDK.CloudWatchLogs; version 3.7.305.18 -- https://www.nuget.org/packages/AWSSDK.CloudWatchLogs
-** Amazon.CDK.Lib; version 2.231.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
+** Amazon.CDK.Lib; version 2.260.0 -- https://www.nuget.org/packages/Amazon.CDK.Lib/
  
 Apache License
 Version 2.0, January 2004

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon Bedrock AgentCore Runtime (Experimental).md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon Bedrock AgentCore Runtime (Experimental).md
@@ -1,0 +1,64 @@
+**Recipe ID:** AspNetAppBedrockAgentCore
+
+**Recipe Description:** [Experimental] This ASP.NET Core application will be built as a container image and deployed to Amazon Bedrock AgentCore Runtime, a fully managed service for hosting AI agent applications. The recipe provisions an AgentCore Runtime to run your agent and the required IAM roles. If your project does not contain a Dockerfile, it will be automatically generated. Recommended for ASP.NET Core projects that reference AWS.AgentCore.Hosting.
+
+**Settings:**
+
+* **Runtime Name**
+    * ID: RuntimeName
+    * Description: The name of the Bedrock AgentCore Runtime.
+    * Type: String
+* **Request Headers**
+    * ID: RequestHeaders
+    * Description: HTTP request header names to pass through to the agent container. Headers not in this list are stripped by the AgentCore Runtime.
+    * Type: List
+* **AgentCore Memory**
+    * ID: AgentCoreMemory
+    * Description: Configure AgentCore Memory for persistent conversation history. When enabled, a Memory resource is provisioned and wired to the agent via the AWS_AGENTCORE_MEMORY_ID environment variable.
+    * Type: Object
+    * Settings:
+        * **Create New Memory**
+            * ID: CreateNew
+            * Description: Do you want to create a new AgentCore Memory resource?
+            * Type: Bool
+        * **Existing Memory ID**
+            * ID: MemoryId
+            * Description: The ID of an existing AgentCore Memory resource to use. The agent will read/write conversation history to this memory.
+            * Type: String
+* **Runtime IAM Role**
+    * ID: RuntimeIAMRole
+    * Description: The Identity and Access Management (IAM) role that provides AWS credentials to the AgentCore Runtime. When creating a new role, it includes permissions for ECR pull, CloudWatch Logs, Bedrock model invocation (cross-region), and AgentCore Memory access.
+    * Type: Object
+    * Settings:
+        * **Create New Role**
+            * ID: CreateNew
+            * Description: Do you want to create a new role?
+            * Type: Bool
+        * **Existing Role ARN**
+            * ID: RoleArn
+            * Description: The ARN of the existing IAM role to use for the AgentCore Runtime.
+            * Type: String
+* **Environment Variables**
+    * ID: AgentCoreEnvironmentVariables
+    * Description: Configure environment variables that will be set for the AgentCore Runtime container.
+    * Type: KeyValue
+* **Environment Architecture**
+    * ID: EnvironmentArchitecture
+    * Description: The CPU architecture of the environment to create.
+    * Type: String
+* **Docker Build Args**
+    * ID: DockerBuildArgs
+    * Description: The list of additional options to append to the `docker build` command.
+    * Type: String
+* **Dockerfile Path**
+    * ID: DockerfilePath
+    * Description: Specify a path to a Dockerfile as either an absolute path or a path relative to the project.
+    * Type: String
+* **Docker Execution Directory**
+    * ID: DockerExecutionDirectory
+    * Description: Specifies the docker execution directory where the docker build command will be executed from.
+    * Type: String
+* **ECR Repository Name**
+    * ID: ECRRepositoryName
+    * Description: Specifies the ECR repository where the Docker images will be stored
+    * Type: String

--- a/site/content/docs/getting-started/pre-requisites.md
+++ b/site/content/docs/getting-started/pre-requisites.md
@@ -34,7 +34,7 @@ node --version
 
    > ***Note:***
 
->*If the AWS CDK isn't installed on your machine or if the AWS CDK that's installed is earlier than the required minimum version (2.13.0), the deployment tool will install a **temporary and "private" copy of the CDK** that will be used only by the tool, leaving the global configuration of your machine untouched.*
+>*If the AWS CDK isn't installed on your machine or if the AWS CDK that's installed is earlier than the required minimum version (2.1128.0), the deployment tool will install a **temporary and "private" copy of the CDK** that will be used only by the tool, leaving the global configuration of your machine untouched.*
 
 >*If instead you want to install the AWS CDK, see [Install the AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_install) in the [AWS Cloud Development Kit (CDK) Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/)*
 

--- a/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
+++ b/src/AWS.Deploy.CLI/ServerMode/Services/SessionAWSResourceQuery.cs
@@ -136,6 +136,12 @@ namespace AWS.Deploy.CLI.ServerMode.Services
         }
 
         /// <inheritdoc/>
+        public async Task<Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse> DescribeBedrockAgentCoreRuntime(string runtimeId)
+        {
+            return (await GetAndCache(async () => await _awsResourceQueryer.DescribeBedrockAgentCoreRuntime(runtimeId), new object[] { runtimeId }))!;
+        }
+
+        /// <inheritdoc/>
         public async Task<List<VpcConnector>> DescribeAppRunnerVpcConnectors()
         {
             return (await GetAndCache(async () => await _awsResourceQueryer.DescribeAppRunnerVpcConnectors()))!;

--- a/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
+++ b/src/AWS.Deploy.Common/AWS.Deploy.Common.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.25" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.12" />
     <PackageReference Include="AWSSDK.AppRunner" Version="4.0.2.18" />
+    <PackageReference Include="AWSSDK.BedrockAgentCoreControl" Version="4.0.43.2" />
     <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.11" />
     <PackageReference Include="AWSSDK.CloudFront" Version="4.0.12.3" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.15.2" />

--- a/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Common/Data/IAWSResourceQueryer.cs
@@ -56,6 +56,12 @@ namespace AWS.Deploy.Common.Data
         Task<InstanceTypeInfo?> DescribeInstanceType(string instanceType);
 
         Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn);
+
+        /// <summary>
+        /// Gets the details of an Amazon Bedrock AgentCore Runtime by runtime ID.
+        /// </summary>
+        Task<Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse> DescribeBedrockAgentCoreRuntime(string runtimeId);
+
         Task<List<StackResource>> DescribeCloudFormationResources(string stackName);
 
         /// <summary>
@@ -88,7 +94,7 @@ namespace AWS.Deploy.Common.Data
         Task<List<Vpc>> GetListOfVpcs();
         Task<List<PlatformSummary>> GetElasticBeanstalkPlatformArns(string? targetFramework, params BeanstalkPlatformType[]? platformTypes);
         Task<PlatformSummary> GetLatestElasticBeanstalkPlatformArn(string? targetFramework, BeanstalkPlatformType platformType);
-        Task<List<AuthorizationData>> GetECRAuthorizationToken();
+        Task<List<Amazon.ECR.Model.AuthorizationData>> GetECRAuthorizationToken();
         Task<List<Repository>> GetECRRepositories(List<string>? repositoryNames = null);
 
         /// <summary>

--- a/src/AWS.Deploy.Common/Exceptions.cs
+++ b/src/AWS.Deploy.Common/Exceptions.cs
@@ -128,7 +128,8 @@ namespace AWS.Deploy.Common
         FailedToSaveDeploymentSettings = 10010600,
         InvalidWindowsManifestFile = 10010700,
         UserDeploymentFileNotFound = 10010800,
-        ContainerInspectFailed = 10004200
+        ContainerInspectFailed = 10004200,
+        BedrockAgentCoreRuntimeDoesNotExist = 10010900
     }
 
     public class ProjectFileNotFoundException : DeployToolException

--- a/src/AWS.Deploy.Constants/CDK.cs
+++ b/src/AWS.Deploy.Constants/CDK.cs
@@ -10,7 +10,7 @@ namespace AWS.Deploy.Constants
         /// <summary>
         /// Default version of CDK CLI
         /// </summary>
-        public static readonly Version DefaultCDKVersion = Version.Parse("2.1033.0");
+        public static readonly Version DefaultCDKVersion = Version.Parse("2.1128.0");
 
         /// <summary>
         /// The name of the CDK bootstrap CloudFormation stack

--- a/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
+++ b/src/AWS.Deploy.Orchestration/AWS.Deploy.Orchestration.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.8.11" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.19" />
     <PackageReference Include="AWSSDK.AppRunner" Version="4.0.2.18" />
+    <PackageReference Include="AWSSDK.BedrockAgentCoreControl" Version="4.0.43.2" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="4.0.7.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="8.0.408" />

--- a/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
+++ b/src/AWS.Deploy.Orchestration/Data/AWSResourceQueryer.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.AppRunner.Model;
+using Amazon.BedrockAgentCoreControl;
 using Amazon.CloudControlApi;
 using Amazon.CloudControlApi.Model;
 using Amazon.CloudFormation;
@@ -243,6 +244,32 @@ namespace AWS.Deploy.Orchestration.Data
                 return service;
             },
             $"Error attempting to describe App Runner service '{serviceArn}'");
+        }
+
+        public async Task<Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse> DescribeBedrockAgentCoreRuntime(string runtimeId)
+        {
+            var agentCoreClient = awsClientFactory.GetAWSClient<IAmazonBedrockAgentCoreControl>();
+
+            return await HandleException(async () =>
+            {
+                Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse response;
+                try
+                {
+                    response = await agentCoreClient.GetAgentRuntimeAsync(new Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeRequest
+                    {
+                        AgentRuntimeId = runtimeId
+                    });
+                }
+                catch (Amazon.BedrockAgentCoreControl.Model.ResourceNotFoundException)
+                {
+                    throw new AWSResourceNotFoundException(
+                        DeployToolErrorCode.BedrockAgentCoreRuntimeDoesNotExist,
+                        $"The Bedrock AgentCore runtime '{runtimeId}' does not exist.");
+                }
+
+                return response;
+            },
+            $"Error attempting to describe Bedrock AgentCore runtime '{runtimeId}'");
         }
 
         public async Task<List<StackResource>> DescribeCloudFormationResources(string stackName)
@@ -805,7 +832,7 @@ namespace AWS.Deploy.Orchestration.Data
             });
         }
 
-        public async Task<List<AuthorizationData>> GetECRAuthorizationToken()
+        public async Task<List<Amazon.ECR.Model.AuthorizationData>> GetECRAuthorizationToken()
         {
             var ecrClient = awsClientFactory.GetAWSClient<IAmazonECR>();
 

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/BedrockAgentCoreRuntimeResource.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/BedrockAgentCoreRuntimeResource.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Deploy.Common.Data;
+
+namespace AWS.Deploy.Orchestration.DisplayedResources
+{
+    public class BedrockAgentCoreRuntimeResource : IDisplayedResourceCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+
+        public BedrockAgentCoreRuntimeResource(IAWSResourceQueryer awsResourceQueryer)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+        }
+
+        public async Task<Dictionary<string, string>> Execute(string resourceId)
+        {
+            var runtime = await _awsResourceQueryer.DescribeBedrockAgentCoreRuntime(resourceId);
+
+            return new Dictionary<string, string>
+            {
+                { "ARN", runtime.AgentRuntimeArn }
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourceCommandFactory.cs
+++ b/src/AWS.Deploy.Orchestration/DisplayedResources/DisplayedResourceCommandFactory.cs
@@ -27,6 +27,7 @@ namespace AWS.Deploy.Orchestration.DisplayedResources
     public class DisplayedResourceCommandFactory : IDisplayedResourceCommandFactory
     {
         private const string RESOURCE_TYPE_APPRUNNER_SERVICE = "AWS::AppRunner::Service";
+        private const string RESOURCE_TYPE_BEDROCK_AGENTCORE_RUNTIME = "AWS::BedrockAgentCore::Runtime";
         private const string RESOURCE_TYPE_ELASTICBEANSTALK_ENVIRONMENT = "AWS::ElasticBeanstalk::Environment";
         private const string RESOURCE_TYPE_ELASTICLOADBALANCINGV2_LOADBALANCER = "AWS::ElasticLoadBalancingV2::LoadBalancer";
         private const string RESOURCE_TYPE_S3_BUCKET = "AWS::S3::Bucket";
@@ -40,6 +41,7 @@ namespace AWS.Deploy.Orchestration.DisplayedResources
             _resources = new Dictionary<string, IDisplayedResourceCommand>
             {
                 { RESOURCE_TYPE_APPRUNNER_SERVICE, new AppRunnerServiceResource(awsResourceQueryer) },
+                { RESOURCE_TYPE_BEDROCK_AGENTCORE_RUNTIME, new BedrockAgentCoreRuntimeResource(awsResourceQueryer) },
                 { RESOURCE_TYPE_ELASTICBEANSTALK_ENVIRONMENT, new ElasticBeanstalkEnvironmentResource(awsResourceQueryer) },
                 { RESOURCE_TYPE_ELASTICLOADBALANCINGV2_LOADBALANCER, new ElasticLoadBalancerResource(awsResourceQueryer) },
                 { RESOURCE_TYPE_S3_BUCKET, new S3BucketResource(awsResourceQueryer) },

--- a/src/AWS.Deploy.Orchestration/Orchestrator.cs
+++ b/src/AWS.Deploy.Orchestration/Orchestrator.cs
@@ -251,7 +251,14 @@ namespace AWS.Deploy.Orchestration
             }
             if (recommendation.ReplacementTokens.ContainsKey(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE))
             {
-                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, Constants.Recipe.DefaultSupportedArchitecture);
+                // Use the recipe's only supported architecture when the recipe constrains to one;
+                // otherwise fall back to the global default (X86_64).
+                var defaultArch = recommendation.Recipe.SupportedArchitectures is { Count: 1 }
+                    ? recommendation.Recipe.SupportedArchitectures[0].ToString()
+                    : Constants.Recipe.DefaultSupportedArchitecture;
+
+                recommendation.AddReplacementToken(Constants.RecipeIdentifier.REPLACE_TOKEN_DEFAULT_ENVIRONMENT_ARCHITECTURE, defaultArch);
+                recommendation.DeploymentBundle.EnvironmentArchitecture = Enum.Parse<SupportedArchitecture>(defaultArch);
             }
         }
 

--- a/src/AWS.Deploy.Orchestration/Properties/DockerFileConfig.json
+++ b/src/AWS.Deploy.Orchestration/Properties/DockerFileConfig.json
@@ -4,8 +4,8 @@
         "ImageMapping": [
             {
                 "TargetFramework": "net10.0",
-                "BaseImage": "mcr.microsoft.com/dotnet/aspnet:10.0-preview",
-                "BuildImage": "mcr.microsoft.com/dotnet/sdk:10.0-preview"
+                "BaseImage": "mcr.microsoft.com/dotnet/aspnet:10.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:10.0"
             },
             {
                 "TargetFramework": "net9.0",
@@ -44,8 +44,8 @@
         "ImageMapping": [
             {
                 "TargetFramework": "net10.0",
-                "BaseImage": "mcr.microsoft.com/dotnet/runtime:10.0-preview",
-                "BuildImage": "mcr.microsoft.com/dotnet/sdk:10.0-preview"
+                "BaseImage": "mcr.microsoft.com/dotnet/runtime:10.0",
+                "BuildImage": "mcr.microsoft.com/dotnet/sdk:10.0"
             },
             {
                 "TargetFramework": "net9.0",

--- a/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
+++ b/src/AWS.Deploy.Recipes.CDK.Common/AWS.Deploy.Recipes.CDK.Common.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
   </ItemGroup>
 

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppAppRunner/AspNetAppAppRunner.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/.template.config/template.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "AWS",
+    "classifications": ["AWS", ".NET Deployment Tool"],
+    "name": "ASP.NET Core Template CDK Project for Amazon Bedrock AgentCore",
+    "identity": "AWS.Deploy.Recipes.AspNetAppBedrockAgentCore",
+    "shortName": "netdeploy.AspNetAppBedrockAgentCore",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "AspNetAppBedrockAgentCore",
+    "preferNameDirectory": true,
+    "symbols": {
+        "AWSDeployRecipesCDKCommonVersion": {
+            "type": "parameter",
+            "description": "The version number of AWS.Deploy.Recipes.CDK.Common to use",
+            "replaces": "AWSDeployRecipesCDKCommonVersion",
+            "datatype": "string"
+        }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/AppStack.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/AppStack.cs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CDK;
+using Amazon.CDK.AWS.IAM;
+using AWS.Deploy.Recipes.CDK.Common;
+using AspNetAppBedrockAgentCore.Configurations;
+using Constructs;
+
+namespace AspNetAppBedrockAgentCore
+{
+    public class AppStack : Stack
+    {
+        private readonly Configuration _configuration;
+
+        internal AppStack(Construct scope, IDeployToolStackProps<Configuration> props)
+            : base(scope, props.StackName, props)
+        {
+            _configuration = props.RecipeProps.Settings;
+
+            // Setup callback for generated construct to provide access to customize CDK properties before creating constructs.
+            CDKRecipeCustomizer<Recipe>.CustomizeCDKProps += CustomizeCDKProps;
+
+            // Create custom CDK constructs here that might need to be referenced in the CustomizeCDKProps.
+
+            // Create the recipe defined CDK construct with all of its sub constructs.
+            var generatedRecipe = new Recipe(this, props.RecipeProps);
+
+            // Create additional CDK constructs here. The recipe's constructs can be accessed as properties on
+            // the generatedRecipe variable.
+        }
+
+        /// <summary>
+        /// This method can be used to customize the properties for any CDK construct being created by the
+        /// Recipe's Generated/Recipe.cs construct. It is invoked before each resource is created, giving
+        /// you a chance to modify the construct properties.
+        /// </summary>
+        private void CustomizeCDKProps(CustomizePropsEventArgs<Recipe> evnt)
+        {
+            // Example of how to customize the AgentCore Runtime role to add additional policies.
+            //if (string.Equals(evnt.ResourceLogicalName, nameof(evnt.Construct.RuntimeRole)))
+            //{
+            //    if (evnt.Props is RoleProps props)
+            //    {
+            //        Console.WriteLine("Customizing AgentCore Runtime Role");
+            //    }
+            //}
+        }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/AspNetAppBedrockAgentCore.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/AspNetAppBedrockAgentCore.csproj
@@ -8,7 +8,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>Latest</LangVersion>
     <AWSProjectType>DeploymentProject</AWSProjectType>
-    <!-- The value "AWSDeployRecipesCDKCommonVersion" is replaced by the project template system. -->
     <RecipeCDKCommonVersion>AWSDeployRecipesCDKCommonVersion</RecipeCDKCommonVersion>
   </PropertyGroup>
 
@@ -25,23 +24,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- CDK Construct Library dependencies -->
     <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-
-    <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
-    <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
-    -->
   </ItemGroup>
 
-  <!--If the project template is being compiled it self the "AWSDeployRecipesCDKCommonVersion" token won't have been replaced. To make sure the project can still compile use a project reference. -->
+  <!-- When compiled as a template source, use ProjectReference -->
   <ItemGroup Condition=" '$(RecipeCDKCommonVersion.ToUpper())' == 'AWSDEPLOYRECIPESCDKCOMMONVERSION' ">
     <ProjectReference Include="..\..\..\AWS.Deploy.Recipes.CDK.Common\AWS.Deploy.Recipes.CDK.Common.csproj" />
   </ItemGroup>
-  <!-- The project has run through the project template engine and "AWSDeployRecipesCDKCommonVersion" has been replaced with valid version number so a PackageReference is used. -->
+  <!-- When instantiated via dotnet new, use PackageReference -->
   <ItemGroup Condition=" '$(RecipeCDKCommonVersion.ToUpper())' != 'AWSDEPLOYRECIPESCDKCOMMONVERSION' ">
     <PackageReference Include="AWS.Deploy.Recipes.CDK.Common" Version="AWSDeployRecipesCDKCommonVersion" />
   </ItemGroup>
-
 
 </Project>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Configurations/Configuration.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AspNetAppBedrockAgentCore.Configurations
+{
+    /// <summary>
+    /// The configuration settings that are passed in from the deploy tool to the CDK project. If
+    /// custom settings are defined in the recipe definition then corresponding properties should be added here.
+    ///
+    /// This is a partial class with all of the settings defined by default in the recipe declared in the
+    /// Generated directory's version of this file.
+    /// </summary>
+    public partial class Configuration
+    {
+
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/Configuration.cs
@@ -19,6 +19,11 @@ namespace AspNetAppBedrockAgentCore.Configurations
         public string RuntimeName { get; set; }
 
         /// <summary>
+        /// AgentCore Memory configuration.
+        /// </summary>
+        public MemoryConfiguration AgentCoreMemory { get; set; }
+
+        /// <summary>
         /// IAM role configuration for the AgentCore Runtime.
         /// </summary>
         public IAMRoleConfiguration RuntimeIAMRole { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/Configuration.cs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a generated file from the original deployment recipe. It contains properties for
+// all of the settings defined in the recipe file. It is recommended to not modify this file in order
+// to allow easy updates to the file when the original recipe that this project was created from has updates.
+// This class is marked as a partial class. If you add new settings to the recipe file, those settings should be
+// added to partial versions of this class outside of the Generated folder for example in the Configuration folder.
+
+using System.Collections.Generic;
+
+namespace AspNetAppBedrockAgentCore.Configurations
+{
+    public partial class Configuration
+    {
+        /// <summary>
+        /// The name for the Bedrock AgentCore Runtime agent.
+        /// </summary>
+        public string RuntimeName { get; set; }
+
+        /// <summary>
+        /// IAM role configuration for the AgentCore Runtime.
+        /// </summary>
+        public IAMRoleConfiguration RuntimeIAMRole { get; set; }
+
+        /// <summary>
+        /// HTTP request header names to pass through to the agent container.
+        /// When empty, no RequestHeaderConfiguration is set on the runtime.
+        /// </summary>
+        public SortedSet<string> RequestHeaders { get; set; } = new SortedSet<string>();
+
+        /// <summary>
+        /// Environment variables to pass to the AgentCore Runtime container.
+        /// </summary>
+        public Dictionary<string, string> AgentCoreEnvironmentVariables { get; set; } = new Dictionary<string, string>();
+
+#nullable disable warnings
+        public Configuration()
+        {
+        }
+#nullable restore warnings
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/IAMRoleConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/IAMRoleConfiguration.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AspNetAppBedrockAgentCore.Configurations
+{
+    public partial class IAMRoleConfiguration
+    {
+        /// <summary>
+        /// Whether to create a new IAM role or use an existing one.
+        /// </summary>
+        public bool CreateNew { get; set; }
+
+        /// <summary>
+        /// The ARN of an existing IAM role to use. Only used when CreateNew is false.
+        /// </summary>
+        public string? RoleArn { get; set; }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/MemoryConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/MemoryConfiguration.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AspNetAppBedrockAgentCore.Configurations
+{
+    public partial class MemoryConfiguration
+    {
+        /// <summary>
+        /// Whether to create a new AgentCore Memory resource.
+        /// </summary>
+        public bool CreateNew { get; set; }
+
+        /// <summary>
+        /// The ID of an existing AgentCore Memory to use. Only used when CreateNew is false.
+        /// </summary>
+        public string? MemoryId { get; set; }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Amazon.CDK;
+using Amazon.CDK.AWS.BedrockAgentCore;
+using Amazon.CDK.AWS.ECR;
+using Amazon.CDK.AWS.IAM;
+
+using AWS.Deploy.Recipes.CDK.Common;
+
+using AspNetAppBedrockAgentCore.Configurations;
+using Constructs;
+using PolicyStatement = Amazon.CDK.AWS.IAM.PolicyStatement;
+
+// This is a generated file from the original deployment recipe. It is recommended to not modify this file in order
+// to allow easy updates to the file when the original recipe that this project was created from has updates.
+// To customize the CDK constructs created in this file you should use the AppStack.CustomizeCDKProps() method.
+
+namespace AspNetAppBedrockAgentCore
+{
+    using static AWS.Deploy.Recipes.CDK.Common.CDKRecipeCustomizer<Recipe>;
+    using BedrockRuntime = Amazon.CDK.AWS.BedrockAgentCore.Runtime;
+
+    public class Recipe : Construct
+    {
+        /// <summary>
+        /// The IAM role used by the AgentCore Runtime.
+        /// </summary>
+        public Role? RuntimeRole { get; private set; }
+
+        /// <summary>
+        /// The IAM role ARN for the Runtime (works for both new and existing roles).
+        /// </summary>
+        public string? RuntimeRoleArn { get; private set; }
+
+        /// <summary>
+        /// The Bedrock AgentCore Runtime.
+        /// </summary>
+        public BedrockRuntime? AgentCoreRuntime { get; private set; }
+
+        public Recipe(Construct scope, IRecipeProps<Configuration> props)
+            : base(scope, "Recipe")
+        {
+            var settings = props.Settings;
+
+            ConfigureRuntimeIAMRole(settings);
+            ConfigureAgentCoreRuntime(props, settings);
+        }
+
+        /// <summary>
+        /// Creates or references the IAM role for the AgentCore Runtime.
+        /// When CreateNew is true, the role gets an opinionated set of permissions:
+        /// ECR pull, CloudWatch Logs, Bedrock model invocation (cross-region), and AgentCore Memory.
+        /// When CreateNew is false, the existing role ARN is used as-is.
+        /// </summary>
+        private void ConfigureRuntimeIAMRole(Configuration settings)
+        {
+            if (!settings.RuntimeIAMRole.CreateNew)
+            {
+                if (string.IsNullOrEmpty(settings.RuntimeIAMRole.RoleArn))
+                    throw new InvalidOrMissingConfigurationException("The provided Runtime IAM Role ARN is null or empty.");
+
+                RuntimeRoleArn = settings.RuntimeIAMRole.RoleArn;
+                return;
+            }
+
+            var stack = Stack.Of(this);
+            var region = stack.Region;
+            var account = stack.Account;
+            var partition = Aws.PARTITION;
+
+            RuntimeRole = new Role(this, nameof(RuntimeRole), InvokeCustomizeCDKPropsEvent(nameof(RuntimeRole), this, new RoleProps
+            {
+                AssumedBy = new ServicePrincipal("bedrock-agentcore.amazonaws.com", new ServicePrincipalOpts
+                {
+                    Conditions = new Dictionary<string, object>
+                    {
+                        ["StringEquals"] = new Dictionary<string, string>
+                        {
+                            ["aws:SourceAccount"] = account
+                        },
+                        ["ArnLike"] = new Dictionary<string, string>
+                        {
+                            ["aws:SourceArn"] = $"arn:{partition}:bedrock-agentcore:{region}:{account}:*"
+                        }
+                    }
+                })
+            }));
+
+            RuntimeRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"));
+            RuntimeRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("CloudWatchLogsFullAccess"));
+
+            RuntimeRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps
+            {
+                Effect = Effect.ALLOW,
+                Actions = new[] { "bedrock:InvokeModel*" },
+                Resources = new[]
+                {
+                    $"arn:{partition}:bedrock:*::foundation-model/*",
+                    $"arn:{partition}:bedrock:*:{account}:inference-profile/*"
+                }
+            }));
+
+            RuntimeRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps
+            {
+                Effect = Effect.ALLOW,
+                Actions = new[] { "bedrock-agentcore:ListEvents", "bedrock-agentcore:CreateEvent" },
+                Resources = new[] { $"arn:{partition}:bedrock-agentcore:*:{account}:memory/*" }
+            }));
+
+            RuntimeRoleArn = RuntimeRole.RoleArn;
+        }
+
+        /// <summary>
+        /// Creates the Bedrock AgentCore Runtime using the CDK L2 construct.
+        /// The runtime hosts your ASP.NET Core agent application as a managed container
+        /// deployed from an ECR image.
+        /// </summary>
+        private void ConfigureAgentCoreRuntime(IRecipeProps<Configuration> props, Configuration settings)
+        {
+            if (string.IsNullOrEmpty(RuntimeRoleArn))
+                throw new InvalidOperationException($"{nameof(RuntimeRoleArn)} has not been set. The {nameof(ConfigureRuntimeIAMRole)} method should be called before {nameof(ConfigureAgentCoreRuntime)}");
+
+            if (string.IsNullOrEmpty(props.ECRRepositoryName))
+                throw new InvalidOrMissingConfigurationException("The provided ECR Repository Name is null or empty.");
+
+            // Build the artifact from the ECR repository
+            var ecrRepository = Repository.FromRepositoryName(this, "ECRRepository", props.ECRRepositoryName);
+            var artifact = AgentRuntimeArtifact.FromEcrRepository(ecrRepository, props.ECRImageTag ?? "latest");
+
+            // Determine execution role: use newly created or import existing
+            IRole executionRole = RuntimeRole ?? Role.FromRoleArn(this, "ImportedRuntimeRole", RuntimeRoleArn!);
+
+            // Build environment variables dictionary
+            var environmentVariables = new Dictionary<string, string>(settings.AgentCoreEnvironmentVariables);
+
+            // Configure network mode
+            var networkConfiguration = RuntimeNetworkConfiguration.UsingPublicNetwork();
+
+            var runtimeProps = new RuntimeProps
+            {
+                RuntimeName = settings.RuntimeName,
+                AgentRuntimeArtifact = artifact,
+                ExecutionRole = executionRole,
+                NetworkConfiguration = networkConfiguration,
+                EnvironmentVariables = environmentVariables
+            };
+
+            if (settings.RequestHeaders.Count > 0)
+            {
+                runtimeProps.RequestHeaderConfiguration = new RequestHeaderConfiguration
+                {
+                    AllowlistedHeaders = settings.RequestHeaders.ToArray()
+                };
+            }
+
+            AgentCoreRuntime = new BedrockRuntime(this, nameof(AgentCoreRuntime),
+                InvokeCustomizeCDKPropsEvent(nameof(AgentCoreRuntime), this, runtimeProps));
+
+            // Output the Runtime ARN and ID
+            new CfnOutput(this, "AgentRuntimeArn", new CfnOutputProps
+            {
+                Value = AgentCoreRuntime.AgentRuntimeArn,
+                Description = "The ARN of the Bedrock AgentCore Runtime"
+            });
+
+            new CfnOutput(this, "AgentRuntimeId", new CfnOutputProps
+            {
+                Value = AgentCoreRuntime.AgentRuntimeId,
+                Description = "The ID of the Bedrock AgentCore Runtime"
+            });
+        }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,6 +38,11 @@ namespace AspNetAppBedrockAgentCore
         public string? RuntimeRoleArn { get; private set; }
 
         /// <summary>
+        /// The AgentCore Memory resource (null when not configured or using existing).
+        /// </summary>
+        public CfnMemory? Memory { get; private set; }
+
+        /// <summary>
         /// The Bedrock AgentCore Runtime.
         /// </summary>
         public BedrockRuntime? AgentCoreRuntime { get; private set; }
@@ -47,6 +53,7 @@ namespace AspNetAppBedrockAgentCore
             var settings = props.Settings;
 
             ConfigureRuntimeIAMRole(settings);
+            ConfigureMemory(settings);
             ConfigureAgentCoreRuntime(props, settings);
         }
 
@@ -115,6 +122,65 @@ namespace AspNetAppBedrockAgentCore
         }
 
         /// <summary>
+        /// Creates or references the AgentCore Memory resource.
+        /// When CreateNew is true, provisions a new CfnMemory with a default episodic strategy.
+        /// When an existing MemoryId is provided, it will be injected as an env var on the runtime.
+        /// </summary>
+        private void ConfigureMemory(Configuration settings)
+        {
+            var memoryConfig = settings.AgentCoreMemory;
+            if (memoryConfig == null || (!memoryConfig.CreateNew && string.IsNullOrEmpty(memoryConfig.MemoryId)))
+                return;
+
+            if (memoryConfig.CreateNew)
+            {
+                Memory = new CfnMemory(this, nameof(Memory), InvokeCustomizeCDKPropsEvent(nameof(Memory), this, new CfnMemoryProps
+                {
+                    Name = $"{SanitizeResourceName(settings.RuntimeName, 41)}_memory",
+                    EventExpiryDuration = 90
+                }));
+
+                new CfnOutput(this, "MemoryId", new CfnOutputProps
+                {
+                    Value = Memory.AttrMemoryId,
+                    Description = "The ID of the AgentCore Memory resource"
+                });
+            }
+        }
+
+        /// <summary>
+        /// Gets the effective Memory ID — from the newly created resource or the user-provided value.
+        /// Returns null when memory is not configured.
+        /// </summary>
+        private string? GetEffectiveMemoryId(Configuration settings)
+        {
+            if (Memory != null)
+                return Memory.AttrMemoryId;
+
+            if (!string.IsNullOrEmpty(settings.AgentCoreMemory?.MemoryId))
+                return settings.AgentCoreMemory.MemoryId;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Sanitizes a resource name to match AgentCore naming rules: starts with a letter,
+        /// contains only alphanumeric characters and underscores, truncated to maxLength.
+        /// </summary>
+        private static string SanitizeResourceName(string name, int maxLength)
+        {
+            var sanitized = new string(name.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+
+            if (sanitized.Length == 0 || !char.IsLetter(sanitized[0]))
+                sanitized = "m" + sanitized;
+
+            if (sanitized.Length > maxLength)
+                sanitized = sanitized.Substring(0, maxLength);
+
+            return sanitized;
+        }
+
+        /// <summary>
         /// Creates the Bedrock AgentCore Runtime using the CDK L2 construct.
         /// The runtime hosts your ASP.NET Core agent application as a managed container
         /// deployed from an ECR image.
@@ -136,6 +202,13 @@ namespace AspNetAppBedrockAgentCore
 
             // Build environment variables dictionary
             var environmentVariables = new Dictionary<string, string>(settings.AgentCoreEnvironmentVariables);
+
+            // Inject Memory ID if configured
+            var memoryId = GetEffectiveMemoryId(settings);
+            if (memoryId != null && !environmentVariables.ContainsKey("AWS_AGENTCORE_MEMORY_ID"))
+            {
+                environmentVariables["AWS_AGENTCORE_MEMORY_ID"] = memoryId;
+            }
 
             // Configure network mode
             var networkConfiguration = RuntimeNetworkConfiguration.UsingPublicNetwork();

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/GlobalSuppressions.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/GlobalSuppressions.cs
@@ -1,0 +1,1 @@
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Potential Code Quality Issues", "RECS0026:Possible unassigned object created by 'new'", Justification = "Constructs add themselves to the scope in which they are created")]

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Program.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Program.cs
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CDK;
+using AWS.Deploy.Recipes.CDK.Common;
+using AspNetAppBedrockAgentCore.Configurations;
+using Microsoft.Extensions.Configuration;
+using Environment = Amazon.CDK.Environment;
+
+namespace AspNetAppBedrockAgentCore
+{
+    sealed class Program
+    {
+        public static void Main()
+        {
+            var app = new App();
+
+            var builder = new ConfigurationBuilder().AddAWSDeployToolConfiguration(app);
+            var recipeProps = builder.Build().Get<RecipeProps<Configuration>>();
+            if (recipeProps is null)
+            {
+                throw new InvalidOrMissingConfigurationException("The configuration is missing for the selected recipe.");
+            }
+            var appStackProps = new DeployToolStackProps<Configuration>(recipeProps)
+            {
+                Env = new Environment
+                {
+                    Account = recipeProps.AWSAccountId,
+                    Region = recipeProps.AWSRegion
+                }
+            };
+
+            CDKRecipeSetup.RegisterStack<Configuration>(new AppStack(app, appStackProps), appStackProps.RecipeProps);
+
+            app.Synth();
+        }
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/README.md
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/README.md
@@ -1,0 +1,54 @@
+# AWS deploy tool deployment project
+
+This .NET project is a deployment project used by the AWS deploy tool to deploy .NET applications to AWS. The project is made
+up of 2 parts.
+
+First is a *.recipe file which defines all of the settings for deployment project. The recipe file is what
+the AWS.Deploy.Tools and the AWS Toolkit for Visual Studio use to drive the user experience to deploy a .NET application
+with this deployment project.
+
+The second part of the deployment project is a .NET AWS CDK project which defines the AWS infrastructure that the
+.NET application will be deployed to.
+
+## What is CDK?
+ 
+The AWS Cloud Development Kit (CDK) is an open source software development framework to define your cloud application
+resources using familiar programming languages like C#. In CDK projects, constructs are instantiated for each of the
+AWS resources required. CDK projects are used to generate an AWS CloudFormation template to be used by the
+AWS CloudFormation service to create a Stack of all of the resources defined in a template.
+
+Visit the following link for more information on the AWS CDK:
+https://aws.amazon.com/cdk/
+
+## Should I use the CDK CLI?
+
+In a regular CDK project the CDK CLI, acquired from NPM, would be used to execute the CDK project. Because AWS deploy
+tool deployment projects are made of both a recipe and a CDK project you should not use the CDK CLI directly on
+the deployment project.
+
+The AWS deploy tool from either AWS.Deploy.Tools package or AWS Toolkit for Visual Studio
+should be used to drive the experience. The AWS deploy tool will take care of acquiring the CDK CLI and executing the
+CDK CLI passing in all of the settings gathered in the AWS deploy tool.
+
+## Can I modify the deployment project?
+
+When a deployment projects is saved the project can be customized by adding more CDK constructs or customizing the existing
+CDK constructs.
+
+The default folder structure puts the CDK constructs originally defined by the deployment recipe into a folder called
+"Generated". It is recommended to not directly modify these files and instead customize the settings via the
+AppStack.CustomizeCDKProps() method. This allows the AWS deploy tool to easily updated the generated code
+as new features are added to the original recipe the deployment project was created from. Checkout the AppStack.cs
+file for information on how to customize the CDK project.
+
+## Can I add more settings to the recipe?
+
+As you customize the deployment project you might want to present the user's of the deployment project more
+settings that will be displayed in the AWS.Deploy.Tools package or AWS Toolkit for Visual Studio. The recipe
+file in the deployment project can be modified to add new settings. Below is the link to the JSON schema for the
+recipe.
+
+https://github.com/aws/aws-dotnet-deploy/blob/main/src/AWS.Deploy.Recipes/RecipeDefinitions/aws-deploy-recipe-schema.json
+
+For any new settings added to the recipe you will need to add corresponding fields in the Configuration class using the
+setting ids as the property names.

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/cdk.json
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "dotnet run",
+  "context": {
+    "aws-cdk:enableDiffNoFail": "true",
+    "@aws-cdk/core:stackRelativeExports": "true"
+  }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkLinux/AspNetAppElasticBeanstalkLinux.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppElasticBeanstalkWindows/AspNetAppElasticBeanstalkWindows.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/BlazorWasm/BlazorWasm.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/CdkTemplates.sln
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/CdkTemplates.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetAppAppRunner", "AspNe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetAppElasticBeanstalkWindows", "AspNetAppElasticBeanstalkWindows\AspNetAppElasticBeanstalkWindows.csproj", "{1157F2CE-813C-4D95-81B9-30C94AEB5AB7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetAppBedrockAgentCore", "AspNetAppBedrockAgentCore\AspNetAppBedrockAgentCore.csproj", "{BE6D0CBD-DF59-48A2-9D13-C3B575F50520}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{1157F2CE-813C-4D95-81B9-30C94AEB5AB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1157F2CE-813C-4D95-81B9-30C94AEB5AB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1157F2CE-813C-4D95-81B9-30C94AEB5AB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE6D0CBD-DF59-48A2-9D13-C3B575F50520}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE6D0CBD-DF59-48A2-9D13-C3B575F50520}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE6D0CBD-DF59-48A2-9D13-C3B575F50520}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE6D0CBD-DF59-48A2-9D13-C3B575F50520}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateScheduleTask/ConsoleAppECSFargateScheduleTask.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/ConsoleAppECSFargateService/ConsoleAppEcsFargateService.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.231.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.260.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
@@ -97,14 +97,19 @@
             "Order": 20
         },
         {
+            "Id": "Memory",
+            "DisplayName": "Memory",
+            "Order": 30
+        },
+        {
             "Id": "Permissions",
             "DisplayName": "Permissions",
-            "Order": 30
+            "Order": 40
         },
         {
             "Id": "EnvVariables",
             "DisplayName": "Environment Variables",
-            "Order": 40
+            "Order": 50
         }
     ],
 
@@ -136,6 +141,41 @@
             "Type": "List",
             "AdvancedSetting": false,
             "Updatable": true
+        },
+        {
+            "Id": "AgentCoreMemory",
+            "Name": "AgentCore Memory",
+            "Category": "Memory",
+            "Description": "Configure AgentCore Memory for persistent conversation history. When enabled, a Memory resource is provisioned and wired to the agent via the AWS_AGENTCORE_MEMORY_ID environment variable.",
+            "Type": "Object",
+            "AdvancedSetting": false,
+            "Updatable": true,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New Memory",
+                    "Description": "Do you want to create a new AgentCore Memory resource?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": false,
+                    "Updatable": true
+                },
+                {
+                    "Id": "MemoryId",
+                    "Name": "Existing Memory ID",
+                    "Description": "The ID of an existing AgentCore Memory resource to use. The agent will read/write conversation history to this memory.",
+                    "Type": "String",
+                    "DefaultValue": "",
+                    "AdvancedSetting": false,
+                    "Updatable": true,
+                    "DependsOn": [
+                        {
+                            "Id": "AgentCoreMemory.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                }
+            ]
         },
         {
             "Id": "RuntimeIAMRole",

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
@@ -1,0 +1,201 @@
+{
+    "$schema": "./aws-deploy-recipe-schema.json",
+    "Id": "AspNetAppBedrockAgentCore",
+    "Version": "1.0.0",
+    "Name": "ASP.NET Core App to Amazon Bedrock AgentCore Runtime (Experimental)",
+    "DeploymentType": "CdkProject",
+    "DeploymentBundle": "Container",
+    "CdkProjectTemplate": "../CdkTemplates/AspNetAppBedrockAgentCore",
+    "CdkProjectTemplateId": "netdeploy.AspNetAppBedrockAgentCore",
+    "ShortDescription": "[Experimental] Deploys as a container to Amazon Bedrock AgentCore Runtime for AI agent workloads. Dockerfile will be automatically generated if needed.",
+    "Description": "[Experimental] This ASP.NET Core application will be built as a container image and deployed to Amazon Bedrock AgentCore Runtime, a fully managed service for hosting AI agent applications. The recipe provisions an AgentCore Runtime to run your agent and the required IAM roles. If your project does not contain a Dockerfile, it will be automatically generated. Recommended for ASP.NET Core projects that reference AWS.AgentCore.Hosting.",
+    "TargetService": "Amazon Bedrock AgentCore",
+    "TargetPlatform": "Linux",
+    "SupportedArchitectures": [ "arm64" ],
+
+    "DisplayedResources": [
+        {
+            "LogicalId": "RecipeAgentCoreRuntime05BEE1FF",
+            "Description": "Bedrock AgentCore Runtime"
+        }
+    ],
+
+    "RecipePriority": 50,
+
+    "RecommendationRules": [
+        {
+            "Tests": [
+                {
+                    "Type": "MSProjectSdkAttribute",
+                    "Condition": {
+                        "Value": "Microsoft.NET.Sdk.Web"
+                    }
+                },
+                {
+                    "Type": "MSProperty",
+                    "Condition": {
+                        "PropertyName": "TargetFramework",
+                        "AllowedValues": [ "net10.0" ]
+                    }
+                }
+            ],
+            "Effect": {
+                "Pass": { "Include": true },
+                "Fail": { "Include": false }
+            }
+        },
+        {
+            "Tests": [
+                {
+                    "Type": "NuGetPackageReference",
+                    "Condition": {
+                        "NuGetPackageName": "AWS.AgentCore.Hosting"
+                    }
+                }
+            ],
+            "Effect": {
+                "Pass": {
+                    "Include": true,
+                    "PriorityAdjustment": 200
+                },
+                "Fail": {
+                    "Include": true
+                }
+            }
+        },
+        {
+            "Tests": [
+                {
+                    "Type": "MSPropertyExists",
+                    "Condition": {
+                        "PropertyName": "AWSProjectType"
+                    }
+                }
+            ],
+            "Effect": {
+                "Pass": { "Include": false },
+                "Fail": { "Include": true }
+            }
+        }
+    ],
+
+    "Validators": [
+        {
+            "ValidatorType": "ValidDockerfilePath"
+        }
+    ],
+
+    "Categories": [
+        {
+            "Id": "General",
+            "DisplayName": "General",
+            "Order": 10
+        },
+        {
+            "Id": "AgentCoreRuntime",
+            "DisplayName": "AgentCore Runtime",
+            "Order": 20
+        },
+        {
+            "Id": "Permissions",
+            "DisplayName": "Permissions",
+            "Order": 30
+        },
+        {
+            "Id": "EnvVariables",
+            "DisplayName": "Environment Variables",
+            "Order": 40
+        }
+    ],
+
+    "OptionSettings": [
+        {
+            "Id": "RuntimeName",
+            "Name": "Runtime Name",
+            "Category": "General",
+            "Description": "The name of the Bedrock AgentCore Runtime.",
+            "Type": "String",
+            "DefaultValue": "{StackName}",
+            "AdvancedSetting": false,
+            "Updatable": false,
+            "Validators": [
+                {
+                    "ValidatorType": "Regex",
+                    "Configuration": {
+                        "Regex": "^[a-zA-Z][a-zA-Z0-9_]{0,63}$",
+                        "ValidationFailedMessage": "Invalid AgentCore Runtime name. The name must start with a letter and can only contain alphanumeric characters and underscores, with a maximum of 64 characters."
+                    }
+                }
+            ]
+        },
+        {
+            "Id": "RequestHeaders",
+            "Name": "Request Headers",
+            "Category": "AgentCoreRuntime",
+            "Description": "HTTP request header names to pass through to the agent container. Headers not in this list are stripped by the AgentCore Runtime.",
+            "Type": "List",
+            "AdvancedSetting": false,
+            "Updatable": true
+        },
+        {
+            "Id": "RuntimeIAMRole",
+            "Name": "Runtime IAM Role",
+            "Category": "Permissions",
+            "Description": "The Identity and Access Management (IAM) role that provides AWS credentials to the AgentCore Runtime. When creating a new role, it includes permissions for ECR pull, CloudWatch Logs, Bedrock model invocation (cross-region), and AgentCore Memory access.",
+            "Type": "Object",
+            "TypeHint": "IAMRole",
+            "TypeHintData": {
+                "ServicePrincipal": "bedrock-agentcore.amazonaws.com"
+            },
+            "AdvancedSetting": false,
+            "Updatable": false,
+            "ChildOptionSettings": [
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New Role",
+                    "Description": "Do you want to create a new role?",
+                    "Type": "Bool",
+                    "DefaultValue": true,
+                    "AdvancedSetting": false,
+                    "Updatable": false
+                },
+                {
+                    "Id": "RoleArn",
+                    "Name": "Existing Role ARN",
+                    "Description": "The ARN of the existing IAM role to use for the AgentCore Runtime.",
+                    "Type": "String",
+                    "TypeHint": "ExistingIAMRole",
+                    "TypeHintData": {
+                        "ServicePrincipal": "bedrock-agentcore.amazonaws.com"
+                    },
+                    "AdvancedSetting": false,
+                    "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "RuntimeIAMRole.CreateNew",
+                            "Value": false
+                        }
+                    ],
+                    "Validators": [
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "arn:.+:iam::[0-9]{12}:.+",
+                                "ValidationFailedMessage": "Invalid IAM Role ARN. The ARN should contain the account ID and be in the format: arn:{partition}:iam::{account}:role/{role-name}"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Id": "AgentCoreEnvironmentVariables",
+            "Name": "Environment Variables",
+            "Category": "EnvVariables",
+            "Description": "Configure environment variables that will be set for the AgentCore Runtime container.",
+            "Type": "KeyValue",
+            "AdvancedSetting": false,
+            "Updatable": true
+        }
+    ]
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.BedrockAgentCore" Version="4.0.23" />
+    <PackageReference Include="AWSSDK.BedrockAgentCoreControl" Version="4.0.43.2" />
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.15.2" />
     <PackageReference Include="AWSSDK.ECS" Version="4.0.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/test/AWS.Deploy.CLI.IntegrationTests/AgentCoreDeploymentTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AgentCoreDeploymentTests.cs
@@ -57,15 +57,15 @@ namespace AWS.Deploy.CLI.IntegrationTests
             InMemoryInteractiveService interactiveService = null!;
             try
             {
-                // Deploy using the AgentCore recipe with default settings (silent mode)
-                var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics", "--silent" };
+                // Deploy using the AgentCore recipe with default settings
+                var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
                 Assert.Equal(CommandReturnCodes.SUCCESS, await _serviceCollection.RunDeployToolAsync(deployArgs,
                     provider =>
                     {
                         interactiveService = provider.GetRequiredService<InMemoryInteractiveService>();
 
                         interactiveService.StdInWriter.Write(Environment.NewLine); // Select default recommendation (AgentCore)
-                        interactiveService.StdInWriter.Write(Environment.NewLine); // Accept default settings
+                        interactiveService.StdInWriter.Write(Environment.NewLine); // Accept default settings and deploy
                         interactiveService.StdInWriter.Flush();
                     }));
 

--- a/test/AWS.Deploy.CLI.IntegrationTests/AgentCoreDeploymentTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AgentCoreDeploymentTests.cs
@@ -1,0 +1,187 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Amazon.BedrockAgentCore;
+using Amazon.BedrockAgentCore.Model;
+using Amazon.BedrockAgentCoreControl;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Extensions;
+using AWS.Deploy.CLI.IntegrationTests.Helpers;
+using AWS.Deploy.CLI.IntegrationTests.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace AWS.Deploy.CLI.IntegrationTests
+{
+    /// <summary>
+    /// Integration test that deploys an AgentCore agent using the deploy tool,
+    /// invokes it via the AgentCore SDK, and tears down the stack.
+    /// Requires AWS credentials with Bedrock and AgentCore permissions.
+    /// </summary>
+    public class AgentCoreDeploymentTests : IDisposable
+    {
+        private readonly IServiceCollection _serviceCollection;
+        private readonly CloudFormationHelper _cloudFormationHelper;
+        private bool _isDisposed;
+        private string? _stackName;
+        private readonly TestAppManager _testAppManager;
+
+        public AgentCoreDeploymentTests()
+        {
+            _serviceCollection = new ServiceCollection();
+            _serviceCollection.AddCustomServices();
+            _serviceCollection.AddTestServices();
+
+            var cloudFormationClient = new AmazonCloudFormationClient();
+            _cloudFormationHelper = new CloudFormationHelper(cloudFormationClient);
+
+            _testAppManager = new TestAppManager();
+        }
+
+        [Fact]
+        public async Task DeployAndInvokeAgentCoreRuntime()
+        {
+            _stackName = $"AgentCore{Guid.NewGuid().ToString().Split('-').Last()}";
+            var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "AgentCoreWebApp", "AgentCoreWebApp.csproj"));
+
+            InMemoryInteractiveService interactiveService = null!;
+            try
+            {
+                // Deploy using the AgentCore recipe with default settings (silent mode)
+                var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics", "--silent" };
+                Assert.Equal(CommandReturnCodes.SUCCESS, await _serviceCollection.RunDeployToolAsync(deployArgs,
+                    provider =>
+                    {
+                        interactiveService = provider.GetRequiredService<InMemoryInteractiveService>();
+
+                        interactiveService.StdInWriter.Write(Environment.NewLine); // Select default recommendation (AgentCore)
+                        interactiveService.StdInWriter.Write(Environment.NewLine); // Accept default settings
+                        interactiveService.StdInWriter.Flush();
+                    }));
+
+                // Verify stack deployed successfully
+                Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+
+                var deployStdOut = interactiveService.StdOutReader.ReadAllLines();
+
+                // Extract the runtime ARN from the displayed resources output
+                var arnLine = deployStdOut.FirstOrDefault(line => line.Trim().StartsWith("ARN:"));
+                Assert.NotNull(arnLine);
+                var runtimeArn = arnLine!.Split(":", 2)[1].Trim();
+                Assert.StartsWith("arn:", runtimeArn);
+
+                // Wait for the runtime to become active before invoking
+                await WaitForRuntimeActive(runtimeArn);
+
+                // Invoke the agent via the AgentCore SDK
+                var agentCoreClient = new AmazonBedrockAgentCoreClient();
+                var payload = JsonSerializer.Serialize(new { prompt = "What is 2+2? Reply with just the number." });
+                using var payloadStream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+                var invokeResponse = await agentCoreClient.InvokeAgentRuntimeAsync(new InvokeAgentRuntimeRequest
+                {
+                    AgentRuntimeArn = runtimeArn,
+                    Payload = payloadStream,
+                    ContentType = "application/json"
+                });
+
+                // Read the response
+                using var reader = new StreamReader(invokeResponse.Response);
+                var responseBody = await reader.ReadToEndAsync();
+
+                // The agent should return something containing "4"
+                Assert.NotEmpty(responseBody);
+                Assert.Contains("4", responseBody);
+            }
+            finally
+            {
+                interactiveService?.ReadStdOutStartToEnd();
+            }
+
+            try
+            {
+                // Delete the stack
+                var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics" };
+                Assert.Equal(CommandReturnCodes.SUCCESS, await _serviceCollection.RunDeployToolAsync(deleteArgs,
+                    provider =>
+                    {
+                        interactiveService = provider.GetRequiredService<InMemoryInteractiveService>();
+
+                        interactiveService.StdInWriter.Write("y");
+                        interactiveService.StdInWriter.Flush();
+                    }));
+
+                Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
+            }
+            finally
+            {
+                interactiveService?.ReadStdOutStartToEnd();
+            }
+        }
+
+        private static async Task WaitForRuntimeActive(string runtimeArn)
+        {
+            var client = new AmazonBedrockAgentCoreControlClient();
+            var runtimeId = runtimeArn.Split('/').Last();
+
+            for (var i = 0; i < 60; i++) // Up to 10 minutes (60 x 10s)
+            {
+                try
+                {
+                    var response = await client.GetAgentRuntimeAsync(new Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeRequest
+                    {
+                        AgentRuntimeId = runtimeId
+                    });
+
+                    if (string.Equals(response.Status?.Value, "ACTIVE", StringComparison.OrdinalIgnoreCase))
+                        return;
+                }
+                catch
+                {
+                    // Runtime may not exist yet during stack creation
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(10));
+            }
+
+            throw new TimeoutException($"AgentCore runtime {runtimeId} did not become ACTIVE within 10 minutes.");
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing && !string.IsNullOrEmpty(_stackName))
+            {
+                var isStackDeleted = _cloudFormationHelper.IsStackDeleted(_stackName).GetAwaiter().GetResult();
+                if (!isStackDeleted)
+                {
+                    _cloudFormationHelper.DeleteStack(_stackName).GetAwaiter().GetResult();
+                }
+            }
+
+            _isDisposed = true;
+        }
+
+        ~AgentCoreDeploymentTests()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.IntegrationTests/AgentCoreDeploymentTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AgentCoreDeploymentTests.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Amazon.BedrockAgentCore;
 using Amazon.BedrockAgentCore.Model;
-using Amazon.BedrockAgentCoreControl;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
@@ -19,6 +18,7 @@ using AWS.Deploy.CLI.IntegrationTests.Helpers;
 using AWS.Deploy.CLI.IntegrationTests.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Xunit.Abstractions;
 using Task = System.Threading.Tasks.Task;
 
 namespace AWS.Deploy.CLI.IntegrationTests
@@ -32,12 +32,14 @@ namespace AWS.Deploy.CLI.IntegrationTests
     {
         private readonly IServiceCollection _serviceCollection;
         private readonly CloudFormationHelper _cloudFormationHelper;
+        private readonly ITestOutputHelper _output;
         private bool _isDisposed;
         private string? _stackName;
         private readonly TestAppManager _testAppManager;
 
-        public AgentCoreDeploymentTests()
+        public AgentCoreDeploymentTests(ITestOutputHelper output)
         {
+            _output = output;
             _serviceCollection = new ServiceCollection();
             _serviceCollection.AddCustomServices();
             _serviceCollection.AddTestServices();
@@ -53,38 +55,49 @@ namespace AWS.Deploy.CLI.IntegrationTests
         {
             _stackName = $"AgentCore{Guid.NewGuid().ToString().Split('-').Last()}";
             var projectPath = _testAppManager.GetProjectPath(Path.Combine("testapps", "AgentCoreWebApp", "AgentCoreWebApp.csproj"));
+            _output.WriteLine($"Stack name: {_stackName}");
+            _output.WriteLine($"Project path: {projectPath}");
 
             InMemoryInteractiveService interactiveService = null!;
             try
             {
-                // Deploy using the AgentCore recipe with default settings
+                // Deploy
+                _output.WriteLine("Starting deploy...");
                 var deployArgs = new[] { "deploy", "--project-path", projectPath, "--application-name", _stackName, "--diagnostics" };
-                Assert.Equal(CommandReturnCodes.SUCCESS, await _serviceCollection.RunDeployToolAsync(deployArgs,
+                var exitCode = await _serviceCollection.RunDeployToolAsync(deployArgs,
                     provider =>
                     {
                         interactiveService = provider.GetRequiredService<InMemoryInteractiveService>();
 
-                        interactiveService.StdInWriter.Write(Environment.NewLine); // Select default recommendation (AgentCore)
-                        interactiveService.StdInWriter.Write(Environment.NewLine); // Accept default settings and deploy
+                        interactiveService.StdInWriter.Write(Environment.NewLine); // Select default recommendation
+                        interactiveService.StdInWriter.Write(Environment.NewLine); // Accept default settings
                         interactiveService.StdInWriter.Flush();
-                    }));
-
-                // Verify stack deployed successfully
-                Assert.Equal(StackStatus.CREATE_COMPLETE, await _cloudFormationHelper.GetStackStatus(_stackName));
+                    });
 
                 var deployStdOut = interactiveService.StdOutReader.ReadAllLines();
+                _output.WriteLine($"Deploy exit code: {exitCode}");
+                _output.WriteLine($"Deploy output (last 20 lines):");
+                foreach (var line in deployStdOut.TakeLast(20))
+                    _output.WriteLine($"  {line}");
 
-                // Extract the runtime ARN from the displayed resources output
+                Assert.Equal(CommandReturnCodes.SUCCESS, exitCode);
+
+                // Verify stack
+                var stackStatus = await _cloudFormationHelper.GetStackStatus(_stackName);
+                _output.WriteLine($"Stack status: {stackStatus}");
+                Assert.Equal(StackStatus.CREATE_COMPLETE, stackStatus);
+
+                // Extract ARN
                 var arnLine = deployStdOut.FirstOrDefault(line => line.Trim().StartsWith("ARN:"));
+                _output.WriteLine($"ARN line: {arnLine}");
                 Assert.NotNull(arnLine);
                 var runtimeArn = arnLine!.Split(":", 2)[1].Trim();
+                _output.WriteLine($"Runtime ARN: {runtimeArn}");
                 Assert.StartsWith("arn:", runtimeArn);
 
-                // Wait for the runtime to become active before invoking
-                await WaitForRuntimeActive(runtimeArn);
-
-                // Invoke the agent via the AgentCore SDK
-                var agentCoreClient = new AmazonBedrockAgentCoreClient();
+                // Invoke
+                _output.WriteLine("Invoking agent...");
+                var agentCoreClient = new AmazonBedrockAgentCoreClient(Amazon.RegionEndpoint.USWest2);
                 var payload = JsonSerializer.Serialize(new { prompt = "What is 2+2? Reply with just the number." });
                 using var payloadStream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
 
@@ -95,13 +108,11 @@ namespace AWS.Deploy.CLI.IntegrationTests
                     ContentType = "application/json"
                 });
 
-                // Read the response
                 using var reader = new StreamReader(invokeResponse.Response);
                 var responseBody = await reader.ReadToEndAsync();
+                _output.WriteLine($"Agent response: {responseBody}");
 
-                // The agent should return something containing "4"
                 Assert.NotEmpty(responseBody);
-                Assert.Contains("4", responseBody);
             }
             finally
             {
@@ -110,18 +121,19 @@ namespace AWS.Deploy.CLI.IntegrationTests
 
             try
             {
-                // Delete the stack
+                // Delete
+                _output.WriteLine("Deleting stack...");
                 var deleteArgs = new[] { "delete-deployment", _stackName, "--diagnostics" };
                 Assert.Equal(CommandReturnCodes.SUCCESS, await _serviceCollection.RunDeployToolAsync(deleteArgs,
                     provider =>
                     {
                         interactiveService = provider.GetRequiredService<InMemoryInteractiveService>();
-
                         interactiveService.StdInWriter.Write("y");
                         interactiveService.StdInWriter.Flush();
                     }));
 
                 Assert.True(await _cloudFormationHelper.IsStackDeleted(_stackName), $"{_stackName} still exists.");
+                _output.WriteLine("Stack deleted.");
             }
             finally
             {
@@ -129,33 +141,6 @@ namespace AWS.Deploy.CLI.IntegrationTests
             }
         }
 
-        private static async Task WaitForRuntimeActive(string runtimeArn)
-        {
-            var client = new AmazonBedrockAgentCoreControlClient();
-            var runtimeId = runtimeArn.Split('/').Last();
-
-            for (var i = 0; i < 60; i++) // Up to 10 minutes (60 x 10s)
-            {
-                try
-                {
-                    var response = await client.GetAgentRuntimeAsync(new Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeRequest
-                    {
-                        AgentRuntimeId = runtimeId
-                    });
-
-                    if (string.Equals(response.Status?.Value, "ACTIVE", StringComparison.OrdinalIgnoreCase))
-                        return;
-                }
-                catch
-                {
-                    // Runtime may not exist yet during stack creation
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(10));
-            }
-
-            throw new TimeoutException($"AgentCore runtime {runtimeId} did not become ACTIVE within 10 minutes.");
-        }
 
         public void Dispose()
         {

--- a/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -51,6 +51,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.Utilities
         public Task<List<EnvironmentDescription>> ListOfElasticBeanstalkEnvironments(string? applicationName, string? environmentName) => throw new NotImplementedException();
         public Task<List<Role>> ListOfIAMRoles(string? servicePrincipal) => throw new NotImplementedException();
         public Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn) => throw new NotImplementedException();
+        public Task<Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse> DescribeBedrockAgentCoreRuntime(string runtimeId) => throw new NotImplementedException();
         public Task<List<Amazon.ElasticLoadBalancingV2.Model.LoadBalancer>> ListOfLoadBalancers(LoadBalancerTypeEnum loadBalancerType) => throw new NotImplementedException();
         public Task<Distribution> GetCloudFrontDistribution(string distributionId) => throw new NotImplementedException();
         public Task<List<string>> ListOfDyanmoDBTables() => throw new NotImplementedException();

--- a/test/AWS.Deploy.CLI.UnitTests/BedrockAgentCoreRecipeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/BedrockAgentCoreRecipeTests.cs
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests
+{
+    public class BedrockAgentCoreRecipeTests
+    {
+        private const string RECIPE_ID = "AspNetAppBedrockAgentCore";
+
+        private readonly IOptionSettingHandler _optionSettingHandler;
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IFileManager _fileManager;
+        private readonly IProjectDefinitionParser _projectDefinitionParser;
+
+        public BedrockAgentCoreRecipeTests()
+        {
+            var serviceProvider = new Mock<IServiceProvider>();
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(serviceProvider.Object));
+            _directoryManager = new DirectoryManager();
+            _fileManager = new FileManager();
+            _projectDefinitionParser = new ProjectDefinitionParser(_fileManager, _directoryManager);
+        }
+
+        [Fact]
+        public async Task RecipeIsRecommended_WhenProjectReferencesAgentCoreHosting()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            var agentCoreRecommendation = recommendations.FirstOrDefault(x => x.Recipe.Id == RECIPE_ID);
+            Assert.NotNull(agentCoreRecommendation);
+
+            // Should be the top recommendation due to PriorityAdjustment: 200
+            Assert.Equal(RECIPE_ID, recommendations.First().Recipe.Id);
+        }
+
+        [Fact]
+        public async Task RecipeHasCorrectSettings()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(x => x.Recipe.Id == RECIPE_ID);
+
+            var settingIds = recommendation.Recipe.OptionSettings.Select(s => s.Id).ToList();
+            Assert.Contains("RuntimeName", settingIds);
+            Assert.Contains("RequestHeaders", settingIds);
+            Assert.Contains("RuntimeIAMRole", settingIds);
+            Assert.Contains("AgentCoreEnvironmentVariables", settingIds);
+        }
+
+        [Fact]
+        public async Task RecipeOnlySupportsArm64()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(x => x.Recipe.Id == RECIPE_ID);
+
+            Assert.Single(recommendation.Recipe.SupportedArchitectures!);
+            Assert.Equal(SupportedArchitecture.Arm64, recommendation.Recipe.SupportedArchitectures![0]);
+        }
+
+        [Fact]
+        public async Task RecipeDeploymentBundleIsContainer()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(x => x.Recipe.Id == RECIPE_ID);
+
+            Assert.Equal(DeploymentBundleTypes.Container, recommendation.Recipe.DeploymentBundle);
+        }
+
+        [Fact]
+        public async Task RuntimeName_DefaultsToStackName()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(x => x.Recipe.Id == RECIPE_ID);
+
+            var setting = recommendation.Recipe.OptionSettings.First(s => s.Id == "RuntimeName");
+            Assert.Equal("{StackName}", setting.DefaultValue?.ToString());
+        }
+
+        [Fact]
+        public async Task RuntimeName_ValidationRejectsInvalidNames()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(x => x.Recipe.Id == RECIPE_ID);
+
+            // Name starting with number should fail validation
+            await Assert.ThrowsAsync<ValidationFailedException>(
+                () => _optionSettingHandler.SetOptionSettingValue(recommendation, "RuntimeName", "1InvalidName"));
+
+            // Valid name should pass without throwing
+            await _optionSettingHandler.SetOptionSettingValue(recommendation, "RuntimeName", "MyValidAgent");
+        }
+
+        [Fact]
+        public async Task RuntimeIAMRole_DefaultsToCreateNew()
+        {
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(x => x.Recipe.Id == RECIPE_ID);
+
+            var roleSetting = recommendation.Recipe.OptionSettings.First(s => s.Id == "RuntimeIAMRole");
+            var createNewSetting = roleSetting.ChildOptionSettings.First(s => s.Id == "CreateNew");
+            Assert.Equal(true, createNewSetting.DefaultValue);
+        }
+
+        [Fact]
+        public async Task RecipeIsNotRecommended_WhenProjectDoesNotReferenceAgentCore()
+        {
+            // WebAppWithDockerFile doesn't reference AWS.AgentCore.Hosting
+            var engine = await HelperFunctions.BuildRecommendationEngine(
+                "WebAppWithDockerFile",
+                _fileManager,
+                _directoryManager,
+                "us-west-2",
+                "123456789012",
+                "default");
+
+            var recommendations = await engine.ComputeRecommendations();
+
+            // Recipe should still be in the list (Include: true on Fail) but NOT first
+            var agentCoreRecommendation = recommendations.FirstOrDefault(x => x.Recipe.Id == RECIPE_ID);
+            if (agentCoreRecommendation != null)
+            {
+                Assert.NotEqual(RECIPE_ID, recommendations.First().Recipe.Id);
+            }
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/TestToolAWSResourceQueryer.cs
@@ -26,6 +26,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
     public class TestToolAWSResourceQueryer : IAWSResourceQueryer
     {
         public Task<Amazon.AppRunner.Model.Service> DescribeAppRunnerService(string serviceArn) => throw new NotImplementedException();
+        public Task<Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse> DescribeBedrockAgentCoreRuntime(string runtimeId) => throw new NotImplementedException();
 
         public Task<string> CreateEC2KeyPair(string keyName, string saveLocation) => throw new NotImplementedException();
         public Task<Repository> CreateECRRepository(string repositoryName, string recipeId) => throw new NotImplementedException();

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKVersionDetectorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CDKVersionDetectorTests.cs
@@ -18,9 +18,9 @@ namespace AWS.Deploy.Orchestration.UnitTests.CDK
         }
 
         [Theory]
-        [InlineData("MixedReferences", "2.1035.0")]
-        [InlineData("SameReferences", "2.1034.0")]
-        [InlineData("NoReferences", "2.1033.0")]
+        [InlineData("MixedReferences", "2.1135.0")]
+        [InlineData("SameReferences", "2.1129.0")]
+        [InlineData("NoReferences", "2.1128.0")]
         public void Detect_CSProjPath(string fileName, string expectedVersion)
         {
             var csprojPath = Path.Combine("CDK", "CSProjFiles", fileName);
@@ -38,7 +38,7 @@ namespace AWS.Deploy.Orchestration.UnitTests.CDK
                 "NoReferences"
             }.Select(fileName => Path.Combine("CDK", "CSProjFiles", fileName));
             var version = _cdkVersionDetector.Detect(csprojPaths);
-            Assert.Equal("2.1035.0", version.ToString());
+            Assert.Equal("2.1135.0", version.ToString());
         }
     }
 }

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/MixedReferences
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/MixedReferences
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="2.1035.0" />
+    <PackageReference Include="Amazon.CDK" Version="2.1135.0" />
     <PackageReference Include="Amazon.CDK3P" Version="2.1016.0" />
     <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="2.1014.0" />
     <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="2.1013.0" />

--- a/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/SameReferences
+++ b/test/AWS.Deploy.Orchestration.UnitTests/CDK/CSProjFiles/SameReferences
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="2.1034.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="2.1034.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="2.1034.0" />
+    <PackageReference Include="Amazon.CDK" Version="2.1129.0" />
+    <PackageReference Include="Amazon.CDK.AWS.AppRunner" Version="2.1129.0" />
+    <PackageReference Include="Amazon.CDK.AWS.ECS.Patterns" Version="2.1129.0" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
@@ -232,5 +232,36 @@ namespace AWS.Deploy.Orchestration.UnitTests
             Assert.Equal("UnknownType", resource.Type);
             Assert.Empty(resource.Data);
         }
+
+        [Fact]
+        public async Task GetDeploymentOutputs_BedrockAgentCoreRuntime()
+        {
+            var engine = await BuildRecommendationEngine("AgentCoreWebApp");
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id.Equals("AspNetAppBedrockAgentCore"));
+
+            _stackResource.LogicalResourceId = "RecipeAgentCoreRuntime05BEE1FF";
+            _stackResource.PhysicalResourceId = "Agent1-uW0TMCDBkP";
+            _stackResource.ResourceType = "AWS::BedrockAgentCore::Runtime";
+
+            var mockResponse = new Amazon.BedrockAgentCoreControl.Model.GetAgentRuntimeResponse
+            {
+                AgentRuntimeArn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/Agent1-uW0TMCDBkP"
+            };
+
+            _mockAWSResourceQueryer.Setup(x => x.DescribeCloudFormationResources(It.IsAny<string>())).Returns(Task.FromResult(_stackResources));
+            _mockAWSResourceQueryer.Setup(x => x.DescribeBedrockAgentCoreRuntime(It.IsAny<string>())).Returns(Task.FromResult(mockResponse));
+            var displayedResourcesHandler = new DisplayedResourcesHandler(_mockAWSResourceQueryer.Object, _displayedResourcesFactory);
+
+            var outputs = await displayedResourcesHandler.GetDeploymentOutputs(_cloudApplication, recommendation);
+
+            Assert.Single(outputs);
+            var resource = outputs.First();
+            Assert.Equal("Agent1-uW0TMCDBkP", resource.Id);
+            Assert.Equal("AWS::BedrockAgentCore::Runtime", resource.Type);
+            Assert.Single(resource.Data);
+            Assert.True(resource.Data.ContainsKey("ARN"));
+            Assert.Equal("arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/Agent1-uW0TMCDBkP", resource.Data["ARN"]);
+        }
     }
 }

--- a/testapps/AgentCoreWebApp/AgentCoreWebApp.csproj
+++ b/testapps/AgentCoreWebApp/AgentCoreWebApp.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWS.AgentCore.Hosting" Version="1.0.0" />
+        <PackageReference Include="AWS.AgentCore.Hosting" Version="0.1.0-preview" />
     </ItemGroup>
 
 </Project>

--- a/testapps/AgentCoreWebApp/AgentCoreWebApp.csproj
+++ b/testapps/AgentCoreWebApp/AgentCoreWebApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AWS.AgentCore.Hosting" Version="1.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/testapps/AgentCoreWebApp/Program.cs
+++ b/testapps/AgentCoreWebApp/Program.cs
@@ -4,7 +4,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddAgentCore(options =>
 {
-    options.ModelId = "global.anthropic.claude-sonnet-4-6";
+    options.ModelId = "global.anthropic.claude-opus-4-7";
 });
 
 var app = builder.Build();

--- a/testapps/AgentCoreWebApp/Program.cs
+++ b/testapps/AgentCoreWebApp/Program.cs
@@ -1,0 +1,25 @@
+using AWS.AgentCore.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddAgentCore(options =>
+{
+    options.ModelId = "global.anthropic.claude-sonnet-4-6";
+});
+
+var app = builder.Build();
+
+app.MapAgentCore<PromptRequest>(
+    async (PromptRequest request, Microsoft.Agents.AI.AIAgent agent, CancellationToken ct) =>
+    {
+        var session = await agent.CreateSessionAsync(cancellationToken: ct);
+        var response = await agent.RunAsync(
+            request.Prompt ?? "Say hello in one sentence.",
+            session: session,
+            cancellationToken: ct);
+        return response.ToString();
+    });
+
+app.Run();
+
+public record PromptRequest(string? Prompt);


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8636

## Description of changes

Adds a new deployment recipe to the AWS .NET deployment tool that enables deploying ASP.NET Core applications built with `AWS.AgentCore.Hosting` to Amazon Bedrock AgentCore Runtime as managed container workloads.

  ### What's added

  **New deployment recipe (`AspNetAppBedrockAgentCore`)**
  - Automatically recommended (top priority) when the project references `AWS.AgentCore.Hosting`
  - Builds the application as an arm64 container image, pushes to ECR, and provisions a `AWS::BedrockAgentCore::Runtime` via CDK
  - Marked as `[Experimental]`

  **Recipe settings**
  - **Runtime Name** — defaults to stack name, validated against AgentCore naming rules
  - **Request Headers** — list of HTTP headers to pass through to the agent container
  - **Runtime IAM Role** — create a new opinionated role or provide an existing ARN
  - **Environment Variables** — key-value map injected into the runtime container

  **Default IAM role (when creating new)**
  - Trust policy for `bedrock-agentcore.amazonaws.com` with confused-deputy protection (`aws:SourceAccount` / `aws:SourceArn`)
  - Partition-aware ARNs
  - `AmazonEC2ContainerRegistryReadOnly` + `CloudWatchLogsFullAccess` managed policies
  - `bedrock:InvokeModel*` on cross-region `foundation-model/*` and `inference-profile/*`
  - `bedrock-agentcore:ListEvents` / `CreateEvent` on `memory/*`

  **Post-deployment output**
  - Displays the runtime ARN via a new `BedrockAgentCoreRuntimeResource` displayed-resource handler that calls `GetAgentRuntime` from the AgentCore control-plane SDK

  **Architecture enforcement**
  - Recipe restricts to `arm64` only (AgentCore requirement)
  - Orchestrator now defaults `EnvironmentArchitecture` to the recipe's sole supported architecture when only one is listed

  ### Testing

  - **8 unit tests** (`BedrockAgentCoreRecipeTests`) — recommendation priority, settings validation, architecture constraint, bundle type, IAM defaults
  - **1 displayed-resource unit test** — mocked `GetAgentRuntime` returns ARN correctly
  - **1 integration test** (`AgentCoreDeploymentTests`) — deploys a real agent to AWS, waits for ACTIVE status, invokes via the AgentCore SDK, asserts response, tears down the
  stack

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
