### PR TITLE
feat: add vpc configuration for agentcore recipe

### DIFF
--- a/.autover/changes/c8d2f4a6-1b3e-4c7d-9a5f-3e8b1c6d7f2a.json
+++ b/.autover/changes/c8d2f4a6-1b3e-4c7d-9a5f-3e8b1c6d7f2a.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Deploy.CLI",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add VPC configuration support for the AgentCore deployment recipe. Users can opt-in to place the runtime in a VPC for access to private resources."
+      ]
+    }
+  ]
+}

--- a/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon Bedrock AgentCore Runtime (Experimental).md
+++ b/site/content/docs/cicd/recipes/ASP.NET Core App to Amazon Bedrock AgentCore Runtime (Experimental).md
@@ -25,6 +25,27 @@
             * ID: MemoryId
             * Description: The ID of an existing AgentCore Memory resource to use. The agent will read/write conversation history to this memory.
             * Type: String
+* **Virtual Private Cloud (VPC)**
+    * ID: VPC
+    * Description: A VPC enables you to place the AgentCore Runtime into a virtual network for access to private resources. Not required for most deployments.
+    * Type: Object
+    * Settings:
+        * **Use a VPC**
+            * ID: UseVPC
+            * Description: Do you want to place the AgentCore Runtime in a VPC?
+            * Type: Bool
+        * **Create New VPC**
+            * ID: CreateNew
+            * Description: Do you want to create a new VPC?
+            * Type: Bool
+        * **VPC ID**
+            * ID: VpcId
+            * Description: The ID of the VPC to use.
+            * Type: String
+        * **Security Groups**
+            * ID: SecurityGroups
+            * Description: A list of EC2 security groups to assign to the AgentCore Runtime. This is commonly used to provide access to resources like Amazon RDS or ElastiCache running in their own security groups.
+            * Type: List
 * **Runtime IAM Role**
     * ID: RuntimeIAMRole
     * Description: The Identity and Access Management (IAM) role that provides AWS credentials to the AgentCore Runtime. When creating a new role, it includes permissions for ECR pull, CloudWatch Logs, Bedrock model invocation (cross-region), and AgentCore Memory access.

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/AgentCoreVpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/AgentCoreVpcCommand.cs
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.Extensions;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.Common;
+using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.TypeHintData;
+
+namespace AWS.Deploy.CLI.Commands.TypeHints
+{
+    public class AgentCoreVpcCommand : ITypeHintCommand
+    {
+        private readonly IAWSResourceQueryer _awsResourceQueryer;
+        private readonly IConsoleUtilities _consoleUtilities;
+        private readonly IToolInteractiveService _toolInteractiveService;
+
+        public AgentCoreVpcCommand(IAWSResourceQueryer awsResourceQueryer, IConsoleUtilities consoleUtilities, IToolInteractiveService toolInteractiveService)
+        {
+            _awsResourceQueryer = awsResourceQueryer;
+            _consoleUtilities = consoleUtilities;
+            _toolInteractiveService = toolInteractiveService;
+        }
+
+        public async Task<TypeHintResourceTable> GetResources(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            var vpcs = await _awsResourceQueryer.GetListOfVpcs() ?? new List<Vpc>();
+            var resourceTable = new TypeHintResourceTable
+            {
+                Rows = vpcs
+                    .Select(x => new TypeHintResource(x.VpcId, x.GetDisplayableVpc()))
+                    .ToList()
+            };
+            return resourceTable;
+        }
+
+        public async Task<object> Execute(Recommendation recommendation, OptionSettingItem optionSetting)
+        {
+            _toolInteractiveService.WriteLine();
+
+            var useVpcAnswer = _consoleUtilities.AskYesNoQuestion(
+                "Do you want to place the AgentCore Runtime in a VPC?", "false");
+
+            if (useVpcAnswer == YesNo.No)
+            {
+                return new AgentCoreVpcTypeHintResponse { UseVPC = false };
+            }
+
+            var vpcs = await _awsResourceQueryer.GetListOfVpcs() ?? new List<Vpc>();
+
+            if (!vpcs.Any())
+            {
+                _toolInteractiveService.WriteLine();
+                _toolInteractiveService.WriteLine("There are no VPCs in the selected account. A new one will be created.");
+                return new AgentCoreVpcTypeHintResponse { UseVPC = true, CreateNew = true };
+            }
+
+            _toolInteractiveService.WriteLine();
+
+            var currentResponse = optionSetting.GetTypeHintData<AgentCoreVpcTypeHintResponse>();
+            var userInputConfig = new UserInputConfiguration<Vpc>(
+                idSelector: vpc => vpc.VpcId,
+                displaySelector: vpc => vpc.GetDisplayableVpc(),
+                defaultSelector: vpc =>
+                    !string.IsNullOrEmpty(currentResponse?.VpcId)
+                        ? vpc.VpcId == currentResponse.VpcId
+                        : vpc.IsDefault ?? false)
+            {
+                CanBeEmpty = false,
+                CreateNew = true
+            };
+
+            var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(
+                vpcs, "Select a VPC:", userInputConfig);
+
+            if (userResponse.CreateNew)
+            {
+                return new AgentCoreVpcTypeHintResponse { UseVPC = true, CreateNew = true };
+            }
+
+            return new AgentCoreVpcTypeHintResponse
+            {
+                UseVPC = true,
+                CreateNew = false,
+                VpcId = userResponse.SelectedOption!.VpcId
+            };
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/AgentCoreVpcCommand.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/AgentCoreVpcCommand.cs
@@ -40,8 +40,10 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
         {
             _toolInteractiveService.WriteLine();
 
+            var currentResponse = optionSetting.GetTypeHintData<AgentCoreVpcTypeHintResponse>();
+            var currentUseVpc = currentResponse?.UseVPC ?? false;
             var useVpcAnswer = _consoleUtilities.AskYesNoQuestion(
-                "Do you want to place the AgentCore Runtime in a VPC?", "false");
+                "Do you want to place the AgentCore Runtime in a VPC?", currentUseVpc ? "true" : "false");
 
             if (useVpcAnswer == YesNo.No)
             {
@@ -59,7 +61,6 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
 
             _toolInteractiveService.WriteLine();
 
-            var currentResponse = optionSetting.GetTypeHintData<AgentCoreVpcTypeHintResponse>();
             var userInputConfig = new UserInputConfiguration<Vpc>(
                 idSelector: vpc => vpc.VpcId,
                 displaySelector: vpc => vpc.GetDisplayableVpc(),
@@ -75,17 +76,51 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
             var userResponse = _consoleUtilities.AskUserToChooseOrCreateNew(
                 vpcs, "Select a VPC:", userInputConfig);
 
-            if (userResponse.CreateNew)
+            if (userResponse.CreateNew || userResponse.SelectedOption == null)
             {
                 return new AgentCoreVpcTypeHintResponse { UseVPC = true, CreateNew = true };
             }
+
+            var selectedVpcId = userResponse.SelectedOption.VpcId;
+
+            // Ask for security groups in the selected VPC
+            var securityGroups = await AskForSecurityGroups(selectedVpcId, optionSetting, recommendation);
 
             return new AgentCoreVpcTypeHintResponse
             {
                 UseVPC = true,
                 CreateNew = false,
-                VpcId = userResponse.SelectedOption!.VpcId
+                VpcId = selectedVpcId,
+                SecurityGroups = securityGroups
             };
+        }
+
+        private async Task<SortedSet<string>> AskForSecurityGroups(string vpcId, OptionSettingItem optionSetting, Recommendation recommendation)
+        {
+            var availableSecurityGroups = (await _awsResourceQueryer.DescribeSecurityGroups(vpcId) ?? new List<SecurityGroup>())
+                .OrderBy(x => x.GroupName)
+                .ToList();
+
+            if (!availableSecurityGroups.Any())
+                return new SortedSet<string>();
+
+            var groupNamePadding = availableSecurityGroups.Max(x => x.GroupName.Length);
+
+            var userInputConfig = new UserInputConfiguration<SecurityGroup>(
+                idSelector: sg => sg.GroupId,
+                displaySelector: sg => $"{sg.GroupName.PadRight(groupNamePadding)} | {sg.GroupId.PadRight(20)} | {sg.VpcId}",
+                defaultSelector: sg => false)
+            {
+                CanBeEmpty = true,
+                CreateNew = false
+            };
+
+            var securityGroupsOptionSetting = optionSetting.ChildOptionSettings.FirstOrDefault(x => x.Id.Equals("SecurityGroups"));
+            _toolInteractiveService.WriteLine();
+            _toolInteractiveService.WriteLine("Security Groups:");
+            _toolInteractiveService.WriteLine(securityGroupsOptionSetting?.Description ?? "Select security groups to assign to the AgentCore Runtime.");
+
+            return _consoleUtilities.AskUserForList(userInputConfig, availableSecurityGroups, securityGroupsOptionSetting ?? optionSetting, recommendation);
         }
     }
 }

--- a/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
+++ b/src/AWS.Deploy.CLI/Commands/TypeHints/TypeHintCommandFactory.cs
@@ -74,6 +74,7 @@ namespace AWS.Deploy.CLI.Commands.TypeHints
                 { OptionSettingTypeHint.ElasticBeanstalkVpc, ActivatorUtilities.CreateInstance<ElasticBeanstalkVpcCommand>(serviceProvider) },
                 { OptionSettingTypeHint.DockerHttpPort, ActivatorUtilities.CreateInstance<DockerHttpPortCommand>(serviceProvider) },
                 { OptionSettingTypeHint.EnvironmentArchitecture, ActivatorUtilities.CreateInstance<EnvironmentArchitectureCommand>(serviceProvider) },
+                { OptionSettingTypeHint.AgentCoreVpc, ActivatorUtilities.CreateInstance<AgentCoreVpcCommand>(serviceProvider) },
             };
         }
 

