### PR TITLE
feat: use msbuild to evaluate projects

### DIFF
--- a/.autover/changes/b7c4e2a1-9f3d-4a8b-bc5e-2d1a7f8e6c3b.json
+++ b/.autover/changes/b7c4e2a1-9f3d-4a8b-bc5e-2d1a7f8e6c3b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add MSBuild evaluation for accurate project property and package reference resolution. Supports Central Package Management, Directory.Build.props, and conditional properties."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
+++ b/src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs
@@ -8,6 +8,7 @@ using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.Extensions;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
 using AWS.Deploy.Orchestration;
@@ -49,6 +50,7 @@ namespace AWS.Deploy.CLI.Extensions
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IFileManager), typeof(FileManager), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(INPMPackageInitializer), typeof(NPMPackageInitializer), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IOrchestratorInteractiveService), typeof(ConsoleOrchestratorLogger), lifetime));
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(IMSBuildEvaluator), typeof(MSBuildEvaluator), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IProjectDefinitionParser), typeof(ProjectDefinitionParser), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(IProjectParserUtility), typeof(ProjectParserUtility), lifetime));
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(ISystemCapabilityEvaluator), typeof(SystemCapabilityEvaluator), lifetime));

--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -80,14 +80,17 @@ namespace AWS.Deploy.Common
                 return null;
 
             // Prefer MSBuild-evaluated value (handles Directory.Build.props, conditions, etc.)
+            // If the key exists in the evaluation dictionary, trust the result — even if empty.
+            // An empty evaluated value means MSBuild resolved it to empty (e.g. conditional property
+            // that didn't apply), which is the correct answer. Only fall back to XML when the
+            // property wasn't part of the evaluation request at all.
             if (Evaluation?.Properties != null &&
-                Evaluation.Properties.TryGetValue(propertyName, out var evaluatedValue) &&
-                !string.IsNullOrEmpty(evaluatedValue))
+                Evaluation.Properties.TryGetValue(propertyName, out var evaluatedValue))
             {
-                return evaluatedValue;
+                return string.IsNullOrEmpty(evaluatedValue) ? null : evaluatedValue;
             }
 
-            // Fallback to raw XML
+            // Fallback to raw XML for properties not included in the evaluation request
             var propertyValue = Contents.SelectSingleNode($"//PropertyGroup/{propertyName}")?.InnerText;
             return propertyValue;
         }

--- a/src/AWS.Deploy.Common/ProjectDefinition.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinition.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using AWS.Deploy.Common.ProjectEvaluation;
 
 namespace AWS.Deploy.Common
 {
@@ -40,6 +41,13 @@ namespace AWS.Deploy.Common
         public string SdkType { get; set; }
 
         /// <summary>
+        /// The MSBuild-evaluated project data, populated when <c>dotnet msbuild -getProperty/-getItem</c>
+        /// is available. When non-null, query methods prefer this over raw XML for accurate results
+        /// with Central Package Management, Directory.Build.props, and conditions.
+        /// </summary>
+        public EvaluatedProject? Evaluation { get; set; }
+
+        /// <summary>
         /// Value of the TargetFramework property of the project
         /// </summary>
         public string? TargetFramework { get; set; }
@@ -70,16 +78,34 @@ namespace AWS.Deploy.Common
         {
             if (string.IsNullOrEmpty(propertyName))
                 return null;
+
+            // Prefer MSBuild-evaluated value (handles Directory.Build.props, conditions, etc.)
+            if (Evaluation?.Properties != null &&
+                Evaluation.Properties.TryGetValue(propertyName, out var evaluatedValue) &&
+                !string.IsNullOrEmpty(evaluatedValue))
+            {
+                return evaluatedValue;
+            }
+
+            // Fallback to raw XML
             var propertyValue = Contents.SelectSingleNode($"//PropertyGroup/{propertyName}")?.InnerText;
             return propertyValue;
         }
 
-        public string? GetPackageReferenceVersion(string? packageName)
+        public bool HasPackageReference(string? packageName)
         {
             if (string.IsNullOrEmpty(packageName))
-                return null;
-            var packageReference = Contents.SelectSingleNode($"//ItemGroup/PackageReference[@Include='{packageName}']") as XmlElement;
-            return packageReference?.GetAttribute("Version");
+                return false;
+
+            // Prefer MSBuild-evaluated items (handles CPM, conditional PackageReferences, SDK-imported refs)
+            if (Evaluation?.PackageReferences != null)
+            {
+                return Evaluation.PackageReferences.Any(p =>
+                    string.Equals(p.Identity, packageName, System.StringComparison.OrdinalIgnoreCase));
+            }
+
+            // Fallback to raw XML
+            return Contents.SelectSingleNode($"//ItemGroup/PackageReference[@Include='{packageName}']") != null;
         }
 
         private bool CheckIfDockerFileExists(string projectPath)

--- a/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
+++ b/src/AWS.Deploy.Common/ProjectDefinitionParser.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.ProjectEvaluation;
 
 namespace AWS.Deploy.Common
 {
@@ -26,11 +27,13 @@ namespace AWS.Deploy.Common
     {
         private readonly IFileManager _fileManager;
         private readonly IDirectoryManager _directoryManager;
+        private readonly IMSBuildEvaluator _msBuildEvaluator;
 
-        public ProjectDefinitionParser(IFileManager fileManager, IDirectoryManager directoryManager)
+        public ProjectDefinitionParser(IFileManager fileManager, IDirectoryManager directoryManager, IMSBuildEvaluator msBuildEvaluator)
         {
             _fileManager = fileManager;
             _directoryManager = directoryManager;
+            _msBuildEvaluator = msBuildEvaluator;
         }
 
         /// <summary>
@@ -84,20 +87,27 @@ namespace AWS.Deploy.Common
                         "The project file that is being referenced does not contain and 'Sdk' attribute.")
                 );
 
-            var targetFramework = xmlProjectFile.GetElementsByTagName("TargetFramework");
-            if (targetFramework.Count > 0)
-            {
-                projectDefinition.TargetFramework = targetFramework[0]?.InnerText;
-            }
+            // Run MSBuild evaluation for accurate property/item resolution.
+            // This handles Directory.Build.props, Central Package Management, conditions, etc.
+            // Falls back gracefully to raw XML when evaluation is unavailable.
+            projectDefinition.Evaluation = await _msBuildEvaluator.EvaluateAsync(projectPath);
 
-            var assemblyName = xmlProjectFile.GetElementsByTagName("AssemblyName");
-            if (assemblyName.Count > 0)
+            // Populate TargetFramework — prefer evaluated value over raw XML
+            projectDefinition.TargetFramework = projectDefinition.GetMSPropertyValue("TargetFramework")
+                ?? xmlProjectFile.GetElementsByTagName("TargetFramework")[0]?.InnerText;
+
+            // Populate AssemblyName — prefer evaluated value over raw XML
+            var evaluatedAssemblyName = projectDefinition.GetMSPropertyValue("AssemblyName");
+            if (!string.IsNullOrWhiteSpace(evaluatedAssemblyName))
             {
-                projectDefinition.AssemblyName = (string.IsNullOrWhiteSpace(assemblyName[0]?.InnerText) ? Path.GetFileNameWithoutExtension(projectPath) : assemblyName[0]?.InnerText);
+                projectDefinition.AssemblyName = evaluatedAssemblyName;
             }
             else
             {
-                projectDefinition.AssemblyName = Path.GetFileNameWithoutExtension(projectPath);
+                var assemblyName = xmlProjectFile.GetElementsByTagName("AssemblyName");
+                projectDefinition.AssemblyName = assemblyName.Count > 0 && !string.IsNullOrWhiteSpace(assemblyName[0]?.InnerText)
+                    ? assemblyName[0]!.InnerText
+                    : Path.GetFileNameWithoutExtension(projectPath);
             }
 
             return projectDefinition;

--- a/src/AWS.Deploy.Common/ProjectEvaluation/IMSBuildEvaluator.cs
+++ b/src/AWS.Deploy.Common/ProjectEvaluation/IMSBuildEvaluator.cs
@@ -50,7 +50,7 @@ public class EvaluatedPackageReference
 
     /// <summary>
     /// The resolved version (may come from the csproj, Directory.Packages.props, or SDK).
-    /// Null when the version couldn't be resolved (e.g. CPM without a matching entry).
+    /// Empty when the version metadata is not present in the evaluation output.
     /// </summary>
-    public string? Version { get; set; }
+    public string Version { get; set; } = string.Empty;
 }

