### PR TITLE
Fix flaky CLI integration tests: serialize xUnit test collections

### DIFF
--- a/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
+++ b/test/AWS.Deploy.CLI.IntegrationTests/AWS.Deploy.CLI.IntegrationTests.csproj
@@ -37,6 +37,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\testapps\**\*">
       <Link>testapps\%(RecursiveDir)/%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/AWS.Deploy.CLI.IntegrationTests/xunit.runner.json
+++ b/test/AWS.Deploy.CLI.IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## Description

The Beanstalk backwards-compatibility CLI integration tests were flaking in CI with:

```
System.IO.IOException : The process cannot access the file '/root/.aws/credentials'
                        because it is being used by another process.
The following constructor parameters did not have matching fixture data: TestContextFixture fixture
```

### Root cause

`TestContextFixture` and `WindowsTestContextFixture` each construct AWS SDK clients in their constructors (e.g. `new AmazonIdentityManagementServiceClient()`). Constructing a client reads the shared credentials file (`~/.aws/credentials`) through `SharedCredentialsFile` / `OptimisticLockedTextFile`, which opens the file with a share mode that rejects a concurrent open.

xUnit v2 runs **separate test collections in parallel by default**, and there was no runner configuration disabling it. When the two fixtures initialized at the same time, they raced on the credentials file; one won the handle and the other threw the `IOException`. That fixture-constructor failure then surfaces as "did not have matching fixture data".

### Fix

Add `xunit.runner.json` with `parallelizeTestCollections: false` for the integration-test assembly and copy it to the output directory via the csproj. These are integration tests that deploy real AWS resources, so serializing collections removes the race with no meaningful throughput cost.

## Testing

- Confirmed the change is isolated to the integration-test project (new `xunit.runner.json` + one csproj `ItemGroup`).
- `xunit.runner.json` validated as well-formed JSON.

_Note: a clean full build wasn't possible in the local checkout due to pre-existing, unrelated errors (NU1901 vulnerability-as-error on Amazon.CDK.Lib and CS1570 XML-comment errors in AWS.Deploy.CLI/AWSUtilities.cs) that exist on the base branch independent of this change._

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.