--- a/src/AWS.Deploy.CLI/TypeHintResponses/AgentCoreVpcTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/AgentCoreVpcTypeHintResponse.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Deploy.CLI.TypeHintResponses
+{
+    public class AgentCoreVpcTypeHintResponse : IDisplayable
+    {
+        public bool UseVPC { get; set; }
+        public bool CreateNew { get; set; }
+        public string? VpcId { get; set; }
+
+        public string? ToDisplayString()
+        {
+            if (!UseVPC)
+                return "*** Not using VPC ***";
+            if (CreateNew)
+                return "*** Create new VPC ***";
+            return VpcId ?? "*** Not using VPC ***";
+        }
+    }
+}

--- a/src/AWS.Deploy.CLI/TypeHintResponses/AgentCoreVpcTypeHintResponse.cs
+++ b/src/AWS.Deploy.CLI/TypeHintResponses/AgentCoreVpcTypeHintResponse.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+
 namespace AWS.Deploy.CLI.TypeHintResponses
 {
     public class AgentCoreVpcTypeHintResponse : IDisplayable
@@ -8,6 +10,7 @@ namespace AWS.Deploy.CLI.TypeHintResponses
         public bool UseVPC { get; set; }
         public bool CreateNew { get; set; }
         public string? VpcId { get; set; }
+        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
 
         public string? ToDisplayString()
         {
@@ -15,7 +18,7 @@ namespace AWS.Deploy.CLI.TypeHintResponses
                 return "*** Not using VPC ***";
             if (CreateNew)
                 return "*** Create new VPC ***";
-            return VpcId ?? "*** Not using VPC ***";
+            return string.IsNullOrEmpty(VpcId) ? "*** Not using VPC ***" : VpcId;
         }
     }
 }