--- a/src/AWS.Deploy.Common/ProjectEvaluation/IMSBuildEvaluator.cs
+++ b/src/AWS.Deploy.Common/ProjectEvaluation/IMSBuildEvaluator.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.Common.ProjectEvaluation;
+
+/// <summary>
+/// Represents the evaluated (resolved) state of a .NET project as determined by MSBuild.
+/// This accounts for Directory.Build.props, Central Package Management, conditions, and
+/// all other MSBuild evaluation features that raw XML parsing cannot handle.
+/// </summary>
+public interface IMSBuildEvaluator
+{
+    /// <summary>
+    /// Evaluates the specified project and returns the resolved project information.
+    /// </summary>
+    /// <param name="projectPath">Absolute path to the .csproj or .fsproj file.</param>
+    /// <returns>The evaluated project data, or null if evaluation failed.</returns>
+    Task<EvaluatedProject?> EvaluateAsync(string projectPath);
+}
+
+/// <summary>
+/// Contains the fully-evaluated (MSBuild-resolved) project data.
+/// All properties reflect the final values after Directory.Build.props, conditions,
+/// and SDK imports are applied.
+/// </summary>
+public class EvaluatedProject
+{
+    /// <summary>
+    /// Resolved MSBuild properties (TargetFramework, AssemblyName, OutputType, etc.).
+    /// Case-insensitive keys to match MSBuild's property name handling.
+    /// </summary>
+    public Dictionary<string, string> Properties { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolved PackageReference items with their evaluated metadata (including Version
+    /// from Central Package Management when applicable).
+    /// </summary>
+    public List<EvaluatedPackageReference> PackageReferences { get; set; } = new();
+}
+
+/// <summary>
+/// A resolved PackageReference item from MSBuild evaluation.
+/// </summary>
+public class EvaluatedPackageReference
+{
+    /// <summary>
+    /// The package name (the Include attribute value).
+    /// </summary>
+    public string Identity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The resolved version (may come from the csproj, Directory.Packages.props, or SDK).
+    /// Null when the version couldn't be resolved (e.g. CPM without a matching entry).
+    /// </summary>
+    public string? Version { get; set; }
+}

--- a/src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs
+++ b/src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs
@@ -1,0 +1,149 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace AWS.Deploy.Common.ProjectEvaluation;
+
+/// <summary>
+/// Evaluates a .NET project using <c>dotnet msbuild -getProperty -getItem</c> to resolve
+/// all MSBuild evaluation (Directory.Build.props, Central Package Management, conditions, etc.).
+/// Falls back gracefully when the dotnet CLI is unavailable or the project cannot be evaluated.
+/// </summary>
+public class MSBuildEvaluator : IMSBuildEvaluator
+{
+    private static readonly string[] PropertiesToEvaluate =
+    {
+        "TargetFramework",
+        "TargetFrameworks",
+        "AssemblyName",
+        "OutputType",
+        "UsingMicrosoftNETSdkWeb",
+        "AWSProjectType"
+    };
+
+    public async Task<EvaluatedProject?> EvaluateAsync(string projectPath)
+    {
+        try
+        {
+            var args = BuildArguments(projectPath);
+            var output = await RunDotnetMSBuildAsync(args);
+            if (string.IsNullOrWhiteSpace(output))
+                return null;
+
+            return ParseOutput(output);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string BuildArguments(string projectPath)
+    {
+        // Ensure absolute path since we run from a temp working directory
+        var absolutePath = Path.GetFullPath(projectPath);
+        var parts = new List<string> { $"\"{absolutePath}\"" };
+
+        foreach (var prop in PropertiesToEvaluate)
+        {
+            parts.Add($"-getProperty:{prop}");
+        }
+
+        parts.Add("-getItem:PackageReference");
+
+        return string.Join(" ", parts);
+    }
+
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(5);
+
+    private static async Task<string?> RunDotnetMSBuildAsync(string arguments)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"msbuild -nologo {arguments}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            // Run from the system temp directory to avoid inheriting a global.json that
+            // pins to an older SDK (e.g. .NET 6/7) which doesn't support -getProperty/-getItem.
+            // MSBuild resolves Directory.Build.props relative to the project file path, not
+            // the working directory, so project-relative imports still work correctly.
+            WorkingDirectory = Path.GetTempPath()
+        };
+
+        using var process = Process.Start(psi);
+        if (process == null)
+            return null;
+
+        // Read both streams concurrently to prevent deadlocks from filled pipe buffers
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        var exited = await Task.Run(() => process.WaitForExit((int)ProcessTimeout.TotalMilliseconds));
+        if (!exited)
+        {
+            try { process.Kill(); } catch { }
+            return null;
+        }
+
+        var output = await outputTask;
+        await errorTask;
+
+        if (process.ExitCode != 0)
+            return null;
+
+        return output;
+    }
+
+    private static EvaluatedProject? ParseOutput(string json)
+    {
+        var trimmed = json.TrimStart();
+        if (!trimmed.StartsWith("{"))
+            return null;
+
+        using var doc = JsonDocument.Parse(trimmed);
+        var root = doc.RootElement;
+
+        var result = new EvaluatedProject();
+
+        if (root.TryGetProperty("Properties", out var properties))
+        {
+            foreach (var prop in properties.EnumerateObject())
+            {
+                result.Properties[prop.Name] = prop.Value.GetString() ?? string.Empty;
+            }
+        }
+        else if (!root.TryGetProperty("Items", out _))
+        {
+            // Single property response (plain text, not JSON) — happens when only
+            // one -getProperty is passed. We don't hit this path since we always
+            // pass multiple, but handle it defensively.
+            return null;
+        }
+
+        if (root.TryGetProperty("Items", out var items) &&
+            items.TryGetProperty("PackageReference", out var packageRefs))
+        {
+            foreach (var item in packageRefs.EnumerateArray())
+            {
+                var identity = item.TryGetProperty("Identity", out var id) ? id.GetString() : null;
+                if (string.IsNullOrEmpty(identity))
+                    continue;
+
+                var version = item.TryGetProperty("Version", out var ver) ? ver.GetString() : null;
+
+                result.PackageReferences.Add(new EvaluatedPackageReference
+                {
+                    Identity = identity!,
+                    Version = string.IsNullOrEmpty(version) ? null : version
+                });
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs
+++ b/src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs
@@ -134,12 +134,12 @@ public class MSBuildEvaluator : IMSBuildEvaluator
                 if (string.IsNullOrEmpty(identity))
                     continue;
 
-                var version = item.TryGetProperty("Version", out var ver) ? ver.GetString() : null;
+                var version = item.TryGetProperty("Version", out var ver) ? ver.GetString() ?? string.Empty : string.Empty;
 
                 result.PackageReferences.Add(new EvaluatedPackageReference
                 {
                     Identity = identity!,
-                    Version = string.IsNullOrEmpty(version) ? null : version
+                    Version = version
                 });
             }
         }

--- a/src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs
+++ b/src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs
@@ -86,7 +86,7 @@ public class MSBuildEvaluator : IMSBuildEvaluator
         var exited = await Task.Run(() => process.WaitForExit((int)ProcessTimeout.TotalMilliseconds));
         if (!exited)
         {
-            try { process.Kill(); } catch { }
+            try { process.Kill(entireProcessTree: true); } catch { }
             return null;
         }
 
@@ -99,13 +99,16 @@ public class MSBuildEvaluator : IMSBuildEvaluator
         return output;
     }
 
-    private static EvaluatedProject? ParseOutput(string json)
+    private static EvaluatedProject? ParseOutput(string output)
     {
-        var trimmed = json.TrimStart();
-        if (!trimmed.StartsWith("{"))
+        // MSBuild/dotnet may emit leading text (banners, workload notices, warnings)
+        // before the JSON object. Find the first '{' to locate the start of JSON.
+        var jsonStart = output.IndexOf('{');
+        if (jsonStart < 0)
             return null;
 
-        using var doc = JsonDocument.Parse(trimmed);
+        var json = output.Substring(jsonStart);
+        using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
         var result = new EvaluatedProject();

--- a/src/AWS.Deploy.Orchestration/RecommendationEngine/NuGetPackageReferenceTest.cs
+++ b/src/AWS.Deploy.Orchestration/RecommendationEngine/NuGetPackageReferenceTest.cs
@@ -11,7 +11,7 @@ namespace AWS.Deploy.Orchestration.RecommendationEngine
 
         public override Task<bool> Execute(RecommendationTestInput input)
         {
-            var result = !string.IsNullOrEmpty(input.ProjectDefinition.GetPackageReferenceVersion(input.Test.Condition.NuGetPackageName));
+            var result = input.ProjectDefinition.HasPackageReference(input.Test.Condition.NuGetPackageName);
             return Task.FromResult(result);
         }
     }

--- a/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.Common.UnitTests/ConfigFileDeployment/DeploymentSettingsHandlerTests.cs
@@ -10,6 +10,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using Moq;
@@ -44,7 +45,7 @@ namespace AWS.Deploy.CLI.Common.UnitTests.ConfigFileDeployment
             _deploymentManifestEngine = new DeploymentManifestEngine(_directoryManager, _fileManager);
             _orchestratorInteractiveService = new Mock<IOrchestratorInteractiveService>().Object;
 
-            var parser = new ProjectDefinitionParser(_fileManager, _directoryManager);
+            var parser = new ProjectDefinitionParser(_fileManager, _directoryManager, new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             _orchestratorSession = new OrchestratorSession(
                 parser.Parse(_projectPath).Result,

--- a/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.IntegrationTests/SaveCdkDeploymentProject/RecommendationTests.cs
@@ -26,6 +26,7 @@ using AWS.Deploy.Orchestration.LocalUserSettings;
 using AWS.Deploy.Orchestration.Utilities;
 using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration.Docker;
 
 namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
@@ -246,7 +247,7 @@ namespace AWS.Deploy.CLI.IntegrationTests.SaveCdkDeploymentProject
             var validatorFactory = new ValidatorFactory(serviceProvider.Object);
             var optionSettingHandler = new OptionSettingHandler(validatorFactory);
             var recipeHandler = new RecipeHandler(deploymentManifestEngine, _inMemoryInteractiveService, directoryManager, fileManager, optionSettingHandler, validatorFactory);
-            var projectDefinition = await new ProjectDefinitionParser(fileManager, directoryManager).Parse(targetApplicationProjectPath);
+            var projectDefinition = await new ProjectDefinitionParser(fileManager, directoryManager, new MSBuildEvaluator()).Parse(targetApplicationProjectPath);
             var session = new OrchestratorSession(projectDefinition);
 
             return new Orchestrator(session,

--- a/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ApplyPreviousSettingsTests.cs
@@ -23,6 +23,7 @@ using AWS.Deploy.Common.Data;
 using Amazon.CloudControlApi.Model;
 using Amazon.ElasticBeanstalk.Model;
 using AWS.Deploy.Common.DeploymentManifest;
+using AWS.Deploy.Common.ProjectEvaluation;
 
 namespace AWS.Deploy.CLI.UnitTests
 {
@@ -62,7 +63,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-            var parser = new ProjectDefinitionParser(_fileManager, _directoryManager);
+            var parser = new ProjectDefinitionParser(_fileManager, _directoryManager, new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             var session =  new OrchestratorSession(
                 await parser.Parse(fullPath),

--- a/test/AWS.Deploy.CLI.UnitTests/BedrockAgentCoreRecipeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/BedrockAgentCoreRecipeTests.cs
@@ -9,6 +9,7 @@ using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using Moq;
 using Xunit;
@@ -30,7 +31,7 @@ namespace AWS.Deploy.CLI.UnitTests
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(serviceProvider.Object));
             _directoryManager = new DirectoryManager();
             _fileManager = new FileManager();
-            _projectDefinitionParser = new ProjectDefinitionParser(_fileManager, _directoryManager);
+            _projectDefinitionParser = new ProjectDefinitionParser(_fileManager, _directoryManager, new MSBuildEvaluator());
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DeploymentBundleHandlerTests.cs
@@ -16,6 +16,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Constants;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
@@ -57,7 +58,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var validatorFactory = new ValidatorFactory(serviceProvider);
             var optionSettingHandler = new OptionSettingHandler(validatorFactory);
             _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager, _fileManager, optionSettingHandler, validatorFactory);
-            _projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            _projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var systemCapabilityEvaluatorMock = new Mock<ISystemCapabilityEvaluator>();
             systemCapabilityEvaluatorMock.Setup(x => x.GetInstalledContainerAppInfo(It.IsAny<Recommendation>())).ReturnsAsync(new ContainerAppInfo("Docker", "", true, ""));
             _systemCapabilityEvaluator = systemCapabilityEvaluatorMock.Object;
@@ -444,7 +445,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             var session =  new OrchestratorSession(
                 await parser.Parse(fullPath),

--- a/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/DockerTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using AWS.Deploy.CLI.Common.UnitTests.IO;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.ProjectEvaluation;
 using Should;
 using Xunit;
 using AWS.Deploy.CLI.UnitTests.Utilities;
@@ -98,7 +99,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var recommendations = await recommendationEngine.ComputeRecommendations();
             var selectedRecommendation = recommendations.First();
 
-            var projectDefinition = await new ProjectDefinitionParser(fileManager, new DirectoryManager()).Parse(projectPath);
+            var projectDefinition = await new ProjectDefinitionParser(fileManager, new DirectoryManager(), new MSBuildEvaluator()).Parse(projectPath);
 
             var engine = new DockerEngine(projectDefinition, fileManager, new TestDirectoryManager());
 

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingTests.cs
@@ -14,6 +14,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -58,7 +59,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             var session =  new OrchestratorSession(
                 await parser.Parse(fullPath),

--- a/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingsMapTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/GetOptionSettingsMapTests.cs
@@ -10,6 +10,7 @@ using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using Moq;
 using Xunit;
@@ -30,7 +31,7 @@ namespace AWS.Deploy.CLI.UnitTests
             _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(_serviceProvider.Object));
             _directoryManager = new DirectoryManager();
             _fileManager = new FileManager();
-            _projectDefinitionParser = new ProjectDefinitionParser(_fileManager, _directoryManager);
+            _projectDefinitionParser = new ProjectDefinitionParser(_fileManager, _directoryManager, new MSBuildEvaluator());
         }
 
         [Fact]

--- a/test/AWS.Deploy.CLI.UnitTests/ProjectEvaluation/MSBuildEvaluatorTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ProjectEvaluation/MSBuildEvaluatorTests.cs
@@ -1,0 +1,237 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.ProjectEvaluation;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests.ProjectEvaluation
+{
+    public class MSBuildEvaluatorTests
+    {
+        [Fact]
+        public async Task EvaluateAsync_ReturnsProperties_ForValidProject()
+        {
+            var evaluator = new MSBuildEvaluator();
+            var projectPath = Utilities.SystemIOUtilities.ResolvePath("AgentCoreWebApp");
+            var csproj = System.IO.Directory.GetFiles(projectPath, "*.csproj")[0];
+
+            var result = await evaluator.EvaluateAsync(csproj);
+
+            Assert.NotNull(result);
+            Assert.True(result!.Properties.ContainsKey("TargetFramework"));
+            Assert.Equal("net10.0", result.Properties["TargetFramework"]);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_ReturnsPackageReferences()
+        {
+            var evaluator = new MSBuildEvaluator();
+            var projectPath = Utilities.SystemIOUtilities.ResolvePath("AgentCoreWebApp");
+            var csproj = System.IO.Directory.GetFiles(projectPath, "*.csproj")[0];
+
+            var result = await evaluator.EvaluateAsync(csproj);
+
+            Assert.NotNull(result);
+            Assert.Contains(result!.PackageReferences, p =>
+                p.Identity == "AWS.AgentCore.Hosting");
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_WorksWithCPM_NoVersionAttribute()
+        {
+            var evaluator = new MSBuildEvaluator();
+            var projectPath = Utilities.SystemIOUtilities.ResolvePath("AgentCoreWebAppCPM");
+            var csproj = System.IO.Directory.GetFiles(projectPath, "*.csproj")[0];
+
+            var result = await evaluator.EvaluateAsync(csproj);
+
+            Assert.NotNull(result);
+            Assert.Contains(result!.PackageReferences, p =>
+                p.Identity == "AWS.AgentCore.Hosting");
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_ReturnsNull_ForNonExistentProject()
+        {
+            var evaluator = new MSBuildEvaluator();
+
+            var result = await evaluator.EvaluateAsync("/nonexistent/path/fake.csproj");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ProjectDefinition_GetMSPropertyValue_PrefersEvaluation()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net6.0</TargetFramework></PropertyGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject
+                {
+                    Properties = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["TargetFramework"] = "net8.0"
+                    }
+                }
+            };
+
+            // Evaluation says net8.0, XML says net6.0 — evaluation wins
+            Assert.Equal("net8.0", projectDef.GetMSPropertyValue("TargetFramework"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_GetMSPropertyValue_FallsBackToXml_WhenEvaluationNull()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net6.0</TargetFramework></PropertyGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = null
+            };
+
+            Assert.Equal("net6.0", projectDef.GetMSPropertyValue("TargetFramework"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_GetMSPropertyValue_FallsBackToXml_WhenPropertyNotInEvaluation()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><CustomProp>hello</CustomProp></PropertyGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject
+                {
+                    Properties = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["TargetFramework"] = "net8.0"
+                    }
+                }
+            };
+
+            // CustomProp not in evaluation → falls back to XML
+            Assert.Equal("hello", projectDef.GetMSPropertyValue("CustomProp"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_GetMSPropertyValue_CaseInsensitive()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup></PropertyGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject
+                {
+                    Properties = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["TargetFramework"] = "net10.0"
+                    }
+                }
+            };
+
+            // Query with different casing
+            Assert.Equal("net10.0", projectDef.GetMSPropertyValue("targetframework"));
+            Assert.Equal("net10.0", projectDef.GetMSPropertyValue("TARGETFRAMEWORK"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_HasPackageReference_PrefersEvaluation()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup></ItemGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject
+                {
+                    PackageReferences = new List<EvaluatedPackageReference>
+                    {
+                        new() { Identity = "AWS.AgentCore.Hosting", Version = "1.0.0" }
+                    }
+                }
+            };
+
+            // Not in XML but in evaluation → found
+            Assert.True(projectDef.HasPackageReference("AWS.AgentCore.Hosting"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_HasPackageReference_CaseInsensitive()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup></ItemGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject
+                {
+                    PackageReferences = new List<EvaluatedPackageReference>
+                    {
+                        new() { Identity = "AWS.AgentCore.Hosting" }
+                    }
+                }
+            };
+
+            Assert.True(projectDef.HasPackageReference("aws.agentcore.hosting"));
+            Assert.True(projectDef.HasPackageReference("AWS.AGENTCORE.HOSTING"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_HasPackageReference_FallsBackToXml_WhenEvaluationNull()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><PackageReference Include=\"Foo\" Version=\"1.0\" /></ItemGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = null
+            };
+
+            Assert.True(projectDef.HasPackageReference("Foo"));
+            Assert.False(projectDef.HasPackageReference("Bar"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_HasPackageReference_ReturnsFalse_WhenPackageNotFound()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup></ItemGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject
+                {
+                    PackageReferences = new List<EvaluatedPackageReference>
+                    {
+                        new() { Identity = "SomeOtherPackage" }
+                    }
+                }
+            };
+
+            Assert.False(projectDef.HasPackageReference("AWS.AgentCore.Hosting"));
+        }
+
+        [Fact]
+        public void ProjectDefinition_HasPackageReference_HandlesNullAndEmpty()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup></ItemGroup></Project>");
+
+            var projectDef = new ProjectDefinition(xml, "/fake/path.csproj", "", "Microsoft.NET.Sdk")
+            {
+                Evaluation = new EvaluatedProject()
+            };
+
+            Assert.False(projectDef.HasPackageReference(null));
+            Assert.False(projectDef.HasPackageReference(""));
+        }
+    }
+}

--- a/test/AWS.Deploy.CLI.UnitTests/ProjectParserUtilityTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ProjectParserUtilityTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using AWS.Deploy.CLI.UnitTests.Utilities;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.ProjectEvaluation;
 using Xunit;
 using Should;
 using AWS.Deploy.CLI.Utilities;
@@ -36,7 +37,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
             var relativeProjectDirectoryPath = Path.GetRelativePath(currrentWorkingDirectory!, absoluteProjectDirectoryPath);
             var projectSolutionPath = SystemIOUtilities.ResolvePathToSolution();
-            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var projectParserUtility = new ProjectParserUtility(projectDefinitionParser, new DirectoryManager());
 
             // Act
@@ -64,7 +65,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var absoluteProjectDirectoryPath = new DirectoryInfo(projectDirectoryPath).FullName;
             var absoluteProjectPath = Path.Combine(absoluteProjectDirectoryPath, csprojName);
             var projectSolutionPath = SystemIOUtilities.ResolvePathToSolution();
-            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var projectParserUtility = new ProjectParserUtility(projectDefinitionParser, new DirectoryManager());
 
             // Act
@@ -82,7 +83,7 @@ namespace AWS.Deploy.CLI.UnitTests
         public async Task Throws_FailedToFindDeployableTargetException_WithInvalidProjectPaths(string projectPath)
         {
             // Arrange
-            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var projectParserUtility = new ProjectParserUtility(projectDefinitionParser, new DirectoryManager());
 
             // Act and Assert

--- a/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/RecommendationTests.cs
@@ -16,6 +16,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -68,7 +69,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             _session =  new OrchestratorSession(
                 await parser.Parse(fullPath),
@@ -495,7 +496,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var projectPath = SystemIOUtilities.ResolvePath("MessageProcessingApp");
 
-            var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager()).Parse(projectPath);
+            var projectDefinition = await new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator()).Parse(projectPath);
 
             var test = new NuGetPackageReferenceTest();
 

--- a/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/ServerModeTests.cs
@@ -25,6 +25,7 @@ using DeploymentTypes = AWS.Deploy.CLI.ServerMode.Models.DeploymentTypes;
 using System;
 using AWS.Deploy.CLI.Commands.Settings;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Recipes;
 
 namespace AWS.Deploy.CLI.UnitTests
@@ -93,7 +94,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var validatorFactory = new ValidatorFactory(serviceProvider.Object);
             var optionSettingHandler = new OptionSettingHandler(validatorFactory);
             var recipeHandler = new RecipeHandler(deploymentManifestEngine, consoleOrchestratorLogger, directoryManager, fileManager, optionSettingHandler, validatorFactory);
-            var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager);
+            var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager, new MSBuildEvaluator());
 
             var recipeController = new RecipeController(recipeHandler, projectDefinitionParser);
             var response = await recipeController.GetRecipe(recipeId);
@@ -109,7 +110,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var deploymentManifestEngine = new DeploymentManifestEngine(directoryManager, fileManager);
             var consoleInteractiveServiceImpl = new ConsoleInteractiveServiceImpl();
             var consoleOrchestratorLogger = new ConsoleOrchestratorLogger(consoleInteractiveServiceImpl);
-            var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager);
+            var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager, new MSBuildEvaluator());
             var serviceProvider = new Mock<IServiceProvider>();
             var validatorFactory = new ValidatorFactory(serviceProvider.Object);
             var optionSettingHandler = new OptionSettingHandler(validatorFactory);
@@ -131,7 +132,7 @@ namespace AWS.Deploy.CLI.UnitTests
         {
             var directoryManager = new DirectoryManager();
             var fileManager = new FileManager();
-            var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager);
+            var projectDefinitionParser = new ProjectDefinitionParser(fileManager, directoryManager, new MSBuildEvaluator());
 
             var deploymentManifestEngine = new Mock<IDeploymentManifestEngine>();
             var serviceProvider = new Mock<IServiceProvider>();

--- a/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/SetOptionSettingTests.cs
@@ -13,6 +13,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using AWS.Deploy.Recipes;
@@ -46,7 +47,7 @@ namespace AWS.Deploy.CLI.UnitTests
             var optionSettingHandler = new OptionSettingHandler(validatorFactory);
             _recipeHandler = new RecipeHandler(_deploymentManifestEngine, _orchestratorInteractiveService, _directoryManager, _fileManager, optionSettingHandler, validatorFactory);
 
-            var parser = new ProjectDefinitionParser(new FileManager(), _directoryManager);
+            var parser = new ProjectDefinitionParser(new FileManager(), _directoryManager, new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             var session =  new OrchestratorSession(
                 parser.Parse(projectPath).Result,

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintTests.cs
@@ -27,6 +27,7 @@ using Moq;
 using Xunit;
 using AWS.Deploy.Common.Data;
 using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.ProjectEvaluation;
 using Should;
 
 namespace AWS.Deploy.CLI.UnitTests
@@ -178,7 +179,7 @@ namespace AWS.Deploy.CLI.UnitTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()).Object;
-            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await projectDefinitionParser.Parse(projectPath);
             recipeDefinition.SupportedArchitectures = archList;
@@ -220,7 +221,7 @@ namespace AWS.Deploy.CLI.UnitTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()).Object;
-            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await projectDefinitionParser.Parse(projectPath);
             var recommendation = new Recommendation(recipeDefinition, project, 0, new Dictionary<string, object>());
@@ -263,7 +264,7 @@ namespace AWS.Deploy.CLI.UnitTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()).Object;
-            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var projectDefinitionParser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var projectPath = SystemIOUtilities.ResolvePath("ConsoleAppTask");
             var project = await projectDefinitionParser.Parse(projectPath);
             var recommendation = new Recommendation(recipeDefinition, project, 0, new Dictionary<string, object>());

--- a/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/Utilities/HelperFunctions.cs
@@ -8,6 +8,7 @@ using AWS.Deploy.Common;
 using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration;
 using AWS.Deploy.Orchestration.RecommendationEngine;
 using Moq;
@@ -50,7 +51,7 @@ namespace AWS.Deploy.CLI.UnitTests.Utilities
             var optionSettingHandler = new OptionSettingHandler(validatorFactory);
             var recipeHandler = new RecipeHandler(deploymentManifestEngine, orchestratorInteractiveService, directoryManager, fileManager, optionSettingHandler, validatorFactory);
 
-            var parser = new ProjectDefinitionParser(fileManager, directoryManager);
+            var parser = new ProjectDefinitionParser(fileManager, directoryManager, new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             var session = new OrchestratorSession(
                 await parser.Parse(fullPath),

--- a/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/DisplayedResourcesHandlerTests.cs
@@ -14,6 +14,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration.Data;
 using AWS.Deploy.Orchestration.DisplayedResources;
 using AWS.Deploy.Orchestration.UnitTests.Utilities;
@@ -63,7 +64,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             _session = new OrchestratorSession(
                 await parser.Parse(fullPath),

--- a/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/ElasticBeanstalkHandlerTests.cs
@@ -16,6 +16,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration.ServiceHandlers;
 using AWS.Deploy.Orchestration.UnitTests.Utilities;
 using AWS.Deploy.Recipes;
@@ -156,7 +157,7 @@ namespace AWS.Deploy.Orchestration.UnitTests
         {
             var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+            var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
             var awsCredentials = new Mock<AWSCredentials>();
             var session = new OrchestratorSession(
                 await parser.Parse(fullPath),

--- a/test/AWS.Deploy.Orchestration.UnitTests/OrchestratorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/OrchestratorTests.cs
@@ -10,6 +10,7 @@ using AWS.Deploy.Common.DeploymentManifest;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
 using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration.UnitTests.Utilities;
 using Moq;
 using Xunit;
@@ -41,7 +42,7 @@ public class OrchestratorTests
     {
         var fullPath = SystemIOUtilities.ResolvePath(testProjectName);
 
-        var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager());
+        var parser = new ProjectDefinitionParser(new FileManager(), new DirectoryManager(), new MSBuildEvaluator());
         var awsCredentials = new Mock<AWSCredentials>();
         _session = new OrchestratorSession(
             await parser.Parse(fullPath),

--- a/test/AWS.Deploy.Orchestration.UnitTests/Utilities/CloudApplicationNameGeneratorTests.cs
+++ b/test/AWS.Deploy.Orchestration.UnitTests/Utilities/CloudApplicationNameGeneratorTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using AWS.Deploy.Common;
 using AWS.Deploy.Common.IO;
 using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.ProjectEvaluation;
 using AWS.Deploy.Orchestration.Utilities;
 using Moq;
 using Should;
@@ -28,7 +29,7 @@ namespace AWS.Deploy.Orchestration.UnitTests.Utilities
             _fakeFileManager = new TestFileManager();
             _mockDirectoryManager = new Mock<IDirectoryManager>();
 
-            _projectDefinitionParser = new ProjectDefinitionParser(_fakeFileManager, _mockDirectoryManager.Object);
+            _projectDefinitionParser = new ProjectDefinitionParser(_fakeFileManager, _mockDirectoryManager.Object, new MSBuildEvaluator());
 
             _cloudApplicationNameGenerator = new CloudApplicationNameGenerator(_fakeFileManager, _mockDirectoryManager.Object);
         }

--- a/testapps/AgentCoreWebAppCPM/AgentCoreWebAppCPM.csproj
+++ b/testapps/AgentCoreWebAppCPM/AgentCoreWebAppCPM.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AWS.AgentCore.Hosting" />
+    </ItemGroup>
+
+</Project>

--- a/testapps/AgentCoreWebAppCPM/Directory.Packages.props
+++ b/testapps/AgentCoreWebAppCPM/Directory.Packages.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="AWS.AgentCore.Hosting" Version="0.1.0-preview" />
+    </ItemGroup>
+</Project>

--- a/testapps/AgentCoreWebAppCPM/Program.cs
+++ b/testapps/AgentCoreWebAppCPM/Program.cs
@@ -1,0 +1,4 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/ping", () => "Healthy");
+app.Run();


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6736

### Problem

The deploy tool reads project metadata (TargetFramework, PackageReferences, etc.) by parsing the `.csproj` XML directly. This breaks for modern .NET project features where the information isn't self-contained in the csproj:

  - **Central Package Management (CPM)** — `<PackageReference Include="Foo" />` without a `Version` attribute (version lives in `Directory.Packages.props`)
  - **Directory.Build.props** — shared properties like `TargetFramework` defined in a parent directory
  - **Conditional properties** — `<TargetFramework Condition="...">` that require MSBuild evaluation to resolve
  - **SDK-imported items** — implicit package references added by the SDK

This caused the AgentCore recipe's `NuGetPackageReference` recommendation rule to fail for CPM projects, since the old code checked `!string.IsNullOrEmpty(GetPackageReferenceVersion(...))` which returned empty for version-less PackageReference elements.

### Solution

Added an `IMSBuildEvaluator` that shells out to `dotnet msbuild -nologo -getProperty -getItem` to get the fully-evaluated project state from MSBuild itself. This resolves all imports, conditions, and CPM versioning correctly.

**Key design decisions:**

  - **Augment, not replace** — the `XmlDocument Contents` property stays on `ProjectDefinition`. Query methods (`GetMSPropertyValue`, `HasPackageReference`) prefer evaluated data when available, with XML fallback.
  - **Evaluate once during `Parse()`** — ~600ms one-time cost, results cached on `ProjectDefinition.Evaluation`.
  - **Graceful fallback** — if `dotnet msbuild` fails (SDK too old, malformed project, missing dotnet), evaluation returns `null` and all queries fall back to raw XML parsing. No user-visible error.
  - **global.json safety** — runs the subprocess from `Path.GetTempPath()` as the working directory to avoid inheriting a `global.json` that pins to .NET 6/7 (which don't support `-getProperty`). MSBuild still resolves `Directory.Build.props` relative to the project file path.
  - **Registered in DI** — `IMSBuildEvaluator` is registered in the service collection and injected into `ProjectDefinitionParser`. Mockable for tests.

### Compatibility

  | Environment | Behavior |
  |---|---|
  | .NET 8+ SDK on machine | Full MSBuild evaluation — CPM, Directory.Build.props, conditions all resolved |
  | .NET 6/7 SDK (via global.json) | global.json bypassed by temp CWD; uses system's .NET 8+ SDK for evaluation |
  | No dotnet on PATH | Graceful fallback to XML parsing (same behavior as before) |
  | Malformed projects | Graceful fallback to XML parsing |

  ### Changes

  **New files:**
  - `src/AWS.Deploy.Common/ProjectEvaluation/IMSBuildEvaluator.cs` — interface + `EvaluatedProject` / `EvaluatedPackageReference` models
  - `src/AWS.Deploy.Common/ProjectEvaluation/MSBuildEvaluator.cs` — implementation with process timeout, deadlock prevention, `-nologo`, and JSON parsing
  - `test/AWS.Deploy.CLI.UnitTests/ProjectEvaluation/MSBuildEvaluatorTests.cs` — 13 tests covering evaluation, fallback, case sensitivity, CPM

  **Modified files:**
  - `src/AWS.Deploy.Common/ProjectDefinition.cs` — added `Evaluation` property; `GetMSPropertyValue()` and `HasPackageReference()` prefer evaluated data with XML fallback
  - `src/AWS.Deploy.Common/ProjectDefinitionParser.cs` — accepts `IMSBuildEvaluator` via DI; calls `EvaluateAsync()` during `Parse()`
  - `src/AWS.Deploy.CLI/Extensions/CustomServiceCollectionExtension.cs` — registers `IMSBuildEvaluator` in DI
  - `src/AWS.Deploy.Orchestration/RecommendationEngine/NuGetPackageReferenceTest.cs` — uses `HasPackageReference()` instead of checking version string
  - All 18 test files — updated `ProjectDefinitionParser` construction to pass `MSBuildEvaluator` explicitly

  **Test fixture:**
  - `testapps/AgentCoreWebAppCPM/` — minimal project with CPM-style `<PackageReference Include="AWS.AgentCore.Hosting" />` (no Version)

  ### Testing

  - 223 CLI unit tests pass (including 13 new MSBuild evaluator tests)
  - 116 orchestration unit tests pass
  - 221 common unit tests pass
  - CPM detection verified end-to-end via `RecipeIsRecommended_WhenProjectUsesCentralPackageManagement` test

  ### Breaking Changes

  None to external consumers. The `ProjectDefinitionParser` constructor now requires `IMSBuildEvaluator` as a third parameter, but this is an internal type resolved via DI. The two-parameter constructor was removed; all internal call sites updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