--- a/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
+++ b/src/AWS.Deploy.Common/Recipes/OptionSettingTypeHint.cs
@@ -41,6 +41,7 @@ namespace AWS.Deploy.Common.Recipes
         FilePath,
         ElasticBeanstalkVpc,
         DockerHttpPort,
-        EnvironmentArchitecture
+        EnvironmentArchitecture,
+        AgentCoreVpc
     };
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/Configuration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/Configuration.cs
@@ -24,6 +24,11 @@ namespace AspNetAppBedrockAgentCore.Configurations
         public MemoryConfiguration AgentCoreMemory { get; set; }
 
         /// <summary>
+        /// VPC configuration for the AgentCore Runtime.
+        /// </summary>
+        public VPCConfiguration VPC { get; set; }
+
+        /// <summary>
         /// IAM role configuration for the AgentCore Runtime.
         /// </summary>
         public IAMRoleConfiguration RuntimeIAMRole { get; set; }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/VPCConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/VPCConfiguration.cs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AspNetAppBedrockAgentCore.Configurations
+{
+    public partial class VPCConfiguration
+    {
+        /// <summary>
+        /// Whether to place the AgentCore Runtime in a VPC.
+        /// When false, PUBLIC networking is used.
+        /// </summary>
+        public bool UseVPC { get; set; }
+
+        /// <summary>
+        /// Whether to create a new VPC.
+        /// </summary>
+        public bool CreateNew { get; set; }
+
+        /// <summary>
+        /// The existing VPC ID to use. Only used when CreateNew is false.
+        /// </summary>
+        public string VpcId { get; set; } = "";
+    }
+}

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/VPCConfiguration.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Configurations/VPCConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+
 namespace AspNetAppBedrockAgentCore.Configurations
 {
     public partial class VPCConfiguration
@@ -20,5 +22,10 @@ namespace AspNetAppBedrockAgentCore.Configurations
         /// The existing VPC ID to use. Only used when CreateNew is false.
         /// </summary>
         public string VpcId { get; set; } = "";
+
+        /// <summary>
+        /// Security groups to assign to the AgentCore Runtime.
+        /// </summary>
+        public SortedSet<string> SecurityGroups { get; set; } = new SortedSet<string>();
     }
 }

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
@@ -202,16 +202,48 @@ namespace AspNetAppBedrockAgentCore
             }
             else
             {
-                return RuntimeNetworkConfiguration.UsingPublicNetwork();
+                throw new InvalidOrMissingConfigurationException(
+                    "VPC mode is enabled but no VPC was specified. Either set CreateNew to true or provide a VpcId.");
             }
 
-            return RuntimeNetworkConfiguration.UsingVpc(this, new VpcConfigProps
+            // Prefer private subnets with egress (NAT) to ensure the runtime can reach AWS
+            // service endpoints. Fall back to private isolated, then public as last resort.
+            // AgentCore runtimes in public subnets are NOT assigned a public IP, so they
+            // won't have internet access without a NAT — but we allow it rather than failing.
+            // Limited to 2 AZs to avoid unsupported availability zones.
+            SubnetSelection subnetSelection;
+            if (vpc.PrivateSubnets.Length > 0)
+            {
+                subnetSelection = new SubnetSelection
+                {
+                    SubnetType = SubnetType.PRIVATE_WITH_EGRESS,
+                    AvailabilityZones = vpc.AvailabilityZones.Take(2).ToArray()
+                };
+            }
+            else
+            {
+                subnetSelection = new SubnetSelection
+                {
+                    SubnetType = SubnetType.PUBLIC,
+                    AvailabilityZones = vpc.AvailabilityZones.Take(2).ToArray()
+                };
+            }
+
+            var vpcConfigProps = new VpcConfigProps
             {
                 Vpc = vpc,
-                // Limit to 2 AZs to avoid unsupported AZs. AgentCore doesn't support all
-                // availability zones in every region (e.g. us-west-2d is unsupported).
-                VpcSubnets = new SubnetSelection { AvailabilityZones = vpc.AvailabilityZones.Take(2).ToArray() }
-            });
+                VpcSubnets = subnetSelection
+            };
+
+            if (settings.VPC.SecurityGroups.Count > 0)
+            {
+                vpcConfigProps.SecurityGroups = settings.VPC.SecurityGroups
+                    .Select((sgId, i) => SecurityGroup.FromSecurityGroupId(this, $"RuntimeSG{i}", sgId))
+                    .Cast<ISecurityGroup>()
+                    .ToArray();
+            }
+
+            return RuntimeNetworkConfiguration.UsingVpc(this, vpcConfigProps);
         }
 
         /// <summary>

--- a/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
+++ b/src/AWS.Deploy.Recipes/CdkTemplates/AspNetAppBedrockAgentCore/Generated/Recipe.cs
@@ -7,6 +7,7 @@ using System.Linq;
 
 using Amazon.CDK;
 using Amazon.CDK.AWS.BedrockAgentCore;
+using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.ECR;
 using Amazon.CDK.AWS.IAM;
 
@@ -114,7 +115,18 @@ namespace AspNetAppBedrockAgentCore
             RuntimeRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps
             {
                 Effect = Effect.ALLOW,
-                Actions = new[] { "bedrock-agentcore:ListEvents", "bedrock-agentcore:CreateEvent" },
+                Actions = new[]
+                {
+                    "bedrock-agentcore:CreateEvent",
+                    "bedrock-agentcore:GetEvent",
+                    "bedrock-agentcore:ListEvents",
+                    "bedrock-agentcore:DeleteEvent",
+                    "bedrock-agentcore:ListActors",
+                    "bedrock-agentcore:ListSessions",
+                    "bedrock-agentcore:RetrieveMemoryRecords",
+                    "bedrock-agentcore:GetMemoryRecord",
+                    "bedrock-agentcore:ListMemoryRecords"
+                },
                 Resources = new[] { $"arn:{partition}:bedrock-agentcore:*:{account}:memory/*" }
             }));
 
@@ -161,6 +173,45 @@ namespace AspNetAppBedrockAgentCore
                 return settings.AgentCoreMemory.MemoryId;
 
             return null;
+        }
+
+        /// <summary>
+        /// Configures VPC networking for the AgentCore Runtime.
+        /// Uses public networking by default; switches to VPC mode when a VPC is configured.
+        /// </summary>
+        private RuntimeNetworkConfiguration ConfigureVpc(Configuration settings)
+        {
+            if (settings.VPC == null || !settings.VPC.UseVPC)
+                return RuntimeNetworkConfiguration.UsingPublicNetwork();
+
+            IVpc vpc;
+            if (settings.VPC.CreateNew)
+            {
+                // Create a new VPC limited to 2 AZs to avoid unsupported AZ issues
+                vpc = new Vpc(this, "RuntimeVpc", InvokeCustomizeCDKPropsEvent("RuntimeVpc", this, new VpcProps
+                {
+                    MaxAzs = 2
+                }));
+            }
+            else if (!string.IsNullOrEmpty(settings.VPC.VpcId))
+            {
+                vpc = Vpc.FromLookup(this, "RuntimeVpc", new VpcLookupOptions
+                {
+                    VpcId = settings.VPC.VpcId
+                });
+            }
+            else
+            {
+                return RuntimeNetworkConfiguration.UsingPublicNetwork();
+            }
+
+            return RuntimeNetworkConfiguration.UsingVpc(this, new VpcConfigProps
+            {
+                Vpc = vpc,
+                // Limit to 2 AZs to avoid unsupported AZs. AgentCore doesn't support all
+                // availability zones in every region (e.g. us-west-2d is unsupported).
+                VpcSubnets = new SubnetSelection { AvailabilityZones = vpc.AvailabilityZones.Take(2).ToArray() }
+            });
         }
 
         /// <summary>
@@ -211,7 +262,7 @@ namespace AspNetAppBedrockAgentCore
             }
 
             // Configure network mode
-            var networkConfiguration = RuntimeNetworkConfiguration.UsingPublicNetwork();
+            var networkConfiguration = ConfigureVpc(settings);
 
             var runtimeProps = new RuntimeProps
             {

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
@@ -102,6 +102,11 @@
             "Order": 30
         },
         {
+            "Id": "VPC",
+            "DisplayName": "VPC",
+            "Order": 35
+        },
+        {
             "Id": "Permissions",
             "DisplayName": "Permissions",
             "Order": 40
@@ -171,6 +176,61 @@
                     "DependsOn": [
                         {
                             "Id": "AgentCoreMemory.CreateNew",
+                            "Value": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Id": "VPC",
+            "Name": "Virtual Private Cloud (VPC)",
+            "Category": "VPC",
+            "Description": "A VPC enables you to place the AgentCore Runtime into a virtual network for access to private resources. Not required for most deployments.",
+            "Type": "Object",
+            "TypeHint": "AgentCoreVpc",
+            "AdvancedSetting": true,
+            "Updatable": false,
+            "ChildOptionSettings": [
+                {
+                    "Id": "UseVPC",
+                    "Name": "Use a VPC",
+                    "Description": "Do you want to place the AgentCore Runtime in a VPC?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": true,
+                    "Updatable": false
+                },
+                {
+                    "Id": "CreateNew",
+                    "Name": "Create New VPC",
+                    "Description": "Do you want to create a new VPC?",
+                    "Type": "Bool",
+                    "DefaultValue": false,
+                    "AdvancedSetting": true,
+                    "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        }
+                    ]
+                },
+                {
+                    "Id": "VpcId",
+                    "Name": "VPC ID",
+                    "Description": "The ID of the VPC to use.",
+                    "Type": "String",
+                    "DefaultValue": "",
+                    "AdvancedSetting": true,
+                    "Updatable": false,
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
                             "Value": false
                         }
                     ]

--- a/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
+++ b/src/AWS.Deploy.Recipes/RecipeDefinitions/ASP.NETAppBedrockAgentCore.recipe
@@ -234,6 +234,48 @@
                             "Value": false
                         }
                     ]
+                },
+                {
+                    "Id": "SecurityGroups",
+                    "Name": "Security Groups",
+                    "Description": "A list of EC2 security groups to assign to the AgentCore Runtime. This is commonly used to provide access to resources like Amazon RDS or ElastiCache running in their own security groups.",
+                    "Type": "List",
+                    "TypeHint": "ExistingSecurityGroups",
+                    "ParentSettingId": "VPC.VpcId",
+                    "AdvancedSetting": true,
+                    "Updatable": false,
+                    "Validators": [
+                        {
+                            "ValidatorType": "Required"
+                        },
+                        {
+                            "ValidatorType": "Regex",
+                            "Configuration": {
+                                "Regex": "^sg-([0-9a-f]{8}|[0-9a-f]{17})$",
+                                "ValidationFailedMessage": "Invalid Security Group ID. The Security Group ID must start with the \"sg-\" prefix, followed by either 8 or 17 characters consisting of digits and letters(lower-case) from a to f. For example sg-abc88de9 is a valid Security Group ID."
+                            }
+                        },
+                        {
+                            "ValidatorType": "SecurityGroupsInVpc",
+                            "Configuration": {
+                                "VpcId": "VPC.VpcId"
+                            }
+                        }
+                    ],
+                    "DependsOn": [
+                        {
+                            "Id": "VPC.UseVPC",
+                            "Value": true
+                        },
+                        {
+                            "Id": "VPC.CreateNew",
+                            "Value": false
+                        },
+                        {
+                            "Id": "VPC.VpcId",
+                            "Operation": "NotEmpty"
+                        }
+                    ]
                 }
             ]
         },

--- a/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/AgentCoreVpcCommandTest.cs
+++ b/test/AWS.Deploy.CLI.UnitTests/TypeHintCommands/AgentCoreVpcCommandTest.cs
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EC2.Model;
+using AWS.Deploy.CLI.Commands.TypeHints;
+using AWS.Deploy.CLI.Common.UnitTests.IO;
+using AWS.Deploy.CLI.TypeHintResponses;
+using AWS.Deploy.CLI.UnitTests.Utilities;
+using AWS.Deploy.Common.Data;
+using AWS.Deploy.Common.IO;
+using AWS.Deploy.Common.Recipes;
+using AWS.Deploy.Common.Recipes.Validation;
+using AWS.Deploy.Orchestration;
+using AWS.Deploy.Orchestration.Data;
+using Moq;
+using Xunit;
+
+namespace AWS.Deploy.CLI.UnitTests.TypeHintCommands
+{
+    public class AgentCoreVpcCommandTest
+    {
+        private readonly Mock<IAWSResourceQueryer> _mockAWSResourceQueryer;
+        private readonly IDirectoryManager _directoryManager;
+        private readonly IToolInteractiveService _toolInteractiveService;
+        private readonly IOptionSettingHandler _optionSettingHandler;
+
+        public AgentCoreVpcCommandTest()
+        {
+            _mockAWSResourceQueryer = new Mock<IAWSResourceQueryer>();
+            _directoryManager = new TestDirectoryManager();
+            _toolInteractiveService = new TestToolInteractiveServiceImpl();
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IAWSResourceQueryer)))
+                .Returns(_mockAWSResourceQueryer.Object);
+            _optionSettingHandler = new OptionSettingHandler(new ValidatorFactory(serviceProvider.Object));
+        }
+
+        [Fact]
+        public async Task GetResources_ReturnsAvailableVpcs()
+        {
+            var engine = await BuildRecommendationEngine();
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id == "AspNetAppBedrockAgentCore");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(recommendation, "VPC");
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.GetListOfVpcs())
+                .ReturnsAsync(new List<Vpc>
+                {
+                    new Vpc { VpcId = "vpc-111", IsDefault = true },
+                    new Vpc { VpcId = "vpc-222", IsDefault = false }
+                });
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>());
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
+            var command = new AgentCoreVpcCommand(_mockAWSResourceQueryer.Object, consoleUtilities, _toolInteractiveService);
+
+            var resources = await command.GetResources(recommendation, vpcOptionSetting);
+
+            Assert.Equal(2, resources.Rows.Count);
+        }
+
+        [Fact]
+        public async Task Execute_UserSelectsNo_ReturnsNotUsingVpc()
+        {
+            var engine = await BuildRecommendationEngine();
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id == "AspNetAppBedrockAgentCore");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(recommendation, "VPC");
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "n"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
+            var command = new AgentCoreVpcCommand(_mockAWSResourceQueryer.Object, consoleUtilities, interactiveServices);
+
+            var result = await command.Execute(recommendation, vpcOptionSetting);
+
+            var response = Assert.IsType<AgentCoreVpcTypeHintResponse>(result);
+            Assert.False(response.UseVPC);
+            Assert.False(response.CreateNew);
+            Assert.Null(response.VpcId);
+            Assert.Equal("*** Not using VPC ***", response.ToDisplayString());
+        }
+
+        [Fact]
+        public async Task Execute_UserSelectsYes_NoVpcsExist_ReturnsCreateNew()
+        {
+            var engine = await BuildRecommendationEngine();
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id == "AspNetAppBedrockAgentCore");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(recommendation, "VPC");
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.GetListOfVpcs())
+                .ReturnsAsync(new List<Vpc>());
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "y"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
+            var command = new AgentCoreVpcCommand(_mockAWSResourceQueryer.Object, consoleUtilities, interactiveServices);
+
+            var result = await command.Execute(recommendation, vpcOptionSetting);
+
+            var response = Assert.IsType<AgentCoreVpcTypeHintResponse>(result);
+            Assert.True(response.UseVPC);
+            Assert.True(response.CreateNew);
+            Assert.Equal("*** Create new VPC ***", response.ToDisplayString());
+        }
+
+        [Fact]
+        public async Task Execute_UserSelectsYes_ChoosesExistingVpc()
+        {
+            var engine = await BuildRecommendationEngine();
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id == "AspNetAppBedrockAgentCore");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(recommendation, "VPC");
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.GetListOfVpcs())
+                .ReturnsAsync(new List<Vpc>
+                {
+                    new Vpc { VpcId = "vpc-abc123", IsDefault = true }
+                });
+
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "y",
+                "1"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
+            var command = new AgentCoreVpcCommand(_mockAWSResourceQueryer.Object, consoleUtilities, interactiveServices);
+
+            var result = await command.Execute(recommendation, vpcOptionSetting);
+
+            var response = Assert.IsType<AgentCoreVpcTypeHintResponse>(result);
+            Assert.True(response.UseVPC);
+            Assert.False(response.CreateNew);
+            Assert.Equal("vpc-abc123", response.VpcId);
+            Assert.Equal("vpc-abc123", response.ToDisplayString());
+        }
+
+        [Fact]
+        public async Task Execute_UserSelectsYes_ChoosesCreateNew()
+        {
+            var engine = await BuildRecommendationEngine();
+            var recommendations = await engine.ComputeRecommendations();
+            var recommendation = recommendations.First(r => r.Recipe.Id == "AspNetAppBedrockAgentCore");
+            var vpcOptionSetting = _optionSettingHandler.GetOptionSetting(recommendation, "VPC");
+
+            _mockAWSResourceQueryer
+                .Setup(x => x.GetListOfVpcs())
+                .ReturnsAsync(new List<Vpc>
+                {
+                    new Vpc { VpcId = "vpc-abc123", IsDefault = true }
+                });
+
+            // "y" to use VPC, "2" to select "Create new" (option after the one VPC)
+            var interactiveServices = new TestToolInteractiveServiceImpl(new List<string>
+            {
+                "y",
+                "2"
+            });
+            var consoleUtilities = new ConsoleUtilities(interactiveServices, _directoryManager, _optionSettingHandler);
+            var command = new AgentCoreVpcCommand(_mockAWSResourceQueryer.Object, consoleUtilities, interactiveServices);
+
+            var result = await command.Execute(recommendation, vpcOptionSetting);
+
+            var response = Assert.IsType<AgentCoreVpcTypeHintResponse>(result);
+            Assert.True(response.UseVPC);
+            Assert.True(response.CreateNew);
+            Assert.Equal("*** Create new VPC ***", response.ToDisplayString());
+        }
+
+        private static async Task<Orchestration.RecommendationEngine.RecommendationEngine> BuildRecommendationEngine()
+        {
+            return await HelperFunctions.BuildRecommendationEngine(
+                "AgentCoreWebApp",
+                new FileManager(),
+                new DirectoryManager(),
+                "us-west-2",
+                "123456789012",
+                "default");
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8636

## Description of changes
Adds an optional VPC setting to the AgentCore deployment recipe, allowing users to place their AgentCore Runtime in a VPC for access to private resources (RDS, ElastiCache, internal APIs).

  ### What's added

  **New `AgentCoreVpc` TypeHint**
  - `AgentCoreVpcCommand` — custom CLI handler with opt-in UX: asks "Do you want to place the AgentCore Runtime in a VPC?" (default No), then presents VPC selection (existing or create new)
  - `AgentCoreVpcTypeHintResponse` — implements `IDisplayable` for proper settings-list rendering (`*** Not using VPC ***`, VPC ID, or `*** Create new VPC ***`)
  - Registered in `OptionSettingTypeHint` enum and `TypeHintCommandFactory`

  **Recipe setting** (advanced, hidden by default)
  - `VPC` Object with children: `UseVPC` (Bool), `CreateNew` (Bool), `VpcId` (String)
  - Only visible when user selects "more" in the settings list

  **CDK behavior**
  - `UseVPC = false` (default): `RuntimeNetworkConfiguration.UsingPublicNetwork()` — no VPC, agent accesses Bedrock over the internet
  - `UseVPC = true, CreateNew = true`: Creates a new VPC with 2 AZs (includes NAT gateway for outbound connectivity)
  - `UseVPC = true, VpcId = "vpc-..."`: Uses existing VPC via `Vpc.FromLookup()`
  - Subnet selection limited to first 2 AZs via `VpcSubnets` to avoid unsupported availability zones (AgentCore doesn't support all AZs in every region)

  ### Important: VPC networking requirements

  When placed in a VPC, the AgentCore Runtime needs outbound internet access to reach AWS service endpoints (Bedrock, ECR, CloudWatch Logs). This requires either:
  - **Private subnets with a NAT gateway** (recommended) — CDK's `new Vpc()` creates this by default
  - **VPC endpoints** for the required services

  Using the default VPC (which only has public subnets) will result in a 502 error because AgentCore runtimes in public subnets are not assigned a public IP address. The "Create new VPC" option is the recommended path for users who need VPC.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
